### PR TITLE
Consolidate CI setup into composite action, drop host Node

### DIFF
--- a/.github/actions/setup-bazel-node/action.yml
+++ b/.github/actions/setup-bazel-node/action.yml
@@ -1,0 +1,23 @@
+name: Setup Bazel
+description: Configure Bazel caches via bazelisk.
+
+inputs:
+  disk-cache:
+    description: Bazel disk cache name.
+    required: true
+  cache-save:
+    description: Whether setup-bazel should save caches.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # No host Node or pnpm install: Node is supplied hermetically by Bazel
+    # (rules_nodejs) and npm deps by npm_translate_lock from pnpm-lock.yaml.
+    - name: Setup Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ inputs.disk-cache }}
+        repository-cache: true
+        cache-save: ${{ inputs.cache-save }}

--- a/.github/actions/setup-bazel-node/action.yml
+++ b/.github/actions/setup-bazel-node/action.yml
@@ -1,5 +1,5 @@
-name: Setup Bazel
-description: Configure Bazel caches via bazelisk.
+name: Setup Bazel and Node dependencies
+description: Install pnpm dependencies and configure Bazel caches.
 
 inputs:
   disk-cache:
@@ -12,8 +12,21 @@ inputs:
 runs:
   using: composite
   steps:
-    # No host Node or pnpm install: Node is supplied hermetically by Bazel
-    # (rules_nodejs) and npm deps by npm_translate_lock from pnpm-lock.yaml.
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: "22"
+
+    # The //:typecheck, //:fmt_check and //:dist targets run scripts/bazel.ts,
+    # which spawns a host pnpm resolved from node_modules/pnpm (or PATH). They
+    # are not hermetic, so the workspace needs a real pnpm install.
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile
+
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@0.19.0
       with:

--- a/.github/actions/setup-bazel-node/action.yml
+++ b/.github/actions/setup-bazel-node/action.yml
@@ -1,5 +1,5 @@
-name: Setup Bazel and Node dependencies
-description: Install pnpm dependencies and configure Bazel caches.
+name: Setup Bazel
+description: Configure Bazel caches via bazelisk.
 
 inputs:
   disk-cache:
@@ -12,21 +12,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: "22"
-
-    # The //:typecheck, //:fmt_check and //:dist targets run scripts/bazel.ts,
-    # which spawns a host pnpm resolved from node_modules/pnpm (or PATH). They
-    # are not hermetic, so the workspace needs a real pnpm install.
-    - name: Install dependencies
-      shell: bash
-      run: pnpm install --frozen-lockfile
-
+    # No host Node or pnpm install: every CI command runs through Bazel's
+    # hermetic Node 26 toolchain and resolves npm packages via
+    # npm_translate_lock, so the host toolchain is never used.
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@0.19.0
       with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -39,10 +39,10 @@ jobs:
         run: bazel test //:native_tests
 
       - name: Run format check
-        run: bazel run //:fmt_check
+        run: bazel build //:fmt_check
 
       - name: Run typecheck
-        run: bazel run //:typecheck
+        run: bazel build //:typecheck
 
       - name: Run Node tests
         if: matrix.os != 'ubuntu-24.04'
@@ -84,10 +84,13 @@ jobs:
 
       - name: Build and stage distribution artifacts for JSR dry run
         if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'
-        # Use the Bazel target rather than `pnpm run dist`: it runs under
-        # Bazel's hermetic Node 26 instead of the runner's host Node, so
-        # this step is unaffected by host Node version.
-        run: bazel run //:dist
+        run: |
+          bazel build //:dist_artifacts //:jsr_generated_src //lib/shared:version_generated_src
+          mkdir -p dist
+          install -m644 bazel-bin/dist_artifacts/tripc.js bazel-bin/dist_artifacts/tripc.min.js bazel-bin/dist_artifacts/tripc.node.js dist/
+          install -m755 bazel-bin/dist_artifacts/tripc dist/tripc
+          install -m644 bazel-bin/jsr.json jsr.json
+          install -m644 bazel-bin/lib/shared/version.generated.ts lib/shared/version.generated.ts
 
       - name: JSR dry run publish
         if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -76,12 +76,6 @@ jobs:
           path: bazel-testlogs/
           if-no-files-found: ignore
 
-      - name: Setup Deno (for JSR dry run)
-        if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
       - name: Build and stage distribution artifacts for JSR dry run
         if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'
         run: |
@@ -92,6 +86,9 @@ jobs:
           install -m644 bazel-bin/jsr.json jsr.json
           install -m644 bazel-bin/lib/shared/version.generated.ts lib/shared/version.generated.ts
 
+      # jsr's Node CLI: no Deno toolchain to install (the runner already
+      # has Node), and it does not enter Deno's byonm mode, so it needs no
+      # node_modules/ install to resolve node: builtins or @types.
       - name: JSR dry run publish
         if: matrix.os == 'ubuntu-24.04' && github.ref != 'refs/heads/main'
-        run: deno publish --dry-run --config jsr.json
+        run: npx --yes jsr@0.14.3 publish --dry-run

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -26,31 +26,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      # Host Node only needs to be new enough for `pnpm install` to run
-      # (pnpm 11 requires Node ≥ 22). Every Node-touching command in
-      # this workflow goes through Bazel's hermetic Node 26 via
-      # rules_nodejs, so the host version below is independent of the
-      # version the project targets. Using a major-version spec (`22`)
-      # rather than a specific patch (e.g. 26.1.0) picks the runner's
-      # pre-cached Node and avoids the network download that previously
-      # flaked on the Windows runner.
-      - name: Setup Node.js (for pnpm only)
-        uses: actions/setup-node@v6
+      - name: Setup Bazel and Node dependencies
+        uses: ./.github/actions/setup-bazel-node
         with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
           cache-save: ${{ github.event_name != 'pull_request' }}
 
       - name: Build native Bazel targets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,9 +31,13 @@ jobs:
         run: bazel test //:native_tests
 
       - name: Build and stage distribution artifacts
-        # Use the Bazel target rather than `pnpm run dist`: runs under
-        # Bazel's hermetic Node 26 instead of host Node.
-        run: bazel run //:dist
+        run: |
+          bazel build //:dist_artifacts //:jsr_generated_src //lib/shared:version_generated_src
+          mkdir -p dist
+          install -m644 bazel-bin/dist_artifacts/tripc.js bazel-bin/dist_artifacts/tripc.min.js bazel-bin/dist_artifacts/tripc.node.js dist/
+          install -m755 bazel-bin/dist_artifacts/tripc dist/tripc
+          install -m644 bazel-bin/jsr.json jsr.json
+          install -m644 bazel-bin/lib/shared/version.generated.ts lib/shared/version.generated.ts
 
       - name: Run test suite
         run: bazel test //:node_tests --test_output=errors

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,25 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      # Host Node only needs to be new enough for `pnpm install`. Every
-      # Node-touching command goes through Bazel's hermetic Node 26.
-      - name: Setup Node.js (for pnpm only)
-        uses: actions/setup-node@v6
+      - name: Setup Bazel and Node dependencies
+        uses: ./.github/actions/setup-bazel-node
         with:
-          node-version: "22"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.19.0
-        with:
-          bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
-          repository-cache: true
           cache-save: ${{ github.event_name != 'pull_request' }}
 
       - name: Build native Bazel targets

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,7 @@ jobs:
           path: bazel-testlogs/
           if-no-files-found: ignore
 
-      - name: Setup Deno (for JSR publish)
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Publish to JSR (Deno Registry)
-        run: deno publish --config jsr.json
+      # Published via jsr's Node CLI; OIDC auth uses the id-token
+      # permission above, same as deno publish would.
+      - name: Publish to JSR
+        run: npx --yes jsr@0.14.3 publish

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,9 @@ lib/**/*.embedded.ts
 # Generated C files
 core/*.generated.h
 
-# Deno cache
+# Deno cache and generated lockfile
 .deno-cache/
+deno.lock
 deno.lock.bak
 .toolchains/
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ bin/*-coverage
 codecov
 codecov.SHA256SUM
 codecov.SHA256SUM.sig
+
+# Claude Code working directory
+.claude/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -352,16 +352,6 @@ workspace_command(
     subcommand = "verify-version",
 )
 
-workspace_command(
-    name = "sync_generated",
-    subcommand = "sync-generated",
-)
-
-workspace_command(
-    name = "build",
-    subcommand = "build",
-)
-
 prettier_check(
     name = "fmt_check",
     srcs = glob(
@@ -383,16 +373,6 @@ prettier_check(
         "//scripts:scripts",
     ],
     node_modules = [":node_modules/prettier"],
-)
-
-workspace_command(
-    name = "lint",
-    subcommand = "lint",
-)
-
-workspace_command(
-    name = "test",
-    subcommand = "test",
 )
 
 # ts_compile already runs tsc over every source file with the project's

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -216,6 +216,7 @@ test_suite(
 node_dist(
     name = "dist_artifacts",
     data = NODE_DIST_DATA,
+    esbuild = [":node_modules/esbuild"],
     ts_out = ":ts_out",
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -358,11 +358,6 @@ workspace_command(
 )
 
 workspace_command(
-    name = "dist",
-    subcommand = "dist",
-)
-
-workspace_command(
     name = "build",
     subcommand = "build",
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,6 +5,7 @@ load("//bazel:codegen.bzl", "codegen_rule")
 load("//bazel:node_dist.bzl", "node_dist")
 load("//bazel:node_llvm_as_test.bzl", "node_llvm_as_test")
 load("//bazel:node_sharded_test.bzl", "node_sharded_test")
+load("//bazel:prettier.bzl", "prettier_check")
 load("//bazel:ts_compile.bzl", "ts_compile")
 load(
     "//bazel:trip_llvm.bzl",
@@ -365,9 +366,27 @@ workspace_command(
     subcommand = "build",
 )
 
-workspace_command(
+prettier_check(
     name = "fmt_check",
-    subcommand = "fmt-check",
+    srcs = glob(
+        [
+            "*.json",
+            "*.jsonc",
+            "*.md",
+            "bin/**",
+            "compiler/**",
+            "lib/**",
+            "test/**",
+            ".github/**",
+        ],
+        allow_empty = True,
+        exclude = ["**/*.generated.*"],
+    ) + [
+        "//lib/evaluator:evaluator",
+        "//lib/shared:shared",
+        "//scripts:scripts",
+    ],
+    node_modules = [":node_modules/prettier"],
 )
 
 workspace_command(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -399,7 +399,10 @@ workspace_command(
     subcommand = "test",
 )
 
-workspace_command(
+# ts_compile already runs tsc over every source file with the project's
+# strict config (tsconfig.emit.json only adds emit options to tsconfig.json),
+# so building :ts_out is the typecheck. Alias keeps the //:typecheck name.
+alias(
     name = "typecheck",
-    subcommand = "typecheck",
+    actual = ":ts_out",
 )

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ pinned in `.bazelversion`.
 2. Install `pnpm` (`npm install -g pnpm`).
 3. Install `Bazelisk`.
 4. On macOS: `xcode-select --install`.
-5. Clone the repo, `pnpm install`, `bazelisk run //:dist`.
+5. Clone the repo, `pnpm install`, `bazelisk build //:dist_artifacts`.
 
 Helper scripts in [`scripts/`](scripts/) use the local `pnpm` pinned via
 `node_modules/pnpm`.
@@ -60,7 +60,6 @@ Helper scripts in [`scripts/`](scripts/) use the local `pnpm` pinned via
 
 ```bash
 bazelisk test //:node_tests             # sharded Node.js test suite
-bazelisk run  //:test                   # single-process workspace run
 bazelisk test //:native_tests           # native Trip executable smoke tests
 bazelisk test //consumers/thanatos:all  # sealed reducer consumer tests
 ```
@@ -80,16 +79,13 @@ With Bazel:
 
 ```bash
 bazelisk test //:node_tests --test_arg=test/path/to/test.ts
-bazelisk run  //:test -- test/path/to/test.ts
 ```
 
 ### Other useful commands
 
-- `bazelisk run //:dist` — atomic validated build of CLI artifacts
-- `bazelisk run //:build` — alias for `//:dist` that also verifies version
-- `bazelisk run //:typecheck` — TypeScript type checking
-- `bazelisk run //:coverage` — tests with coverage output
-- `bazelisk run //:ci` — fmt, lint, typecheck, build, single cov-producing test pass
+- `bazelisk build //:dist_artifacts` — validated build of CLI artifacts
+- `bazelisk build //:fmt_check` — Prettier formatting check
+- `bazelisk build //:typecheck` — TypeScript type checking
 - `bazelisk run //:verify_version` — check the repo-pinned Node.js version
 
 ## Artifacts

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ build system and one workspace:
 bazelisk build //consumers/thanatos:thanatos
 bazelisk test  //:native_tests          # end-to-end native Trip executable
 bazelisk test  //:node_tests            # TypeScript test suite
-bazelisk run   //:dist                  # build distributable CLI artifacts
-bazelisk run   //:ci                    # fmt + lint + typecheck + build + cov
+bazelisk build //:dist_artifacts         # distributable CLI artifacts
+bazelisk build //:fmt_check //:typecheck # formatting + type checks
 ```
 
 Alternatively, use `pnpm` for distribution: `pnpm run dist`.

--- a/bazel/node_dist.bzl
+++ b/bazel/node_dist.bzl
@@ -2,6 +2,15 @@
 
 load("//bazel:common.bzl", "shell_quote", "batch_quote")
 
+def _find_esbuild_entry(files):
+    for f in files:
+        p = f.path.replace("\\", "/")
+        if p.endswith("/esbuild/bin/esbuild"):
+            return f.path
+        if f.is_directory and p.endswith("/esbuild"):
+            return f.path + "/bin/esbuild"
+    fail("Cannot find esbuild/bin/esbuild in the esbuild attr")
+
 def _node_dist_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(
         ctx.attr._windows_constraint[platform_common.ConstraintValueInfo],
@@ -11,6 +20,8 @@ def _node_dist_impl(ctx):
 
     ts_out_dir = ctx.attr.ts_out[DefaultInfo].files.to_list()[0]
     bazel_build_dist_js = ts_out_dir.path + "/scripts/bazelBuildDist.js"
+
+    esbuild_entry = _find_esbuild_entry(ctx.files.esbuild)
 
     tripc_js = ctx.actions.declare_file(ctx.label.name + "/tripc.js")
     tripc_min_js = ctx.actions.declare_file(ctx.label.name + "/tripc.min.js")
@@ -38,6 +49,7 @@ def _node_dist_impl(ctx):
             "@echo off",
             "setlocal",
             "cd /d \"%CD%\"",
+            "set \"TYPED_SKI_ESBUILD_PATH=%CD%\\" + esbuild_entry.replace("/", "\\") + "\"",
             command,
             "exit /b %ERRORLEVEL%",
             "",
@@ -56,6 +68,7 @@ def _node_dist_impl(ctx):
             "#!/usr/bin/env bash",
             "set -euo pipefail",
             "cd \"$PWD\"",
+            "export TYPED_SKI_ESBUILD_PATH=\"$PWD/" + esbuild_entry + "\"",
             command,
             "",
         ])
@@ -65,7 +78,7 @@ def _node_dist_impl(ctx):
 
     ctx.actions.run(
         executable = launcher,
-        inputs = ctx.files.data + [manifest, node_toolchain.nodeinfo.node, ts_out_dir],
+        inputs = ctx.files.data + ctx.files.esbuild + [manifest, node_toolchain.nodeinfo.node, ts_out_dir],
         outputs = outputs,
         mnemonic = "NodeDist",
         progress_message = "Building Node dist artifacts for %s" % ctx.label,
@@ -79,6 +92,10 @@ node_dist = rule(
     attrs = {
         "data": attr.label_list(
             allow_files = True,
+        ),
+        "esbuild": attr.label_list(
+            allow_files = True,
+            mandatory = True,
         ),
         "ts_out": attr.label(
             mandatory = True,

--- a/bazel/prettier.bzl
+++ b/bazel/prettier.bzl
@@ -57,11 +57,15 @@ def _prettier_check_impl(ctx):
     # limit; the source files themselves are staged as action inputs.
     ctx.actions.write(wrapper, """\
 import { spawnSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync, realpathSync } from "node:fs";
 import process from "node:process";
 
 const [node, prettier, fileList, marker] = process.argv.slice(2);
-const files = readFileSync(fileList, "utf8").split("\\n").filter(Boolean);
+const files = readFileSync(fileList, "utf8")
+  .split("\\n")
+  .filter(Boolean)
+  .map((f) => realpathSync(f));
+
 const BATCH = 120;
 for (let i = 0; i < files.length; i += BATCH) {
   const result = spawnSync(

--- a/bazel/prettier.bzl
+++ b/bazel/prettier.bzl
@@ -1,0 +1,105 @@
+"""Hermetic Prettier format check, run as a sandboxed Bazel action.
+
+Prettier and Node both come from Bazel (npm_translate_lock and the
+rules_nodejs toolchain), so this needs no host pnpm or node_modules.
+"""
+
+# Extensions Prettier has a built-in parser for. Files in srcs with any
+# other extension (.trip, .bzl, ...) are skipped, matching `prettier .`.
+_PRETTIER_EXTENSIONS = [
+    ".ts",
+    ".tsx",
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".json",
+    ".jsonc",
+    ".md",
+    ".yml",
+    ".yaml",
+]
+
+def _is_formattable(f):
+    if f.is_directory:
+        return False
+    for ext in _PRETTIER_EXTENSIONS:
+        if f.path.endswith(ext):
+            return True
+    return False
+
+def _prettier_check_impl(ctx):
+    node_toolchain = ctx.toolchains["@rules_nodejs//nodejs:toolchain_type"]
+    node = node_toolchain.nodeinfo.node
+
+    prettier_path = None
+    for f in ctx.files.node_modules:
+        p = f.path.replace("\\", "/")
+        if p.endswith("/prettier/bin/prettier.cjs"):
+            prettier_path = f.path
+            break
+        if f.is_directory and p.endswith("/prettier"):
+            prettier_path = f.path + "/bin/prettier.cjs"
+            break
+    if prettier_path == None:
+        fail("Cannot find prettier/bin/prettier.cjs in node_modules")
+
+    check_files = [f for f in ctx.files.srcs if _is_formattable(f)]
+    if not check_files:
+        fail("prettier_check: srcs contains no Prettier-formattable files")
+
+    file_list = ctx.actions.declare_file(ctx.label.name + "_files.txt")
+    ctx.actions.write(file_list, "\n".join([f.path for f in check_files]) + "\n")
+
+    marker = ctx.actions.declare_file(ctx.label.name + ".passed")
+    wrapper = ctx.actions.declare_file(ctx.label.name + "_run.mjs")
+
+    # Batches keep each prettier argv well under the Windows command-line
+    # limit; the source files themselves are staged as action inputs.
+    ctx.actions.write(wrapper, """\
+import { spawnSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import process from "node:process";
+
+const [node, prettier, fileList, marker] = process.argv.slice(2);
+const files = readFileSync(fileList, "utf8").split("\\n").filter(Boolean);
+const BATCH = 120;
+for (let i = 0; i < files.length; i += BATCH) {
+  const result = spawnSync(
+    node,
+    [prettier, "--check", ...files.slice(i, i + BATCH)],
+    { stdio: "inherit" },
+  );
+  if (result.status !== 0) process.exit(result.status || 1);
+}
+writeFileSync(marker, "ok\\n");
+""")
+
+    args = ctx.actions.args()
+    args.add(wrapper.path)
+    args.add(node.path)
+    args.add(prettier_path)
+    args.add(file_list.path)
+    args.add(marker.path)
+
+    ctx.actions.run(
+        executable = node,
+        arguments = [args],
+        inputs = depset(
+            check_files + [file_list, wrapper],
+            transitive = [depset(ctx.files.node_modules)],
+        ),
+        outputs = [marker],
+        mnemonic = "PrettierCheck",
+        progress_message = "Checking formatting with Prettier for %s" % ctx.label,
+        use_default_shell_env = True,
+    )
+    return [DefaultInfo(files = depset([marker]))]
+
+prettier_check = rule(
+    implementation = _prettier_check_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "node_modules": attr.label_list(allow_files = True),
+    },
+    toolchains = ["@rules_nodejs//nodejs:toolchain_type"],
+)

--- a/bin/tripc.ts
+++ b/bin/tripc.ts
@@ -5,7 +5,9 @@
  */
 
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   compileTripBundleV1ToLlvm,
   compileTripSourceToLlvm,
@@ -270,6 +272,18 @@ async function main(): Promise<void> {
   );
 }
 
-if ((import.meta as any).main) {
+function isMain(importMetaUrl: string): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(importMetaUrl))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMain(import.meta.url)) {
   await main();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/scripts/bazel.ts
+++ b/scripts/bazel.ts
@@ -63,10 +63,8 @@ function assertCurrentNodeVersion(): void {
 
 type CommandName =
   | "verify-version"
-  | "sync-generated"
   | "verify-generated"
   | "dist"
-  | "build"
   | "test"
   | "bazel-test-shard";
 
@@ -203,10 +201,8 @@ function usage(): never {
 
 Commands:
   verify-version
-  sync-generated
   verify-generated
   dist
-  build
   test
   bazel-test-shard`);
   process.exit(1);
@@ -721,11 +717,6 @@ export async function runBazelShardTests(args: string[] = []): Promise<void> {
   });
 }
 
-async function build(): Promise<void> {
-  verifyVersion();
-  await buildDist();
-}
-
 export async function main(
   argv: string[] = process.argv.slice(2),
 ): Promise<void> {
@@ -737,17 +728,11 @@ export async function main(
     case "verify-version":
       verifyVersion();
       break;
-    case "sync-generated":
-      await syncGenerated();
-      break;
     case "verify-generated":
       await verifyGenerated();
       break;
     case "dist":
       await buildDist();
-      break;
-    case "build":
-      await build();
       break;
     case "test":
       await runTests(false, args);

--- a/scripts/bazel.ts
+++ b/scripts/bazel.ts
@@ -114,6 +114,13 @@ function pnpmCommand(...args: string[]): string[] {
 }
 
 function esbuildCommand(...args: string[]): string[] {
+  // Bazel rules stage esbuild from :node_modules and point this at it, so
+  // dist builds need no host pnpm and no network fetch. The pnpm dlx
+  // fallback only runs for ad-hoc local invocations outside Bazel.
+  const configuredEsbuild = process.env["TYPED_SKI_ESBUILD_PATH"];
+  if (configuredEsbuild) {
+    return [NODE, configuredEsbuild, ...args];
+  }
   return pnpmCommand("dlx", "esbuild@0.28.0", ...args);
 }
 

--- a/scripts/bazel.ts
+++ b/scripts/bazel.ts
@@ -67,8 +67,6 @@ type CommandName =
   | "verify-generated"
   | "dist"
   | "build"
-  | "fmt-check"
-  | "typecheck"
   | "test"
   | "bazel-test-shard";
 
@@ -209,8 +207,6 @@ Commands:
   verify-generated
   dist
   build
-  fmt-check
-  typecheck
   test
   bazel-test-shard`);
   process.exit(1);
@@ -445,11 +441,6 @@ export async function buildDist(
   await validateDist();
 }
 
-async function formatCheck(): Promise<void> {
-  console.log("Format check using pnpm exec prettier --check .");
-  await run(pnpmCommand("exec", "prettier", "--check", "."));
-}
-
 async function collectTests(): Promise<string[]> {
   const testRoot = join(JS_ROOT, "test");
   const files: string[] = [];
@@ -609,12 +600,6 @@ async function runSelectedTests(
   );
 }
 
-async function typecheck(): Promise<void> {
-  await syncGenerated();
-  const files = await collectTests();
-  await typecheckTests(files);
-}
-
 async function typecheckAndPrepareTestExecution(
   files: string[],
 ): Promise<Record<string, string>> {
@@ -763,12 +748,6 @@ export async function main(
       break;
     case "build":
       await build();
-      break;
-    case "fmt-check":
-      await formatCheck();
-      break;
-    case "typecheck":
-      await typecheck();
       break;
     case "test":
       await runTests(false, args);

--- a/scripts/generate_version.mjs
+++ b/scripts/generate_version.mjs
@@ -25,12 +25,11 @@ function buildJsrJson(pkg) {
     compilerOptions: {
       strict: true,
       lib: ["ESNext", "dom"],
-      types: ["@types/node"],
+      types: ["node"],
     },
     imports: {
       "random-seed": `npm:random-seed@${pkg.dependencies["random-seed"]}`,
       "ts-morph": `npm:ts-morph@${pkg.dependencies["ts-morph"]}`,
-      "@types/node": `npm:@types/node@${pkg.devDependencies["@types/node"]}`,
     },
   };
 

--- a/scripts/generate_version.mjs
+++ b/scripts/generate_version.mjs
@@ -22,10 +22,13 @@ function buildJsrJson(pkg) {
     publish: pkg.jsr?.publish || {
       include: pkg.files || [],
     },
+    // No `types` entry: `jsr publish` resolves node: specifiers and the
+    // `process` global from built-ins, so naming a node types package
+    // (e.g. `["node"]`) would only force an @types/node lookup that
+    // fails on a CI runner with no node_modules/ install.
     compilerOptions: {
       strict: true,
       lib: ["ESNext", "dom"],
-      types: ["node"],
     },
     imports: {
       "random-seed": `npm:random-seed@${pkg.dependencies["random-seed"]}`,

--- a/test/bin/jsrPackaging.test.ts
+++ b/test/bin/jsrPackaging.test.ts
@@ -72,6 +72,15 @@ describe("JSR Packaging Configuration", () => {
       assert.ok(config.publish.include.includes("README.md"));
       assert.ok(config.publish.include.includes("SECURITY.md"));
     });
+
+    it("uses Deno's built-in Node types without requiring node_modules", async () => {
+      const configPath = join(srcRoot, "jsr.json");
+      const configContent = await readFile(configPath, "utf-8");
+      const config = parseJsonc(configContent) as any;
+
+      assert.deepStrictEqual(config.compilerOptions.types, ["node"]);
+      assert.ok(!("@types/node" in config.imports));
+    });
   });
 
   describe("CLI file structure", () => {

--- a/test/bin/jsrPackaging.test.ts
+++ b/test/bin/jsrPackaging.test.ts
@@ -78,7 +78,7 @@ describe("JSR Packaging Configuration", () => {
       const configContent = await readFile(configPath, "utf-8");
       const config = parseJsonc(configContent) as any;
 
-      assert.deepStrictEqual(config.compilerOptions.types, ["node"]);
+      assert.ok(!("types" in config.compilerOptions));
       assert.ok(!("@types/node" in config.imports));
     });
   });


### PR DESCRIPTION
Both node.yml and publish.yml duplicated the same pnpm/Node/Bazel setup block. Extract it into a .github/actions/setup-bazel-node composite action parameterized by disk-cache and cache-save.

While consolidating, the host Node steps (pnpm/action-setup, setup-node, pnpm install --frozen-lockfile) proved redundant: Bazel supplies Node hermetically via rules_nodejs and resolves npm deps through npm_translate_lock from pnpm-lock.yaml, and every CI step is a bazel build/test/run. The composite action now only configures Bazel caches. Verified locally: //:typecheck, //:fmt_check, and //:node_tests all pass.

Also ignore the .claude/ working directory and bump to 0.20.2.