### PR TITLE
Trip-side ANF→LLVM emitter + multi-bundle correctness

### DIFF
--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -46,7 +46,7 @@ import Anf MkAnfProgram
 export emitProgram
 export compileSourceToLlvmText
 
-data EmitRes = MkEmitRes Bin (List U8) (List U8)
+data EmitRes = MkEmitRes Bin (List (List U8)) (List U8)
 
 poly rec lookupEnv = \env : List (Pair (List U8) (List U8)) => \name : List U8 =>
   matchList [Pair (List U8) (List U8)] [Maybe (List U8)] env
@@ -88,7 +88,7 @@ poly rec emitArgsString = \env : List (Pair (List U8) (List U8)) => \args : List
             }
       })
 
-poly rec emitExpr = \env : List (Pair (List U8) (List U8)) => \counter : Bin => \instrs : List U8 => \e : AnfExpr =>
+poly rec emitExpr = \env : List (Pair (List U8) (List U8)) => \counter : Bin => \instrs : List (List U8) => \e : AnfExpr =>
   match e [Result (List U8) EmitRes] {
     | AE_Var n =>
         match (lookupEnv env n) [Result (List U8) EmitRes] {
@@ -110,7 +110,7 @@ poly rec emitExpr = \env : List (Pair (List U8) (List U8)) => \counter : Bin => 
                       (append [U8] f
                         (append [U8] "("
                           (append [U8] argStr ")\n"))))) in
-              Ok [List U8] [EmitRes] (MkEmitRes counter1 (append [U8] instrs line) dest)
+              Ok [List U8] [EmitRes] (MkEmitRes counter1 (cons [List U8] line instrs) dest)
         }
     | AE_Con tag total arity args => Err [List U8] [EmitRes] "Unsupported expression: constructor"
     | AE_Case scrut arms => Err [List U8] [EmitRes] "Unsupported expression: case"
@@ -144,19 +144,25 @@ poly rec paramEnv = \params : List (List U8) =>
         (MkPair [List U8] [List U8] h (append [U8] "%" h))
         (paramEnv t))
 
+poly rec joinLines = \acc : List U8 => \lines : List (List U8) =>
+  matchList [List U8] [List U8] lines
+    acc
+    (\h : List U8 => \t : List (List U8) => joinLines (append [U8] h acc) t)
+
 poly emitFunc = \fn : AnfFunc =>
   match fn [Result (List U8) (List U8)] { | MkAnfFunc name params body =>
-    match (emitExpr (paramEnv params) BZ (nil [U8]) body) [Result (List U8) (List U8)] {
+    match (emitExpr (paramEnv params) BZ (nil [List U8]) body) [Result (List U8) (List U8)] {
       | Err e => Err [List U8] [List U8] e
       | Ok res =>
           match res [Result (List U8) (List U8)] { | MkEmitRes c instrs op =>
+            let instrText = joinLines (nil [U8]) instrs in
             Ok [List U8] [List U8]
               (append [U8] "define i8 @"
                 (append [U8] name
                   (append [U8] "("
                     (append [U8] (paramDeclsString params true)
                       (append [U8] ") {\nentry:\n"
-                        (append [U8] instrs
+                        (append [U8] instrText
                           (append [U8] "  ret i8 "
                             (append [U8] op "\n}\n\n"))))))))
           }

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -1,0 +1,204 @@
+module AnfLlvm
+
+import Prelude List
+import Prelude nil
+import Prelude cons
+import Prelude matchList
+import Prelude append
+import Prelude Result
+import Prelude Ok
+import Prelude Err
+import Prelude Maybe
+import Prelude Some
+import Prelude None
+import Prelude Bool
+import Prelude true
+import Prelude false
+import Prelude if
+import Prelude U8
+import Prelude eqListU8
+import Prelude Pair
+import Prelude MkPair
+import Prelude fst
+import Prelude snd
+import Prelude Bin
+import Prelude BZ
+import Bin incBin
+import Bin binToDigits
+import Lexer tokenize
+import Parser parseProgram
+import Bridge elaborateProgramToCore
+import MiniCore buildMiniProgram
+import Anf normalizeProgram
+import Anf AnfExpr
+import Anf AE_Var
+import Anf AE_Native
+import Anf AE_Lam
+import Anf AE_Call
+import Anf AE_Con
+import Anf AE_Case
+import Anf AE_Let
+import Anf AnfFunc
+import Anf MkAnfFunc
+import Anf AnfProgram
+import Anf MkAnfProgram
+
+export emitProgram
+export compileSourceToLlvmText
+
+data EmitRes = MkEmitRes Bin (List U8) (List U8)
+
+poly rec lookupEnv = \env : List (Pair (List U8) (List U8)) => \name : List U8 =>
+  matchList [Pair (List U8) (List U8)] [Maybe (List U8)] env
+    (None [List U8])
+    (\h : Pair (List U8) (List U8) => \t : List (Pair (List U8) (List U8)) =>
+      if [Maybe (List U8)] (eqListU8 (fst [List U8] [List U8] h) name)
+        (\u : U8 => Some [List U8] (snd [List U8] [List U8] h))
+        (\u : U8 => lookupEnv t name))
+
+poly atomOperand = \env : List (Pair (List U8) (List U8)) => \e : AnfExpr =>
+  match e [Result (List U8) (List U8)] {
+    | AE_Var n =>
+        match (lookupEnv env n) [Result (List U8) (List U8)] {
+          | None => Err [List U8] [List U8] (append [U8] "Unbound variable: " n)
+          | Some op => Ok [List U8] [List U8] op
+        }
+    | AE_Native t => Err [List U8] [List U8] "Unsupported atom: native"
+    | AE_Lam n b => Err [List U8] [List U8] "Unsupported atom: lambda"
+    | AE_Call f args => Err [List U8] [List U8] "Unsupported atom: call"
+    | AE_Con tag total arity args => Err [List U8] [List U8] "Unsupported atom: constructor"
+    | AE_Case scrut arms => Err [List U8] [List U8] "Unsupported atom: case"
+    | AE_Let name val body => Err [List U8] [List U8] "Unsupported atom: let"
+  }
+
+poly rec emitArgsString = \env : List (Pair (List U8) (List U8)) => \args : List AnfExpr => \leading : Bool =>
+  matchList [AnfExpr] [Result (List U8) (List U8)] args
+    (Ok [List U8] [List U8] (nil [U8]))
+    (\h : AnfExpr => \t : List AnfExpr =>
+      match (atomOperand env h) [Result (List U8) (List U8)] {
+        | Err e => Err [List U8] [List U8] e
+        | Ok op =>
+            let piece =
+              if [List U8] leading
+                (\u : U8 => append [U8] "i8 " op)
+                (\u : U8 => append [U8] ", i8 " op) in
+            match (emitArgsString env t false) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] e
+              | Ok rest => Ok [List U8] [List U8] (append [U8] piece rest)
+            }
+      })
+
+poly rec emitExpr = \env : List (Pair (List U8) (List U8)) => \counter : Bin => \instrs : List U8 => \e : AnfExpr =>
+  match e [Result (List U8) EmitRes] {
+    | AE_Var n =>
+        match (lookupEnv env n) [Result (List U8) EmitRes] {
+          | None => Err [List U8] [EmitRes] (append [U8] "Unbound variable: " n)
+          | Some op => Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
+        }
+    | AE_Native t => Err [List U8] [EmitRes] "Unsupported expression: native"
+    | AE_Lam n b => Err [List U8] [EmitRes] "Unsupported expression: lambda"
+    | AE_Call f args =>
+        match (emitArgsString env args true) [Result (List U8) EmitRes] {
+          | Err e => Err [List U8] [EmitRes] e
+          | Ok argStr =>
+              let dest = append [U8] "%__ll" (binToDigits counter) in
+              let counter1 = incBin counter in
+              let line =
+                append [U8] "  "
+                  (append [U8] dest
+                    (append [U8] " = call i8 @"
+                      (append [U8] f
+                        (append [U8] "("
+                          (append [U8] argStr ")\n"))))) in
+              Ok [List U8] [EmitRes] (MkEmitRes counter1 (append [U8] instrs line) dest)
+        }
+    | AE_Con tag total arity args => Err [List U8] [EmitRes] "Unsupported expression: constructor"
+    | AE_Case scrut arms => Err [List U8] [EmitRes] "Unsupported expression: case"
+    | AE_Let name val body =>
+        match (emitExpr env counter instrs val) [Result (List U8) EmitRes] {
+          | Err e => Err [List U8] [EmitRes] e
+          | Ok midRes =>
+              match midRes [Result (List U8) EmitRes] { | MkEmitRes c1 i1 vop =>
+                emitExpr
+                  (cons [Pair (List U8) (List U8)] (MkPair [List U8] [List U8] name vop) env)
+                  c1 i1 body
+              }
+        }
+  }
+
+poly rec paramDeclsString = \params : List (List U8) => \leading : Bool =>
+  matchList [List U8] [List U8] params
+    (nil [U8])
+    (\h : List U8 => \t : List (List U8) =>
+      let piece =
+        if [List U8] leading
+          (\u : U8 => append [U8] "i8 %" h)
+          (\u : U8 => append [U8] ", i8 %" h) in
+      append [U8] piece (paramDeclsString t false))
+
+poly rec paramEnv = \params : List (List U8) =>
+  matchList [List U8] [List (Pair (List U8) (List U8))] params
+    (nil [Pair (List U8) (List U8)])
+    (\h : List U8 => \t : List (List U8) =>
+      cons [Pair (List U8) (List U8)]
+        (MkPair [List U8] [List U8] h (append [U8] "%" h))
+        (paramEnv t))
+
+poly emitFunc = \fn : AnfFunc =>
+  match fn [Result (List U8) (List U8)] { | MkAnfFunc name params body =>
+    match (emitExpr (paramEnv params) BZ (nil [U8]) body) [Result (List U8) (List U8)] {
+      | Err e => Err [List U8] [List U8] e
+      | Ok res =>
+          match res [Result (List U8) (List U8)] { | MkEmitRes c instrs op =>
+            Ok [List U8] [List U8]
+              (append [U8] "define i8 @"
+                (append [U8] name
+                  (append [U8] "("
+                    (append [U8] (paramDeclsString params true)
+                      (append [U8] ") {\nentry:\n"
+                        (append [U8] instrs
+                          (append [U8] "  ret i8 "
+                            (append [U8] op "\n}\n\n"))))))))
+          }
+    }
+  }
+
+poly rec emitFuncs = \fns : List AnfFunc =>
+  matchList [AnfFunc] [Result (List U8) (List U8)] fns
+    (Ok [List U8] [List U8] (nil [U8]))
+    (\h : AnfFunc => \t : List AnfFunc =>
+      match (emitFunc h) [Result (List U8) (List U8)] {
+        | Err e => Err [List U8] [List U8] e
+        | Ok block =>
+            match (emitFuncs t) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] e
+              | Ok rest => Ok [List U8] [List U8] (append [U8] block rest)
+            }
+      })
+
+poly emitProgram = \prog : AnfProgram =>
+  match prog [Result (List U8) (List U8)] { | MkAnfProgram funcs entry =>
+    emitFuncs funcs
+  }
+
+poly compileSourceToLlvmText = \source : List U8 =>
+  match (tokenize source) [List U8] {
+    | Err e => append [U8] "ERR:" "Lex error"
+    | Ok toks =>
+        match (parseProgram toks) [List U8] {
+          | Err e => append [U8] "ERR:" "Parse error"
+          | Ok decls =>
+              match (elaborateProgramToCore decls) [List U8] {
+                | Err e => append [U8] "ERR:" e
+                | Ok coreDefs =>
+                    match (buildMiniProgram coreDefs "main") [List U8] {
+                      | Err e => append [U8] "ERR:" e
+                      | Ok prog =>
+                          match (emitProgram (normalizeProgram prog)) [List U8] {
+                            | Err e => append [U8] "ERR:" e
+                            | Ok llvm => llvm
+                          }
+                    }
+              }
+        }
+  }

--- a/lib/compiler/bootstrapModules.ts
+++ b/lib/compiler/bootstrapModules.ts
@@ -35,6 +35,7 @@ export type BootstrapTripModuleName =
   | "MiniCore"
   | "MiniVerify"
   | "Anf"
+  | "AnfLlvm"
   | "Compiler"
   | "Telemetry";
 
@@ -60,6 +61,7 @@ const BOOTSTRAP_MODULE_FILES: Record<BootstrapTripModuleName, string> = {
   MiniCore: "miniCore.trip",
   MiniVerify: "miniVerify.trip",
   Anf: "anf.trip",
+  AnfLlvm: "anfLlvm.trip",
   Compiler: "index.trip",
   Telemetry: "telemetry.trip",
 };

--- a/lib/minicore/fromTrip.ts
+++ b/lib/minicore/fromTrip.ts
@@ -2113,6 +2113,89 @@ class MiniCoreBuilder {
   }
 }
 
+function sortModulesAndValidate(
+  modules: SourceModule[],
+  entryModule: string,
+): SourceModule[] {
+  const moduleMap = new Map<string, SourceModule>();
+  for (const mod of modules) {
+    moduleMap.set(mod.name, mod);
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const order: SourceModule[] = [];
+
+  function dfs(name: string) {
+    if (name === "Prelude" && !moduleMap.has("Prelude")) {
+      return;
+    }
+
+    if (visiting.has(name)) {
+      const path = [...visiting];
+      const startIndex = path.indexOf(name);
+      const cyclePath = path.slice(startIndex).concat(name).join(" -> ");
+      throw new MiniCoreCompileError(`Dependency cycle detected: ${cyclePath}`);
+    }
+    if (visited.has(name)) {
+      return;
+    }
+
+    const mod = moduleMap.get(name);
+    if (!mod) {
+      throw new MiniCoreCompileError(`Unknown module ${name}`);
+    }
+
+    visiting.add(name);
+
+    // Collect direct dependencies, sorted alphabetically for determinism
+    const directDeps = new Set<string>();
+    for (const qName of mod.imports.values()) {
+      const depName = qName.split(".")[0];
+      if (depName && depName !== name) {
+        directDeps.add(depName);
+      }
+    }
+    const sortedDeps = [...directDeps].sort();
+
+    for (const dep of sortedDeps) {
+      dfs(dep);
+    }
+
+    visiting.delete(name);
+    visited.add(name);
+    order.push(mod);
+  }
+
+  dfs(entryModule);
+
+  // Validate imports up-front for reachable modules
+  for (const mod of order) {
+    for (const [localName, qName] of mod.imports.entries()) {
+      const [targetModuleName, targetLocalName] = splitQualifiedName(qName);
+      if (targetModuleName === "Prelude" && !moduleMap.has("Prelude")) {
+        continue;
+      }
+      const targetModule = moduleMap.get(targetModuleName);
+      if (!targetModule) {
+        throw new MiniCoreCompileError(`Module ${mod.name} imports ${targetLocalName} from unknown module ${targetModuleName}`);
+      }
+      if (!targetModule.exports.has(targetLocalName)) {
+        throw new MiniCoreCompileError(`Module ${mod.name} imports ${targetLocalName} which is not exported by module ${targetModuleName}`);
+      }
+    }
+  }
+
+  // Preserve all input modules (including unreachable ones) at the end to keep ADT/constructor loading intact
+  for (const mod of modules) {
+    if (!visited.has(mod.name)) {
+      order.push(mod);
+    }
+  }
+
+  return order;
+}
+
 export function compileMiniCoreModules(
   modules: MiniCoreModuleSource[],
   entryModuleName?: string,
@@ -2125,10 +2208,12 @@ export function compileMiniCoreModules(
   if (!entryModule) {
     throw new MiniCoreCompileError("No MiniCore entry module found");
   }
-  const builder = new MiniCoreBuilder(sourceModules);
+  const sortedModules = sortModulesAndValidate(sourceModules, entryModule);
+  const builder = new MiniCoreBuilder(sortedModules);
   const program = builder.build(`${entryModule}.main`);
   validateMiniCoreProgram(program, {
     requireNullaryEntry: options.requireNullaryEntry,
   });
   return program;
 }
+

--- a/lib/minicore/fromTrip.ts
+++ b/lib/minicore/fromTrip.ts
@@ -2178,10 +2178,14 @@ function sortModulesAndValidate(
       }
       const targetModule = moduleMap.get(targetModuleName);
       if (!targetModule) {
-        throw new MiniCoreCompileError(`Module ${mod.name} imports ${targetLocalName} from unknown module ${targetModuleName}`);
+        throw new MiniCoreCompileError(
+          `Module ${mod.name} imports ${targetLocalName} from unknown module ${targetModuleName}`,
+        );
       }
       if (!targetModule.exports.has(targetLocalName)) {
-        throw new MiniCoreCompileError(`Module ${mod.name} imports ${targetLocalName} which is not exported by module ${targetModuleName}`);
+        throw new MiniCoreCompileError(
+          `Module ${mod.name} imports ${targetLocalName} which is not exported by module ${targetModuleName}`,
+        );
       }
     }
   }
@@ -2216,4 +2220,3 @@ export function compileMiniCoreModules(
   });
   return program;
 }
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.20.8",
+  "version": "0.21.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/anfLlvmEmit.test.ts
+++ b/test/compiler/anfLlvmEmit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Stage-0 verification of the .trip ANF -> LLVM emitter (anfLlvm.trip).
+ *
+ * Runs `AnfLlvm.compileSourceToLlvmText` under the TypeScript MiniCore
+ * evaluator on a small straight-line `U8` corpus (params, let-bindings,
+ * and direct known-symbol calls) and asserts the emitted LLVM text. This
+ * is the minimal slice of the ANF->LLVM tail: no constructors, cases,
+ * inner lambdas, or runtime primitives yet.
+ */
+
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { compilerTripModuleSourcePath } from "../../lib/compiler/bootstrapModules.ts";
+import { compileMiniCoreModules } from "../../lib/minicore/fromTrip.ts";
+import { evaluateMiniCore } from "../../lib/minicore/evaluator.ts";
+import type { Value } from "../../lib/minicore/ast.ts";
+
+const MODULE_NAMES = [
+  "Prelude",
+  "Nat",
+  "Bin",
+  "Avl",
+  "Lexer",
+  "Parser",
+  "Core",
+  "DataEnv",
+  "CoreToLower",
+  "Unparse",
+  "Lowering",
+  "Bridge",
+  "CoreToMini",
+  "MiniCore",
+  "Anf",
+  "AnfLlvm",
+] as const;
+
+/** Decodes a Scott/ADT-encoded `List U8` MiniCore value to a byte array. */
+function valueToBytes(value: Value): number[] {
+  const bytes: number[] = [];
+  let cur: Value = value;
+  while (cur.kind === "con" && cur.fields.length === 2) {
+    const head = cur.fields[0];
+    const tail = cur.fields[1];
+    if (head === undefined || tail === undefined || head.kind !== "lit") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    const literal = head.value;
+    if (literal.kind !== "u8") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    bytes.push(literal.value);
+    cur = tail;
+  }
+  if (cur.kind !== "con" || cur.fields.length !== 0) {
+    throw new Error(`expected nil terminator, got ${JSON.stringify(cur)}`);
+  }
+  return bytes;
+}
+
+const DEMO_SOURCE = `module Demo
+export konst
+export main
+poly konst = \\x : U8 => \\y : U8 => x
+poly main = \\z : U8 => konst (konst z z) z
+`;
+
+const EXPECTED_LLVM = `define i8 @konst(i8 %x, i8 %y) {
+entry:
+  ret i8 %x
+}
+
+define i8 @main(i8 %z) {
+entry:
+  %__ll0 = call i8 @konst(i8 %z, i8 %z)
+  %__ll1 = call i8 @konst(i8 %__ll0, i8 %z)
+  ret i8 %__ll1
+}
+
+`;
+
+describe("ANF -> LLVM emitter (.trip)", () => {
+  it("emits LLVM for the straight-line U8 subset (params, lets, calls)", async () => {
+    const modules: Array<{ name: string; source: string }> = await Promise.all(
+      MODULE_NAMES.map(async (name) => ({
+        name,
+        source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+      })),
+    );
+    modules.push({
+      name: "Verify",
+      source: `module Verify
+import Prelude List
+import Prelude U8
+import AnfLlvm compileSourceToLlvmText
+
+export main
+
+poly main = compileSourceToLlvmText ${JSON.stringify(DEMO_SOURCE)}
+`,
+    });
+
+    const program = compileMiniCoreModules(modules, "Verify");
+    const result = evaluateMiniCore(program);
+    const actual = Buffer.from(valueToBytes(result.value)).toString("utf8");
+
+    assert.equal(actual, EXPECTED_LLVM);
+  });
+});

--- a/test/compiler/llvm/bundleV1.test.ts
+++ b/test/compiler/llvm/bundleV1.test.ts
@@ -1237,7 +1237,9 @@ poly main = #u8(0)
   });
 
   it("compiles and runs cross-module calls", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "typed-ski-cross-module-test-"));
+    const tempDir = await mkdtemp(
+      join(tmpdir(), "typed-ski-cross-module-test-"),
+    );
     try {
       const bundleBytes = serializeTripBundleV1({
         entryModule: "Main",
@@ -1280,7 +1282,9 @@ poly main = addOne #u8(5)
   });
 
   it("links duplicate local names in separate modules successfully", async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), "typed-ski-duplicate-names-test-"));
+    const tempDir = await mkdtemp(
+      join(tmpdir(), "typed-ski-duplicate-names-test-"),
+    );
     try {
       const bundleBytes = serializeTripBundleV1({
         entryModule: "Main",
@@ -1433,7 +1437,6 @@ poly main = a_val
     );
   });
 });
-
 
 async function compileBundleSummaryExecutable(
   tempDir: string,

--- a/test/compiler/llvm/bundleV1.test.ts
+++ b/test/compiler/llvm/bundleV1.test.ts
@@ -1235,7 +1235,205 @@ poly main = #u8(0)
       },
     );
   });
+
+  it("compiles and runs cross-module calls", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "typed-ski-cross-module-test-"));
+    try {
+      const bundleBytes = serializeTripBundleV1({
+        entryModule: "Main",
+        target: { kind: "x86_64-unknown-linux-gnu" },
+        emitMainWrapper: true,
+        modules: [
+          {
+            name: "Math",
+            source: `module Math
+import Prelude U8
+import Prelude addU8
+export addOne
+poly addOne = \\x : U8 => addU8 x #u8(1)
+`,
+          },
+          {
+            name: "Main",
+            source: `module Main
+import Prelude U8
+import Math addOne
+export main
+poly main = addOne #u8(5)
+`,
+          },
+          {
+            name: "Prelude",
+            source: realBootstrapModuleSource("Prelude"),
+          },
+        ],
+      });
+      const llvm = compileTripBundleV1ToLlvm(bundleBytes);
+      const llPath = join(tempDir, "cross-module.ll");
+      await writeFile(llPath, llvm, "utf8");
+      const exePath = await compileLlvmToExecutable(llPath);
+      const result = runExecutable(exePath);
+      assert.equal(result.status, 6);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("links duplicate local names in separate modules successfully", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "typed-ski-duplicate-names-test-"));
+    try {
+      const bundleBytes = serializeTripBundleV1({
+        entryModule: "Main",
+        target: { kind: "x86_64-unknown-linux-gnu" },
+        emitMainWrapper: true,
+        modules: [
+          {
+            name: "A",
+            source: `module A
+import Prelude U8
+export val
+poly val = #u8(10)
+`,
+          },
+          {
+            name: "B",
+            source: `module B
+import Prelude U8
+export val
+export getVal
+poly val = #u8(20)
+poly getVal = val
+`,
+          },
+          {
+            name: "Main",
+            source: `module Main
+import Prelude U8
+import Prelude addU8
+import A val
+import B getVal
+export main
+poly main = addU8 val getVal
+`,
+          },
+          {
+            name: "Prelude",
+            source: realBootstrapModuleSource("Prelude"),
+          },
+        ],
+      });
+      const llvm = compileTripBundleV1ToLlvm(bundleBytes);
+      const llPath = join(tempDir, "duplicate-names.ll");
+      await writeFile(llPath, llvm, "utf8");
+      const exePath = await compileLlvmToExecutable(llPath);
+      const result = runExecutable(exePath);
+      assert.equal(result.status, 30);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  it("rejects missing module import with a clear compile-time error", () => {
+    assert.throws(
+      () =>
+        compileTripBundleV1ToLlvm(
+          serializeTripBundleV1({
+            entryModule: "Main",
+            target: { kind: "x86_64-unknown-linux-gnu" },
+            modules: [
+              {
+                name: "Main",
+                source: `module Main
+import NonExistent foo
+export main
+poly main = foo
+`,
+              },
+            ],
+          }),
+        ),
+      {
+        name: "MiniCoreCompileError",
+        message: /Unknown module NonExistent/,
+      },
+    );
+  });
+
+  it("rejects unexported symbol import with a clear compile-time error", () => {
+    assert.throws(
+      () =>
+        compileTripBundleV1ToLlvm(
+          serializeTripBundleV1({
+            entryModule: "Main",
+            target: { kind: "x86_64-unknown-linux-gnu" },
+            modules: [
+              {
+                name: "Lib",
+                source: `module Lib
+poly foo = #u8(7)
+`,
+              },
+              {
+                name: "Main",
+                source: `module Main
+import Lib foo
+export main
+poly main = foo
+`,
+              },
+            ],
+          }),
+        ),
+      {
+        name: "MiniCoreCompileError",
+        message: /imports foo which is not exported by module Lib/,
+      },
+    );
+  });
+
+  it("rejects circular module dependencies with a clear cycle error", () => {
+    assert.throws(
+      () =>
+        compileTripBundleV1ToLlvm(
+          serializeTripBundleV1({
+            entryModule: "Main",
+            target: { kind: "x86_64-unknown-linux-gnu" },
+            modules: [
+              {
+                name: "A",
+                source: `module A
+import B b_val
+export a_val
+poly a_val = b_val
+`,
+              },
+              {
+                name: "B",
+                source: `module B
+import A a_val
+export b_val
+poly b_val = a_val
+`,
+              },
+              {
+                name: "Main",
+                source: `module Main
+import A a_val
+export main
+poly main = a_val
+`,
+              },
+            ],
+          }),
+        ),
+      {
+        name: "MiniCoreCompileError",
+        message: /Dependency cycle detected: A -> B -> A/,
+      },
+    );
+  });
 });
+
 
 async function compileBundleSummaryExecutable(
   tempDir: string,


### PR DESCRIPTION
## Summary

Two stacked pieces that advance the self-hosting bootstrap:

1. **Multi-bundle correctness (host front half).** `lib/minicore/fromTrip.ts` gains `sortModulesAndValidate` (wired into `compileMiniCoreModules`): DFS topological sort of the module graph, cycle detection, and import/export validation (imports must reference a known module and a name it actually exports). This is the canonical home for graph validation — the front half owns all cross-module semantics.

2. **Minimal Trip-side ANF→LLVM tail (`bootstrap/src/anfLlvm.trip`).** The first rung of "plan B": a real ANF→LLVM emitter layered on top of the MiniVerify front half, rather than growing the direct-AST stub in `llvm.trip`. The front half (elaborate→MiniCore→ANF) owns all semantics and emits a flat `AnfProgram`; this back half is a per-`AnfExpr`-constructor transliteration that owns zero semantics.

   `AnfLlvm.emitProgram : AnfProgram -> Result` plus the `compileSourceToLlvmText` driver handle the straight-line unboxed-`U8` subset:
   - `AE_Var` → environment lookup
   - `AE_Let` → SSA env binding
   - `AE_Call` → fresh `%__ll<n>` temp + `call i8 @<f>(...)`
   - function entry emits `define i8 @<name>(<params>) { ... }`

   `AE_Native` / `AE_Lam` / `AE_Con` / `AE_Case` deliberately error — those constructors (boxed runtime + basic blocks, then closures) are the next rungs.

`lib/compiler/bootstrapModules.ts` registers the new `AnfLlvm` module.

## Testing

- `test/compiler/anfLlvmEmit.test.ts` — runs `compileSourceToLlvmText` under the host MiniCore evaluator (no clang needed) on the `nestedCall` corpus shape and asserts exact emitted LLVM text.
- `test/compiler/llvm/bundleV1.test.ts` — behavioral coverage for cross-module calls, duplicate local names across modules, missing imports, and cycles.

The behavioral clang-and-run golden for the ANF tail is a deferred follow-up; this slice uses host-evaluator text assertion only.

## Notes

- This branch was built on top of #167; since #167 is still open, this PR carries that commit too. If #167 merges first, this will need a rebase onto main.
- Next rungs: `AE_Con`/`AE_Case`, then `AE_Lam`/closures, then re-point `index.trip`'s `compileBundleToLlvm` at the MiniVerify front half + `AnfLlvm`.

## Credits

- Max DeLiso (@maxdeliso) — author
- Multi-bundle correctness front half (#167)
- ANF→LLVM emitter, formatting, and version bump co-authored by Claude Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)