### PR TITLE
Centralize built-in Trip module paths in tripModules.ts

### DIFF
--- a/lib/avl.ts
+++ b/lib/avl.ts
@@ -1,11 +1,9 @@
 /**
  * Avl module provider.
  */
-import { join } from "node:path";
 import type { TripCObject } from "./compiler/objectFile.ts";
-import { loadTripModuleObject } from "./tripSourceLoader.ts";
-import { workspaceRoot } from "./shared/workspaceRoot.ts";
+import { getTripModuleObject } from "./tripModules.ts";
 
-export async function getAvlObject(): Promise<TripCObject> {
-  return await loadTripModuleObject(join(workspaceRoot, "lib", "avl.trip"));
+export function getAvlObject(): Promise<TripCObject> {
+  return getTripModuleObject("Avl");
 }

--- a/lib/bin.ts
+++ b/lib/bin.ts
@@ -1,11 +1,9 @@
 /**
  * Bin module provider.
  */
-import { join } from "node:path";
 import type { TripCObject } from "./compiler/objectFile.ts";
-import { loadTripModuleObject } from "./tripSourceLoader.ts";
-import { workspaceRoot } from "./shared/workspaceRoot.ts";
+import { getTripModuleObject } from "./tripModules.ts";
 
-export async function getBinObject(): Promise<TripCObject> {
-  return await loadTripModuleObject(join(workspaceRoot, "lib", "bin.trip"));
+export function getBinObject(): Promise<TripCObject> {
+  return getTripModuleObject("Bin");
 }

--- a/lib/compiler/bootstrapModules.ts
+++ b/lib/compiler/bootstrapModules.ts
@@ -1,0 +1,98 @@
+/**
+ * Bootstrap compiler module registry.
+ *
+ * The self-hosted Trip compiler is spread across .trip files under
+ * lib/compiler/. This file is the single source of truth for their
+ * name -> path mapping, extending the four public Trip modules from
+ * lib/tripModules.ts. Three call sites (combinatorCompiler,
+ * test/compiler/index.test.ts, test/compiler/llvm/nativeHarness.ts)
+ * previously each hardcoded a parallel copy of this table; they now
+ * all consume this registry.
+ *
+ * @module
+ */
+import { join } from "node:path";
+import { workspaceRoot } from "../shared/workspaceRoot.ts";
+import { loadTripModuleObject } from "../tripSourceLoader.ts";
+import type { TripCObject } from "./objectFile.ts";
+import {
+  tripModuleSourcePath,
+  type PublicTripModuleName,
+} from "../tripModules.ts";
+
+export type BootstrapTripModuleName =
+  | "Lexer"
+  | "Parser"
+  | "Core"
+  | "DataEnv"
+  | "CoreToLower"
+  | "Unparse"
+  | "Lowering"
+  | "Bridge"
+  | "Llvm"
+  | "BundleSummary"
+  | "CoreToMini"
+  | "MiniCore"
+  | "Anf"
+  | "Compiler"
+  | "Telemetry";
+
+export type CompilerTripModuleName =
+  | PublicTripModuleName
+  | BootstrapTripModuleName;
+
+const BOOTSTRAP_MODULE_FILES: Record<BootstrapTripModuleName, string> = {
+  Lexer: "lexer.trip",
+  Parser: "parser.trip",
+  Core: "core.trip",
+  DataEnv: "dataEnv.trip",
+  CoreToLower: "coreToLower.trip",
+  Unparse: "unparse.trip",
+  Lowering: "lowering.trip",
+  Bridge: "bridge.trip",
+  Llvm: "llvm.trip",
+  BundleSummary: "bundleSummary.trip",
+  CoreToMini: "coreToMini.trip",
+  MiniCore: "miniCore.trip",
+  Anf: "anf.trip",
+  Compiler: "index.trip",
+  Telemetry: "telemetry.trip",
+};
+
+export const ALL_COMPILER_TRIP_MODULE_NAMES: readonly CompilerTripModuleName[] =
+  [
+    "Prelude",
+    "Nat",
+    "Bin",
+    "Avl",
+    ...(Object.keys(BOOTSTRAP_MODULE_FILES) as BootstrapTripModuleName[]),
+  ];
+
+function isBootstrapModule(
+  name: CompilerTripModuleName,
+): name is BootstrapTripModuleName {
+  return Object.hasOwn(BOOTSTRAP_MODULE_FILES, name);
+}
+
+export function isKnownCompilerTripModule(
+  name: string,
+): name is CompilerTripModuleName {
+  return ALL_COMPILER_TRIP_MODULE_NAMES.includes(
+    name as CompilerTripModuleName,
+  );
+}
+
+export function compilerTripModuleSourcePath(
+  name: CompilerTripModuleName,
+): string {
+  if (isBootstrapModule(name)) {
+    return join(workspaceRoot, "lib", "compiler", BOOTSTRAP_MODULE_FILES[name]);
+  }
+  return tripModuleSourcePath(name);
+}
+
+export function loadCompilerTripModule(
+  name: CompilerTripModuleName,
+): Promise<TripCObject> {
+  return loadTripModuleObject(compilerTripModuleSourcePath(name));
+}

--- a/lib/compiler/combinatorCompiler.ts
+++ b/lib/compiler/combinatorCompiler.ts
@@ -1,160 +1,18 @@
-import { join } from "node:path";
-import { getAvlObject } from "../avl.ts";
-import { getBinObject } from "../bin.ts";
 import { linkModules } from "../linker/moduleLinker.ts";
-import { getNatObject } from "../nat.ts";
 import { parseTripLang } from "../parser/tripLang.ts";
-import { getPreludeObject } from "../prelude.ts";
 import { sortedStrings } from "../shared/canonical.ts";
-import { workspaceRoot } from "../shared/workspaceRoot.ts";
+import { loadTripSourceFile } from "../tripSourceLoader.ts";
 import {
-  loadTripModuleObject,
-  loadTripSourceFile,
-} from "../tripSourceLoader.ts";
+  ALL_COMPILER_TRIP_MODULE_NAMES,
+  compilerTripModuleSourcePath,
+  isKnownCompilerTripModule,
+  loadCompilerTripModule,
+} from "./bootstrapModules.ts";
 import type { TripCObject } from "./objectFile.ts";
 import {
   compileToObjectFile,
   SingleFileCompilerError,
 } from "./singleFileCompiler.ts";
-
-const lib = (...parts: string[]) => join(workspaceRoot, "lib", ...parts);
-
-const PRELUDE_SOURCE_FILE = lib("prelude.trip");
-const NAT_SOURCE_FILE = lib("nat.trip");
-const BIN_SOURCE_FILE = lib("bin.trip");
-const AVL_SOURCE_FILE = lib("avl.trip");
-const LEXER_SOURCE_FILE = lib("compiler", "lexer.trip");
-const PARSER_SOURCE_FILE = lib("compiler", "parser.trip");
-const CORE_SOURCE_FILE = lib("compiler", "core.trip");
-const DATA_ENV_SOURCE_FILE = lib("compiler", "dataEnv.trip");
-const CORE_TO_LOWER_SOURCE_FILE = lib("compiler", "coreToLower.trip");
-const UNPARSE_SOURCE_FILE = lib("compiler", "unparse.trip");
-const LOWERING_SOURCE_FILE = lib("compiler", "lowering.trip");
-const BRIDGE_SOURCE_FILE = lib("compiler", "bridge.trip");
-const LLVM_SOURCE_FILE = lib("compiler", "llvm.trip");
-const BUNDLE_SUMMARY_SOURCE_FILE = lib("compiler", "bundleSummary.trip");
-const CORE_TO_MINI_SOURCE_FILE = lib("compiler", "coreToMini.trip");
-const MINI_CORE_SOURCE_FILE = lib("compiler", "miniCore.trip");
-const ANF_SOURCE_FILE = lib("compiler", "anf.trip");
-const COMPILER_SOURCE_FILE = lib("compiler", "index.trip");
-const TELEMETRY_SOURCE_FILE = lib("compiler", "telemetry.trip");
-
-interface BuiltinModuleSpec {
-  source: string;
-  load: () => Promise<TripCObject>;
-}
-
-const BUILTIN_MODULES = new Map<string, BuiltinModuleSpec>([
-  ["Prelude", { source: PRELUDE_SOURCE_FILE, load: getPreludeObject }],
-  ["Nat", { source: NAT_SOURCE_FILE, load: getNatObject }],
-  ["Bin", { source: BIN_SOURCE_FILE, load: getBinObject }],
-  ["Avl", { source: AVL_SOURCE_FILE, load: getAvlObject }],
-  [
-    "Lexer",
-    {
-      source: LEXER_SOURCE_FILE,
-      load: () => loadTripModuleObject(LEXER_SOURCE_FILE),
-    },
-  ],
-  [
-    "Parser",
-    {
-      source: PARSER_SOURCE_FILE,
-      load: () => loadTripModuleObject(PARSER_SOURCE_FILE),
-    },
-  ],
-  [
-    "Core",
-    {
-      source: CORE_SOURCE_FILE,
-      load: () => loadTripModuleObject(CORE_SOURCE_FILE),
-    },
-  ],
-  [
-    "DataEnv",
-    {
-      source: DATA_ENV_SOURCE_FILE,
-      load: () => loadTripModuleObject(DATA_ENV_SOURCE_FILE),
-    },
-  ],
-  [
-    "CoreToLower",
-    {
-      source: CORE_TO_LOWER_SOURCE_FILE,
-      load: () => loadTripModuleObject(CORE_TO_LOWER_SOURCE_FILE),
-    },
-  ],
-  [
-    "Unparse",
-    {
-      source: UNPARSE_SOURCE_FILE,
-      load: () => loadTripModuleObject(UNPARSE_SOURCE_FILE),
-    },
-  ],
-  [
-    "Lowering",
-    {
-      source: LOWERING_SOURCE_FILE,
-      load: () => loadTripModuleObject(LOWERING_SOURCE_FILE),
-    },
-  ],
-  [
-    "Bridge",
-    {
-      source: BRIDGE_SOURCE_FILE,
-      load: () => loadTripModuleObject(BRIDGE_SOURCE_FILE),
-    },
-  ],
-  [
-    "Llvm",
-    {
-      source: LLVM_SOURCE_FILE,
-      load: () => loadTripModuleObject(LLVM_SOURCE_FILE),
-    },
-  ],
-  [
-    "BundleSummary",
-    {
-      source: BUNDLE_SUMMARY_SOURCE_FILE,
-      load: () => loadTripModuleObject(BUNDLE_SUMMARY_SOURCE_FILE),
-    },
-  ],
-  [
-    "CoreToMini",
-    {
-      source: CORE_TO_MINI_SOURCE_FILE,
-      load: () => loadTripModuleObject(CORE_TO_MINI_SOURCE_FILE),
-    },
-  ],
-  [
-    "MiniCore",
-    {
-      source: MINI_CORE_SOURCE_FILE,
-      load: () => loadTripModuleObject(MINI_CORE_SOURCE_FILE),
-    },
-  ],
-  [
-    "Anf",
-    {
-      source: ANF_SOURCE_FILE,
-      load: () => loadTripModuleObject(ANF_SOURCE_FILE),
-    },
-  ],
-  [
-    "Compiler",
-    {
-      source: COMPILER_SOURCE_FILE,
-      load: () => loadTripModuleObject(COMPILER_SOURCE_FILE),
-    },
-  ],
-  [
-    "Telemetry",
-    {
-      source: TELEMETRY_SOURCE_FILE,
-      load: () => loadTripModuleObject(TELEMETRY_SOURCE_FILE),
-    },
-  ],
-]);
 
 function sanitizeImportedModule(
   moduleName: string,
@@ -195,7 +53,7 @@ function importedModuleNames(source: string): string[] {
 }
 
 function supportedModuleNames(): string {
-  return sortedStrings(BUILTIN_MODULES.keys()).join(", ");
+  return sortedStrings(ALL_COMPILER_TRIP_MODULE_NAMES).join(", ");
 }
 
 async function loadBuiltinModuleGraph(
@@ -209,8 +67,7 @@ async function loadBuiltinModuleGraph(
       return;
     }
 
-    const spec = BUILTIN_MODULES.get(moduleName);
-    if (!spec) {
+    if (!isKnownCompilerTripModule(moduleName)) {
       throw new SingleFileCompilerError(
         `Unsupported imported module '${moduleName}'. Supported built-ins: ${supportedModuleNames()}`,
       );
@@ -218,7 +75,9 @@ async function loadBuiltinModuleGraph(
 
     visiting.add(moduleName);
     try {
-      const source = await loadTripSourceFile(spec.source);
+      const source = await loadTripSourceFile(
+        compilerTripModuleSourcePath(moduleName),
+      );
       for (const importedModuleName of importedModuleNames(source)) {
         if (
           moduleName === "Compiler" &&
@@ -231,7 +90,10 @@ async function loadBuiltinModuleGraph(
       }
       loaded.set(
         moduleName,
-        sanitizeImportedModule(moduleName, await spec.load()),
+        sanitizeImportedModule(
+          moduleName,
+          await loadCompilerTripModule(moduleName),
+        ),
       );
     } finally {
       visiting.delete(moduleName);

--- a/lib/nat.ts
+++ b/lib/nat.ts
@@ -1,11 +1,9 @@
 /**
  * Nat module provider.
  */
-import { join } from "node:path";
 import type { TripCObject } from "./compiler/objectFile.ts";
-import { loadTripModuleObject } from "./tripSourceLoader.ts";
-import { workspaceRoot } from "./shared/workspaceRoot.ts";
+import { getTripModuleObject } from "./tripModules.ts";
 
-export async function getNatObject(): Promise<TripCObject> {
-  return await loadTripModuleObject(join(workspaceRoot, "lib", "nat.trip"));
+export function getNatObject(): Promise<TripCObject> {
+  return getTripModuleObject("Nat");
 }

--- a/lib/prelude.ts
+++ b/lib/prelude.ts
@@ -1,11 +1,9 @@
 /**
  * Prelude module provider.
  */
-import { join } from "node:path";
 import type { TripCObject } from "./compiler/objectFile.ts";
-import { loadTripModuleObject } from "./tripSourceLoader.ts";
-import { workspaceRoot } from "./shared/workspaceRoot.ts";
+import { getTripModuleObject } from "./tripModules.ts";
 
-export async function getPreludeObject(): Promise<TripCObject> {
-  return await loadTripModuleObject(join(workspaceRoot, "lib", "prelude.trip"));
+export function getPreludeObject(): Promise<TripCObject> {
+  return getTripModuleObject("Prelude");
 }

--- a/lib/tripModules.ts
+++ b/lib/tripModules.ts
@@ -1,0 +1,31 @@
+/**
+ * Built-in Trip module registry.
+ *
+ * Single source of truth for the name -> .trip source mapping used by the
+ * four public `getXObject` providers. Internal to the lib tree; the public
+ * surface continues to expose the named providers re-exported by
+ * `lib/index.ts`.
+ */
+import { join } from "node:path";
+import type { TripCObject } from "./compiler/objectFile.ts";
+import { loadTripModuleObject } from "./tripSourceLoader.ts";
+import { workspaceRoot } from "./shared/workspaceRoot.ts";
+
+export type PublicTripModuleName = "Prelude" | "Nat" | "Bin" | "Avl";
+
+const MODULE_PATHS: Record<PublicTripModuleName, readonly string[]> = {
+  Prelude: ["lib", "prelude.trip"],
+  Nat: ["lib", "nat.trip"],
+  Bin: ["lib", "bin.trip"],
+  Avl: ["lib", "avl.trip"],
+};
+
+export function tripModuleSourcePath(name: PublicTripModuleName): string {
+  return join(workspaceRoot, ...MODULE_PATHS[name]);
+}
+
+export function getTripModuleObject(
+  name: PublicTripModuleName,
+): Promise<TripCObject> {
+  return loadTripModuleObject(tripModuleSourcePath(name));
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.20.4",
+  "version": "0.20.5",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/index.test.ts
+++ b/test/compiler/index.test.ts
@@ -1,80 +1,33 @@
 import { describe, it } from "../util/test_shim.ts";
 import assert from "node:assert/strict";
-import { join } from "node:path";
-import { workspaceRoot } from "../../lib/shared/workspaceRoot.ts";
 import { compileToObjectFile } from "../../lib/compiler/singleFileCompiler.ts";
 import type { TripCObject } from "../../lib/compiler/objectFile.ts";
+import {
+  type CompilerTripModuleName,
+  loadCompilerTripModule,
+} from "../../lib/compiler/bootstrapModules.ts";
 import { linkModules } from "../../lib/linker/moduleLinker.ts";
-import { getPreludeObject } from "../../lib/prelude.ts";
 import { parseSKI } from "../../lib/parser/ski.ts";
 import { toTopoDagWire } from "../../lib/ski/topoDagWire.ts";
-import { loadTripModuleObject } from "../../lib/tripSourceLoader.ts";
 
-const LEXER_SOURCE_FILE = join(workspaceRoot, "lib", "compiler", "lexer.trip");
-const PARSER_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "parser.trip",
-);
-const CORE_SOURCE_FILE = join(workspaceRoot, "lib", "compiler", "core.trip");
-const DATA_ENV_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "dataEnv.trip",
-);
-const UNPARSE_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "unparse.trip",
-);
-const LOWERING_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "lowering.trip",
-);
-const BRIDGE_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "bridge.trip",
-);
-const CORE_TO_LOWER_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "coreToLower.trip",
-);
-const COMPILER_SOURCE_FILE = join(
-  workspaceRoot,
-  "lib",
-  "compiler",
-  "index.trip",
-);
-const LLVM_SOURCE_FILE = join(workspaceRoot, "lib", "compiler", "llvm.trip");
-const AVL_SOURCE_FILE = join(workspaceRoot, "lib", "avl.trip");
-const BIN_SOURCE_FILE = join(workspaceRoot, "lib", "bin.trip");
-const NAT_SOURCE_FILE = join(workspaceRoot, "lib", "nat.trip");
+const HARNESS_MODULE_NAMES: readonly CompilerTripModuleName[] = [
+  "Prelude",
+  "Nat",
+  "Bin",
+  "Avl",
+  "Lexer",
+  "Parser",
+  "Core",
+  "DataEnv",
+  "CoreToLower",
+  "Unparse",
+  "Lowering",
+  "Bridge",
+  "Llvm",
+  "Compiler",
+];
 
-interface CompilerModules {
-  prelude: TripCObject;
-  lexer: TripCObject;
-  parser: TripCObject;
-  core: TripCObject;
-  dataEnv: TripCObject;
-  unparse: TripCObject;
-  lowering: TripCObject;
-  coreToLower: TripCObject;
-  bridge: TripCObject;
-  llvm: TripCObject;
-  compiler: TripCObject;
-  avl: TripCObject;
-  bin: TripCObject;
-  nat: TripCObject;
-}
+type CompilerModules = Map<CompilerTripModuleName, TripCObject>;
 
 let compilerModulesPromise: Promise<CompilerModules> | null = null;
 
@@ -107,57 +60,26 @@ function compilerCombOnly(object: TripCObject): TripCObject {
 async function getCompilerModules(): Promise<CompilerModules> {
   if (!compilerModulesPromise) {
     compilerModulesPromise = (async () => {
-      const [
-        prelude,
-        lexer,
-        parser,
-        core,
-        dataEnv,
-        unparse,
-        lowering,
-        coreToLower,
-        bridge,
-        llvm,
-        compiler,
-        avl,
-        bin,
-        nat,
-      ] = await Promise.all([
-        getPreludeObject(),
-        loadTripModuleObject(LEXER_SOURCE_FILE),
-        loadTripModuleObject(PARSER_SOURCE_FILE),
-        loadTripModuleObject(CORE_SOURCE_FILE),
-        loadTripModuleObject(DATA_ENV_SOURCE_FILE),
-        loadTripModuleObject(UNPARSE_SOURCE_FILE),
-        loadTripModuleObject(LOWERING_SOURCE_FILE),
-        loadTripModuleObject(CORE_TO_LOWER_SOURCE_FILE),
-        loadTripModuleObject(BRIDGE_SOURCE_FILE),
-        loadTripModuleObject(LLVM_SOURCE_FILE),
-        loadTripModuleObject(COMPILER_SOURCE_FILE),
-        loadTripModuleObject(AVL_SOURCE_FILE),
-        loadTripModuleObject(BIN_SOURCE_FILE),
-        loadTripModuleObject(NAT_SOURCE_FILE),
-      ]);
-
-      return {
-        prelude,
-        lexer,
-        parser,
-        core,
-        dataEnv,
-        unparse,
-        lowering,
-        coreToLower,
-        bridge,
-        llvm,
-        compiler,
-        avl,
-        bin,
-        nat,
-      };
+      const objects = await Promise.all(
+        HARNESS_MODULE_NAMES.map((name) => loadCompilerTripModule(name)),
+      );
+      return new Map(
+        HARNESS_MODULE_NAMES.map((name, i) => [name, objects[i]!]),
+      );
     })();
   }
-  return await compilerModulesPromise;
+  return compilerModulesPromise;
+}
+
+function moduleObject(
+  modules: CompilerModules,
+  name: CompilerTripModuleName,
+): TripCObject {
+  const object = modules.get(name);
+  if (!object) {
+    throw new Error(`Harness module '${name}' not loaded`);
+  }
+  return object;
 }
 
 function makeParityHarness(source: string, expected: string): string {
@@ -204,29 +126,33 @@ poly main =
 
 async function buildCompilerHarnessExpression(source: string) {
   const modules = await getCompilerModules();
-  const compilerForHarness = compilerCombOnly(modules.compiler);
+  const get = (name: CompilerTripModuleName) => moduleObject(modules, name);
+  const compilerForHarness = compilerCombOnly(get("Compiler"));
   const testObject = compileToObjectFile(source, {
     importedModules: [
-      modules.prelude,
-      modules.lexer,
-      modules.unparse,
+      get("Prelude"),
+      get("Lexer"),
+      get("Unparse"),
       compilerForHarness,
     ],
   });
 
+  const LINKED_MODULE_NAMES: readonly CompilerTripModuleName[] = [
+    "Prelude",
+    "Bin",
+    "Nat",
+    "Avl",
+    "Lexer",
+    "Parser",
+    "Core",
+    "DataEnv",
+    "Unparse",
+    "Lowering",
+    "CoreToLower",
+    "Bridge",
+  ];
   const linked = linkModules([
-    { name: "Prelude", object: modules.prelude },
-    { name: "Bin", object: modules.bin },
-    { name: "Nat", object: modules.nat },
-    { name: "Avl", object: modules.avl },
-    { name: "Lexer", object: modules.lexer },
-    { name: "Parser", object: modules.parser },
-    { name: "Core", object: modules.core },
-    { name: "DataEnv", object: modules.dataEnv },
-    { name: "Unparse", object: modules.unparse },
-    { name: "Lowering", object: modules.lowering },
-    { name: "CoreToLower", object: modules.coreToLower },
-    { name: "Bridge", object: modules.bridge },
+    ...LINKED_MODULE_NAMES.map((name) => ({ name, object: get(name) })),
     { name: "Compiler", object: compilerForHarness },
     { name: "Test", object: testObject },
   ]);

--- a/test/compiler/llvm/nativeHarness.ts
+++ b/test/compiler/llvm/nativeHarness.ts
@@ -4,6 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { workspaceRoot } from "../../../lib/shared/workspaceRoot.ts";
 import {
+  compilerTripModuleSourcePath,
+  isKnownCompilerTripModule,
+  type CompilerTripModuleName,
+} from "../../../lib/compiler/bootstrapModules.ts";
+import {
   compileTripSourceToLlvm,
   type CompileTripSourceToLlvmOptions,
 } from "../../../lib/compiler/index.ts";
@@ -161,10 +166,7 @@ export const bootstrap = {
     const cleanup = () => rm(tempDir, { recursive: true, force: true });
 
     try {
-      const libDir = join(PROJECT_ROOT, "lib");
-      const compilerLibDir = join(libDir, "compiler");
-
-      const moduleNames = [
+      const moduleNames: readonly CompilerTripModuleName[] = [
         "Prelude",
         "Nat",
         "Bin",
@@ -181,22 +183,14 @@ export const bootstrap = {
         "Llvm",
       ];
       const moduleSources = await Promise.all(
-        moduleNames.map(async (name) => {
-          let path = join(libDir, `${name.toLowerCase()}.trip`);
-          try {
-            await readFile(path);
-          } catch {
-            path = join(
-              compilerLibDir,
-              `${name.charAt(0).toLowerCase() + name.slice(1)}.trip`,
-            );
-          }
-          return { name, source: await readFile(path, "utf8") };
-        }),
+        moduleNames.map(async (name) => ({
+          name,
+          source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+        })),
       );
 
       const compilerSource = await readFile(
-        join(compilerLibDir, "index.trip"),
+        compilerTripModuleSourcePath("Compiler"),
         "utf8",
       );
 
@@ -240,21 +234,15 @@ export const bootstrap = {
 export async function loadCommonModules(
   names: string[],
 ): Promise<Array<{ name: string; source: string }>> {
-  const libDir = join(PROJECT_ROOT, "lib");
-  const compilerLibDir = join(libDir, "compiler");
-
   return Promise.all(
     names.map(async (name) => {
-      let path = join(libDir, `${name.toLowerCase()}.trip`);
-      try {
-        await readFile(path);
-      } catch {
-        path = join(
-          compilerLibDir,
-          `${name.charAt(0).toLowerCase() + name.slice(1)}.trip`,
-        );
+      if (!isKnownCompilerTripModule(name)) {
+        throw new Error(`loadCommonModules: unknown module '${name}'`);
       }
-      return { name, source: await readFile(path, "utf8") };
+      return {
+        name,
+        source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+      };
     }),
   );
 }


### PR DESCRIPTION
The four module providers (prelude, nat, bin, avl) carried near-identical copies of a join(workspaceRoot, "lib", "<name>.trip") call. The name -> path mapping is repeated again in lib/compiler/combinatorCompiler and in two test harnesses, but unifying those needs the bootstrap-manifest work; this change addresses just the public-provider duplication.

Introduce lib/tripModules.ts as the single declarative table and reduce each provider to a one-line delegate. Public API surface (the named getXObject exports re-exported from lib/index.ts) is unchanged. Bump to 0.20.5.