### PR TITLE
clean up some tech debt in the bazel rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,14 +11,6 @@ test:windows --test_env=LOCALAPPDATA
 test:windows --test_env=TEMP
 test:windows --test_env=TMP
 test:windows --test_env=USERPROFILE
-
-build:linux --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=/tmp/zig-cache
-build:linux --sandbox_add_mount_pair=/tmp
-build:linux --sandbox_writable_path=/tmp/zig-cache
-
-build:windows --repo_env=HERMETIC_CC_TOOLCHAIN_CACHE_PREFIX=C:/Temp/zig-cache
-build:windows --sandbox_add_mount_pair=C:\Temp
-build:windows --sandbox_writable_path=C:/Temp/zig-cache
 build:windows --action_env=APPDATA
 build:windows --action_env=LOCALAPPDATA
 build:windows --action_env=TEMP

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,15 +42,6 @@ jobs:
           repository-cache: true
           cache-save: ${{ github.event_name != 'pull_request' }}
 
-      - name: Prepare hermetic Zig cache (Linux)
-        if: runner.os == 'Linux'
-        run: mkdir -p /tmp/zig-cache
-
-      - name: Prepare hermetic Zig cache (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: New-Item -ItemType Directory -Force C:\Temp\zig-cache | Out-Null
-
       - name: Build native Bazel targets
         run: bazel build //:thanatos //:performance_test //:release_wasm
 
@@ -66,17 +57,13 @@ jobs:
       - name: Run typecheck
         run: bazel run //:typecheck
 
-      - name: Build distributable artifacts
-        run: bazel run //:dist
-
-      - name: Run Node tests (Windows)
-        if: matrix.os == 'windows-2025'
+      - name: Run Node tests
         run: bazel test //:node_tests --test_output=errors
 
-      - name: Run Node tests and collect coverage (Ubuntu)
+      - name: Collect Node test coverage (Ubuntu)
         if: matrix.os == 'ubuntu-24.04'
         run: |
-          bazel coverage //:node_tests --test_output=errors
+          bazel coverage //:node_tests --test_output=errors --nocache_test_results
           echo "Found coverage files:"
           find -L bazel-testlogs -name "coverage.dat" -print || true
           find -L bazel-testlogs -name "coverage.dat" -exec cat {} + > coverage.lcov
@@ -106,6 +93,13 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
+
+      - name: Stage Bazel dist artifacts for JSR dry run
+        if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          cp -a bazel-bin/dist_artifacts/. dist/
 
       - name: JSR dry run publish
         if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,6 @@ jobs:
           repository-cache: true
           cache-save: ${{ github.event_name != 'pull_request' }}
 
-      - name: Prepare hermetic Zig cache
-        run: mkdir -p /tmp/zig-cache
-
       - name: Build native Bazel targets
         run: bazel build //:thanatos //:release_wasm
 

--- a/bazel/codegen.bzl
+++ b/bazel/codegen.bzl
@@ -1,6 +1,5 @@
 def _codegen_impl(ctx):
     node_toolchain = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"]
-    node_path = node_toolchain.nodeinfo.target_tool_path
 
     args = ctx.actions.args()
     args.add("--experimental-transform-types")

--- a/bazel/wasm_release.bzl
+++ b/bazel/wasm_release.bzl
@@ -28,11 +28,15 @@ _WASM_MAX_PAGES = 65535
 def _export_flags():
     return ["-Wl,--export=%s" % symbol for symbol in _WASM_EXPORTS]
 
-_ZIG_CACHE_PATH_LINUX = "/tmp/zig-cache"
-_ZIG_CACHE_PATH_WINDOWS = "C:/Temp/zig-cache"
+def _wasm_release_impl(ctx):
+    wasm = ctx.actions.declare_file(ctx.label.name + ".wasm")
+    zig_cache = ctx.actions.declare_directory(ctx.label.name + ".zig-cache")
 
-def wasm_release(name, srcs, hdrs = [], visibility = None):
-    flags = [
+    args = ctx.actions.args()
+    args.add("cc")
+    for header in ctx.files.hdrs:
+        args.add("-I%s" % header.dirname)
+    args.add_all([
         "-O3",
         "-DNDEBUG",
         "-std=c11",
@@ -46,39 +50,44 @@ def wasm_release(name, srcs, hdrs = [], visibility = None):
         "-Wl,--shared-memory",
         "-Wl,--initial-memory=0x%x" % (_WASM_INITIAL_PAGES * _WASM_PAGE_SIZE),
         "-Wl,--max-memory=0x%x" % (_WASM_MAX_PAGES * _WASM_PAGE_SIZE),
-    ] + _export_flags()
-    src_locations = " ".join(["$(location %s)" % src for src in srcs])
-    flag_string = " ".join(flags)
+    ])
+    args.add_all(_export_flags())
+    args.add("-o")
+    args.add(wasm)
+    args.add_all(ctx.files.srcs)
 
-    # We use dirname to get the directory of each header.
-    # On Linux, path/to/file/.. is an error (ENOTDIR) because the filesystem
-    # requires the component before /.. to be a directory.
-    include_flags_bash = " ".join(["-I$$(dirname $(location %s))" % hdr for hdr in hdrs])
-    include_flags_bat = " ".join(["-I$(location %s)\\..\\" % hdr for hdr in hdrs])
-
-    # We explicitly set ZIG_LOCAL_CACHE_DIR and ZIG_GLOBAL_CACHE_DIR to avoid
-    # AppDataDirUnavailable errors in CI environments where the default cache
-    # locations (like $HOME/.cache or %APPDATA%) might not be writable or available.
-    cmd_bash = "export ZIG_LOCAL_CACHE_DIR={cache} && export ZIG_GLOBAL_CACHE_DIR={cache} && \"$(execpath @zig_sdk//:zig)\" cc {includes} {flags} -o \"$@\" {srcs}".format(
-        cache = _ZIG_CACHE_PATH_LINUX,
-        includes = include_flags_bash,
-        flags = flag_string,
-        srcs = src_locations,
+    ctx.actions.run(
+        executable = ctx.file._zig,
+        arguments = [args],
+        inputs = ctx.files.srcs + ctx.files.hdrs,
+        outputs = [wasm, zig_cache],
+        env = {
+            "ZIG_GLOBAL_CACHE_DIR": "%s/global" % zig_cache.path,
+            "ZIG_LOCAL_CACHE_DIR": "%s/local" % zig_cache.path,
+        },
+        mnemonic = "WasmRelease",
+        progress_message = "Building WASM release %{output}",
     )
 
-    cmd_bat = "set ZIG_LOCAL_CACHE_DIR={cache}&& set ZIG_GLOBAL_CACHE_DIR={cache}&& $(execpath @zig_sdk//:zig) cc {includes} {flags} -o $@ {srcs}".format(
-        cache = _ZIG_CACHE_PATH_WINDOWS,
-        includes = include_flags_bat,
-        flags = flag_string,
-        srcs = src_locations,
-    )
+    return [DefaultInfo(files = depset([wasm]))]
 
-    native.genrule(
+_wasm_release = rule(
+    implementation = _wasm_release_impl,
+    attrs = {
+        "hdrs": attr.label_list(allow_files = [".h"]),
+        "srcs": attr.label_list(allow_files = [".c"]),
+        "_zig": attr.label(
+            default = "@zig_sdk//:zig",
+            allow_single_file = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def wasm_release(name, srcs, hdrs = [], visibility = None):
+    _wasm_release(
         name = name,
-        srcs = srcs + hdrs,
-        outs = [name + ".wasm"],
-        cmd_bash = cmd_bash,
-        cmd_bat = cmd_bat,
-        tools = ["@zig_sdk//:zig"],
+        srcs = srcs,
+        hdrs = hdrs,
         visibility = visibility,
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@maxdeliso/typed-ski",
-      "version": "0.17.14",
+      "version": "0.17.15",
       "license": "MIT",
       "dependencies": {
         "random-seed": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.17.14",
+  "version": "0.17.15",
   "license": "MIT",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- Replace the wasm release `genrule` with a custom Starlark rule backed by `ctx.actions.run`
- Move Zig local/global cache paths into an action-owned declared output directory
- Remove global Zig cache setup from `.bazelrc` and GitHub Actions
- Simplify CI so Linux and Windows both run the same Bazel Node test target
- Keep Ubuntu-only coverage and JSR dry-run publishing, staging the same Bazel-built dist artifacts
