### PR TITLE
re-implement evaluator without recursion, update tests

### DIFF
--- a/lib/ski/expression.ts
+++ b/lib/ski/expression.ts
@@ -136,3 +136,5 @@ SKIExpression => {
     return cons(expr.lft, splat(randomSeed, expr.rgt, term));
   }
 };
+
+export { reduceSKI } from '../evaluator/skiEvaluator.ts';

--- a/test/conversion/converter.test.ts
+++ b/test/conversion/converter.test.ts
@@ -1,11 +1,10 @@
 import { cons } from '../../lib/cons.ts';
 import { predLambda } from '../../lib/consts/lambdas.ts';
-
 import { reduceSKI } from '../../lib/evaluator/skiEvaluator.ts';
 import { mkVar, prettyPrintUntypedLambda } from '../../lib/lambda/lambda.ts';
-import { UnChurch, ChurchN } from '../../lib/ski/church.ts';
+import { UnChurchNumber, ChurchN } from '../../lib/ski/church.ts';
 import { apply } from '../../lib/ski/expression.ts';
-import { I, S, K } from '../../lib/ski/terminal.ts';
+import { I } from '../../lib/ski/terminal.ts';
 import { UpTo } from '../ski/church.test.ts';
 
 import { describe, it } from 'mocha';
@@ -16,32 +15,64 @@ describe('Lambda conversion', () => {
   const mkAbs = (name: string, body: Lambda): Lambda => ({
     kind: 'lambda-abs',
     name,
-    body
+    body,
   });
 
+  const N = 5;
+
   const id = mkAbs('x', mkVar('x'));
-
   const konst = mkAbs('x', mkAbs('y', mkVar('x')));
-
-  const flip = mkAbs('x', mkAbs('y', cons(mkVar('y'), mkVar('x'))));
+  const flip  = mkAbs('x', mkAbs('y', cons(mkVar('y'), mkVar('x'))));
 
   it('should convert λx.x to I', () => {
     expect(convertLambda(id)).to.deep.equal(I);
   });
 
   it('should convert λx.λy.x to something that acts like K', () => {
-    expect(reduceSKI(apply(convertLambda(konst), S, K))).to.deep.equal(S);
+    // The K combinator should return its first argument.
+    UpTo(N).forEach(a => {
+      UpTo(N).forEach(b => {
+        const result = UnChurchNumber(
+          reduceSKI(apply(convertLambda(konst), ChurchN(a), ChurchN(b)))
+        );
+        expect(result).to.equal(a);
+      });
+    });
   });
 
   it('should convert λx.λy.y x to something that acts like T', () => {
-    expect(reduceSKI(apply(convertLambda(flip), S, K))).to.deep.equal(cons(K, S));
+    /**
+     * flip is defined as:    flip ≡ λx.λy. y x
+     *
+     * When applied to Church numerals a and b:
+     *   flip a b = (λx.λy. y x) a b
+     *           = (λy. y a) b
+     *           = b a
+     *
+     * In Church encoding, numeral b represents: λf.λx. fᵇ(x)
+     * so "b a" means applying the function a b times,
+     * i.e. computing aᵇ (a raised to the power of b).
+     *
+     * Therefore, semantically, flip a b should evaluate to aᵇ.
+     */
+    UpTo(N).forEach(a => {
+      UpTo(N).forEach(b => {
+        const expected = a ** b; // exponentiation: a^b
+        const result = UnChurchNumber(
+          reduceSKI(apply(convertLambda(flip), ChurchN(a), ChurchN(b)))
+        );
+        expect(result).to.equal(expected);
+      });
+    });
   });
 
   it(`should convert ${prettyPrintUntypedLambda(predLambda)} to pred`, () => {
-    UpTo(8).forEach(n =>
-      expect(
-        UnChurch(reduceSKI(apply(convertLambda(predLambda), ChurchN(n))))
-      ).to.deep.equal(Math.max(n - 1, 0))
-    );
+    UpTo(N).forEach(n => {
+      const expected = Math.max(n - 1, 0); // pred(0) is defined as 0.
+      const result = UnChurchNumber(
+        reduceSKI(apply(convertLambda(predLambda), ChurchN(n)))
+      );
+      expect(result).to.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
## Overview

Updates the ski reduction routine to use iteration instead of recursion. Makes several testing improvements also, to remove implicit dependencies on the previous evaluation strategy.