### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,5 +1,7 @@
 name: Node.js CI
 on: [push]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maxdeliso/typed-ski/security/code-scanning/1](https://github.com/maxdeliso/typed-ski/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only performs read-only operations (e.g., checking out the repository, installing dependencies, and running tests), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` used by the workflow has the least privilege necessary to complete its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
