### PR TITLE
Add TripLang list and pair literal syntax

### DIFF
--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -76,7 +76,7 @@ data AnfFunc = MkAnfFunc (List U8) (List (List U8)) AnfExpr
 
 data AnfProgram = MkAnfProgram (List AnfFunc) (List U8)
 
-poly tempPrefix = cons [U8] '_' (cons [U8] '_' (cons [U8] 't' (nil [U8])))
+poly tempPrefix = {U8 | '_' '_' 't'}
 
 poly freshName = \counter : Bin => append [U8] tempPrefix (binToDigits counter)
 

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -37,7 +37,7 @@ data MiniExpr =
   | ME_Native Terminal
   | ME_Match MiniExpr (List MiniExpr)
 
-poly anonName = cons [U8] '_' (nil [U8])
+poly anonName = {U8 | '_'}
 
 poly rec collectSpine = \expr : Core => \acc : List Core =>
   match expr [Pair Core (List Core)] {
@@ -60,7 +60,7 @@ poly rec applyAnon = \head : MiniExpr => \args : List MiniExpr =>
     head
     (\h : MiniExpr => \t : List MiniExpr =>
       applyAnon
-        (ME_Call anonName (cons [MiniExpr] head (cons [MiniExpr] h (nil [MiniExpr]))))
+        (ME_Call anonName {MiniExpr | head h})
         t)
 
 poly rec coreToMini = \expr : Core =>

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -266,20 +266,8 @@ poly kwPoly : List U8 = "poly"
 poly isKeywordPoly = \word : List U8 => eqListU8 word kwPoly
 
 poly keywordWords =
-  cons [List U8] "poly"
-    (cons [List U8] "rec"
-      (cons [List U8] "let"
-        (cons [List U8] "in"
-          (cons [List U8] "match"
-            (cons [List U8] "module"
-              (cons [List U8] "import"
-                (cons [List U8] "export"
-                  (cons [List U8] "native"
-                    (cons [List U8] "opaque"
-                      (cons [List U8] "combinator"
-                        (cons [List U8] "type"
-                          (cons [List U8] "data"
-                            (nil [List U8])))))))))))))
+  {List U8 | "poly" "rec" "let" "in" "match" "module" "import" "export" "native" "opaque" "combinator" "type" "data"}
+
 
 poly rec anyEqWord = \word : List U8 => \words : List (List U8) =>
   matchList [List U8] [Bool] words false
@@ -500,19 +488,21 @@ poly mapResult = #A => #B => \f : A -> B => \res : Result ParseError A =>
   }
 
 poly simpleTokensU8 =
-  cons [Pair U8 Token] (MkPair [U8] [Token] '(' T_LParen)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] ')' T_RParen)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '{' T_LBrace)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '}' T_RBrace)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '[' T_LBracket)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] ']' T_RBracket)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '\\' T_Backslash)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] ':' T_Colon)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '#' T_Hash)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '|' T_Pipe)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] '.' T_Dot)
-  (cons [Pair U8 Token] (MkPair [U8] [Token] ',' T_Comma)
-  (nil [Pair U8 Token]))))))))))))
+  {Pair U8 Token |
+    (MkPair [U8] [Token] '(' T_LParen)
+    (MkPair [U8] [Token] ')' T_RParen)
+    (MkPair [U8] [Token] '{' T_LBrace)
+    (MkPair [U8] [Token] '}' T_RBrace)
+    (MkPair [U8] [Token] '[' T_LBracket)
+    (MkPair [U8] [Token] ']' T_RBracket)
+    (MkPair [U8] [Token] '\\' T_Backslash)
+    (MkPair [U8] [Token] ':' T_Colon)
+    (MkPair [U8] [Token] '#' T_Hash)
+    (MkPair [U8] [Token] '|' T_Pipe)
+    (MkPair [U8] [Token] '.' T_Dot)
+    (MkPair [U8] [Token] ',' T_Comma)
+  }
+
 
 poly rec lookupTokenU8 = \c : U8 => \list : List (Pair U8 Token) =>
   matchList [Pair U8 Token] [Maybe Token] list

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -491,10 +491,94 @@ poly isAtomStartTag = \tag : U8 =>
                 (\u : U8 =>
                   if [Bool] (eqU8 tag dotTag)
                     (\u : U8 => true)
-                    (\u : U8 => eqU8 tag hashTag)))))
+                    (\u : U8 =>
+                      if [Bool] (eqU8 tag hashTag)
+                        (\u : U8 => true)
+                        (\u : U8 => eqU8 tag lBraceTag))))))
 
 poly isAtomStart = \tok : Token =>
   isAtomStartTag (tokenTag tok)
+
+poly rec buildListExpr = \elements : List Expr =>
+  matchList [Expr] [Expr] elements
+    (E_Var "nil")
+    (\h : Expr => \t : List Expr =>
+      E_App (E_App (E_Var "cons") h) (buildListExpr t))
+
+poly rec parseListElements = \toks : List Token => \acc : List Expr =>
+  matchList [Token] [Result ParseError (Pair (List Expr) (List Token))] toks
+    (Err [ParseError] [Pair (List Expr) (List Token)] parseError)
+    (\h : Token => \t : List Token =>
+      let tag = tokenTag h in
+      if [Result ParseError (Pair (List Expr) (List Token))] (eqU8 tag rBraceTag)
+        (\u : U8 => Ok [ParseError] [Pair (List Expr) (List Token)] (MkPair [List Expr] [List Token] (reverse [Expr] acc) t))
+        (\u : U8 =>
+          match (parseAtomWith parseExpr toks) [Result ParseError (Pair (List Expr) (List Token))] {
+            | Err e => Err [ParseError] [Pair (List Expr) (List Token)] e
+            | Ok elemRes =>
+                let elem = fstExprToken elemRes in
+                let rest = sndExprToken elemRes in
+                parseListElements rest (cons [Expr] elem acc)
+          })
+    )
+
+poly parseBraceBody = \afterBrace : List Token =>
+  match (parseType afterBrace) [Result ParseError (Pair Expr (List Token))] {
+    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+    | Ok type1Res =>
+        let afterType1 = sndTypeToken type1Res in
+        matchList [Token] [Result ParseError (Pair Expr (List Token))] afterType1
+          (Err [ParseError] [Pair Expr (List Token)] parseError)
+          (\h : Token => \t : List Token =>
+            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag h) commaTag)
+              (\u : U8 =>
+                match (parseType t) [Result ParseError (Pair Expr (List Token))] {
+                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                  | Ok type2Res =>
+                      let afterType2 = sndTypeToken type2Res in
+                      match (expect afterType2 pipeTag) [Result ParseError (Pair Expr (List Token))] {
+                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        | Ok afterPipe =>
+                            match (parseAtomWith parseExpr afterPipe) [Result ParseError (Pair Expr (List Token))] {
+                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                              | Ok firstRes =>
+                                  let first = fstExprToken firstRes in
+                                  let afterFirst = sndExprToken firstRes in
+                                  match (expect afterFirst commaTag) [Result ParseError (Pair Expr (List Token))] {
+                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                    | Ok afterComma =>
+                                        match (parseAtomWith parseExpr afterComma) [Result ParseError (Pair Expr (List Token))] {
+                                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                          | Ok secondRes =>
+                                              let second = fstExprToken secondRes in
+                                              let afterSecond = sndExprToken secondRes in
+                                              match (expect afterSecond rBraceTag) [Result ParseError (Pair Expr (List Token))] {
+                                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                | Ok rest =>
+                                                    Ok [ParseError] [Pair Expr (List Token)]
+                                                      (MkPair [Expr] [List Token]
+                                                        (E_App (E_App (E_Var "MkPair") first) second)
+                                                        rest)
+                                              }
+                                        }
+                                  }
+                            }
+                      }
+                })
+              (\u : U8 =>
+                match (expect afterType1 pipeTag) [Result ParseError (Pair Expr (List Token))] {
+                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                  | Ok afterPipe =>
+                      match (parseListElements afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
+                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        | Ok listRes =>
+                            let elements = fst [List Expr] [List Token] listRes in
+                            let rest = snd [List Expr] [List Token] listRes in
+                            Ok [ParseError] [Pair Expr (List Token)]
+                              (MkPair [Expr] [List Token] (buildListExpr elements) rest)
+                      }
+                }))
+  }
 
 poly parseAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
   matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
@@ -571,7 +655,9 @@ poly parseAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (Lis
                                   }
                               })
                             (\u : U8 =>
-                              Err [ParseError] [Pair Expr (List Token)] parseError))
+                              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
+                                (\u : U8 => parseBraceBody t)
+                                (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)))
                     )
                 )
             )
@@ -596,11 +682,32 @@ poly parseSimpleTypeWith = \recurse : (List Token -> Result ParseError (Pair Typ
             | Err e => Err [ParseError] [Pair Type (List Token)] e
             | Ok res =>
               let inner = fstTypeToken res in
-              let rest = sndTypeToken res in
-              match (expect rest rParenTag) [Result ParseError (Pair Type (List Token))] {
-                | Err e => Err [ParseError] [Pair Type (List Token)] e
-                | Ok final => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] inner final)
-              }
+              let afterInner = sndTypeToken res in
+              matchList [Token] [Result ParseError (Pair Type (List Token))] afterInner
+                (Err [ParseError] [Pair Type (List Token)] parseError)
+                (\h2 : Token => \t2 : List Token =>
+                  if [Result ParseError (Pair Type (List Token))]
+                    (eqU8 (tokenTag h2) commaTag)
+                    (\u : U8 =>
+                      match (recurse t2) [Result ParseError (Pair Type (List Token))] {
+                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                        | Ok res2 =>
+                          let second = fstTypeToken res2 in
+                          let afterSecond = sndTypeToken res2 in
+                          match (expect afterSecond rParenTag) [Result ParseError (Pair Type (List Token))] {
+                            | Err e => Err [ParseError] [Pair Type (List Token)] e
+                            | Ok final =>
+                              Ok [ParseError] [Pair Type (List Token)]
+                                (MkPair [Type] [List Token]
+                                  (Ty_App (Ty_App (Ty_Var "Pair") inner) second)
+                                  final)
+                          }
+                      })
+                    (\u : U8 =>
+                      match (expect afterInner rParenTag) [Result ParseError (Pair Type (List Token))] {
+                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                        | Ok final => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] inner final)
+                      }))
           })
         (\u : U8 =>
           if [Result ParseError (Pair Type (List Token))]
@@ -728,6 +835,50 @@ poly rec parseAppLoopWith = \recurse : (List Token -> Result ParseError (Pair Ex
         )
     )
 
+poly rec parseAppLoopNoBraceWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \lhs : Expr => \toks : List Token =>
+  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
+    (Ok [ParseError] [Pair Expr (List Token)]
+      (MkPair [Expr] [List Token] lhs toks))
+    (\h : Token => \t : List Token =>
+      let tag = tokenTag h in
+      if [Result ParseError (Pair Expr (List Token))]
+        (eqU8 tag lBraceTag)
+        (\u : U8 => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] lhs toks))
+        (\u : U8 =>
+          if [Result ParseError (Pair Expr (List Token))]
+            (eqU8 tag lBracketTag)
+            (\u : U8 =>
+              match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
+                | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                | Ok afterType => parseAppLoopNoBraceWith recurse lhs afterType
+              })
+            (\u : U8 =>
+              if [Result ParseError (Pair Expr (List Token))]
+                (isAtomStartTag tag)
+                (\u : U8 =>
+                  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                    | Ok rhsRes =>
+                      let rhs = fstExprToken rhsRes in
+                      let rest = sndExprToken rhsRes in
+                      parseAppLoopNoBraceWith recurse (E_App lhs rhs) rest
+                  })
+                (\u : U8 =>
+                  Ok [ParseError] [Pair Expr (List Token)]
+                    (MkPair [Expr] [List Token] lhs toks))
+            )
+        )
+    )
+
+poly parseAppNoBraceWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
+  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+    | Ok headRes =>
+      let head = fstExprToken headRes in
+      let rest = sndExprToken headRes in
+      parseAppLoopNoBraceWith recurse head rest
+  }
+
 poly parseAppWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
   match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
     | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -845,7 +996,7 @@ poly rec parseExpr = \toks : List Token =>
               if [Result ParseError (Pair Expr (List Token))]
                 (eqU8 tag kwMatchTag)
                 (\u : U8 =>
-                  match (parseAppWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
+                  match (parseAppNoBraceWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
                     | Err e => Err [ParseError] [Pair Expr (List Token)] e
                     | Ok scrutRes =>
                       let scrutinee = fstExprToken scrutRes in

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -136,11 +136,17 @@ export parsePatternArgs
 export parseMatchArm
 export parseMatchArms
 export isAtomStart
+export parseLiteralAtomWith
+export buildListExpr
+export parseListElements
+export parseBraceBodyWith
 export skipTypeArg
 export parseCtorArity
 export parseAtomWith
 export parseAppLoopWith
 export parseAppWith
+export parseAppLoopNoBraceWith
+export parseAppNoBraceWith
 export parseMatchArmWith
 export parseMatchArmsWith
 export parseAtom
@@ -505,7 +511,88 @@ poly rec buildListExpr = \elements : List Expr =>
     (\h : Expr => \t : List Expr =>
       E_App (E_App (E_Var "cons") h) (buildListExpr t))
 
-poly rec parseListElements = \toks : List Token => \acc : List Expr =>
+poly parseLiteralAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
+  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
+    (Err [ParseError] [Pair Expr (List Token)] parseError)
+    (\h : Token => \t : List Token =>
+      let tag = tokenTag h in
+      if [Result ParseError (Pair Expr (List Token))]
+        (eqU8 tag identTag)
+        (\u : U8 =>
+          Ok [ParseError] [Pair Expr (List Token)]
+            (MkPair [Expr] [List Token] (E_Var (tokenText h)) t))
+        (\u : U8 =>
+          if [Result ParseError (Pair Expr (List Token))]
+            (eqU8 tag natTag)
+            (\u : U8 =>
+              Ok [ParseError] [Pair Expr (List Token)]
+                (MkPair [Expr] [List Token] (E_Nat (tokenNatValue h)) t))
+            (\u : U8 =>
+              if [Result ParseError (Pair Expr (List Token))]
+                (eqU8 tag lParenTag)
+                (\u : U8 =>
+                  match (recurse t) [Result ParseError (Pair Expr (List Token))] {
+                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                    | Ok res =>
+                      let inner = fstExprToken res in
+                      let rest = sndExprToken res in
+                      match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        | Ok final =>
+                          Ok [ParseError] [Pair Expr (List Token)]
+                            (MkPair [Expr] [List Token] inner final)
+                      }
+                  })
+                (\u : U8 =>
+                  if [Result ParseError (Pair Expr (List Token))]
+                    (eqU8 tag commaTag)
+                    (\u : U8 =>
+                      Ok [ParseError] [Pair Expr (List Token)]
+                        (MkPair [Expr] [List Token] (E_Var ",") t))
+                    (\u : U8 =>
+                      if [Result ParseError (Pair Expr (List Token))]
+                        (eqU8 tag dotTag)
+                        (\u : U8 =>
+                          Ok [ParseError] [Pair Expr (List Token)]
+                            (MkPair [Expr] [List Token] (E_Var ".") t))
+                        (\u : U8 =>
+                          if [Result ParseError (Pair Expr (List Token))]
+                            (eqU8 tag hashTag)
+                            (\u : U8 =>
+                              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
+                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                | Ok tvRes =>
+                                  match tvRes [Result ParseError (Pair Expr (List Token))] {
+                                    | MkPair tyVar afterTyVar =>
+                                      if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
+                                        (\u : U8 =>
+                                          match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                            | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                            | Ok afterOpen =>
+                                              matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen
+                                                (Err [ParseError] [Pair Expr (List Token)] parseError)
+                                                (\natTok : Token => \afterNat : List Token =>
+                                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
+                                                    (\u : U8 =>
+                                                      match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                        | Ok rest =>
+                                                          Ok [ParseError] [Pair Expr (List Token)]
+                                                            (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)
+                                                      })
+                                                    (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
+                                          })
+                                        (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)
+                                  }
+                              })
+                            (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
+                    )
+                )
+            )
+        )
+    )
+
+poly rec parseListElements = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token => \acc : List Expr =>
   matchList [Token] [Result ParseError (Pair (List Expr) (List Token))] toks
     (Err [ParseError] [Pair (List Expr) (List Token)] parseError)
     (\h : Token => \t : List Token =>
@@ -513,16 +600,16 @@ poly rec parseListElements = \toks : List Token => \acc : List Expr =>
       if [Result ParseError (Pair (List Expr) (List Token))] (eqU8 tag rBraceTag)
         (\u : U8 => Ok [ParseError] [Pair (List Expr) (List Token)] (MkPair [List Expr] [List Token] (reverse [Expr] acc) t))
         (\u : U8 =>
-          match (parseAtomWith parseExpr toks) [Result ParseError (Pair (List Expr) (List Token))] {
+          match (parseLiteralAtomWith recurse toks) [Result ParseError (Pair (List Expr) (List Token))] {
             | Err e => Err [ParseError] [Pair (List Expr) (List Token)] e
             | Ok elemRes =>
                 let elem = fstExprToken elemRes in
                 let rest = sndExprToken elemRes in
-                parseListElements rest (cons [Expr] elem acc)
+                parseListElements recurse rest (cons [Expr] elem acc)
           })
     )
 
-poly parseBraceBody = \afterBrace : List Token =>
+poly parseBraceBodyWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \afterBrace : List Token =>
   match (parseType afterBrace) [Result ParseError (Pair Expr (List Token))] {
     | Err e => Err [ParseError] [Pair Expr (List Token)] e
     | Ok type1Res =>
@@ -539,7 +626,7 @@ poly parseBraceBody = \afterBrace : List Token =>
                       match (expect afterType2 pipeTag) [Result ParseError (Pair Expr (List Token))] {
                         | Err e => Err [ParseError] [Pair Expr (List Token)] e
                         | Ok afterPipe =>
-                            match (parseAtomWith parseExpr afterPipe) [Result ParseError (Pair Expr (List Token))] {
+                            match (parseLiteralAtomWith recurse afterPipe) [Result ParseError (Pair Expr (List Token))] {
                               | Err e => Err [ParseError] [Pair Expr (List Token)] e
                               | Ok firstRes =>
                                   let first = fstExprToken firstRes in
@@ -547,7 +634,7 @@ poly parseBraceBody = \afterBrace : List Token =>
                                   match (expect afterFirst commaTag) [Result ParseError (Pair Expr (List Token))] {
                                     | Err e => Err [ParseError] [Pair Expr (List Token)] e
                                     | Ok afterComma =>
-                                        match (parseAtomWith parseExpr afterComma) [Result ParseError (Pair Expr (List Token))] {
+                                        match (parseLiteralAtomWith recurse afterComma) [Result ParseError (Pair Expr (List Token))] {
                                           | Err e => Err [ParseError] [Pair Expr (List Token)] e
                                           | Ok secondRes =>
                                               let second = fstExprToken secondRes in
@@ -569,7 +656,7 @@ poly parseBraceBody = \afterBrace : List Token =>
                 match (expect afterType1 pipeTag) [Result ParseError (Pair Expr (List Token))] {
                   | Err e => Err [ParseError] [Pair Expr (List Token)] e
                   | Ok afterPipe =>
-                      match (parseListElements afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
+                      match (parseListElements recurse afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
                         | Err e => Err [ParseError] [Pair Expr (List Token)] e
                         | Ok listRes =>
                             let elements = fst [List Expr] [List Token] listRes in
@@ -656,7 +743,7 @@ poly parseAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (Lis
                               })
                             (\u : U8 =>
                               if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
-                                (\u : U8 => parseBraceBody t)
+                                (\u : U8 => parseBraceBodyWith recurse t)
                                 (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)))
                     )
                 )

--- a/lib/linker/moduleLinker.ts
+++ b/lib/linker/moduleLinker.ts
@@ -491,6 +491,7 @@ function substituteDependencies(
   localName: string,
   ps: ProgramSpace,
   exportIndex: Map<string, Set<string>>,
+  scc?: Set<string>,
 ): TripLangTerm {
   const defValue = extractDefinitionValue(def);
   if (!defValue) return def;
@@ -535,10 +536,16 @@ function substituteDependencies(
         continue;
       }
 
-      const targetQualified = termEnv.get(termRef);
-      if (targetQualified) {
+      const targetQualified =
+        termEnv.get(termRef) ?? qualifiedName(moduleName, termRef);
+      if (scc?.has(targetQualified)) {
+        continue;
+      }
+
+      const importQualified = termEnv.get(termRef);
+      if (importQualified) {
         // It's an import (in termEnv)
-        const targetTerm = ps.terms.get(targetQualified);
+        const targetTerm = ps.terms.get(importQualified);
         if (targetTerm) {
           replacements.set(termRef, targetTerm);
         } else {
@@ -702,11 +709,20 @@ function substituteDependencies(
     let changed = false; // Track if any substitution actually occurred
 
     for (const typeRef of currentExternalTypeRefs) {
-      const targetQualified = typeEnv.get(typeRef);
+      const importQualified = typeEnv.get(typeRef);
+      const localQualified = qualifiedName(moduleName, typeRef);
+      if (
+        (importQualified && scc?.has(importQualified)) ||
+        (!importQualified &&
+          ps.types.has(localQualified) &&
+          scc?.has(localQualified))
+      ) {
+        continue;
+      }
 
       // Case 1: Resolution via Environment (Imports)
-      if (targetQualified) {
-        const targetType = ps.types.get(targetQualified);
+      if (importQualified) {
+        const targetType = ps.types.get(importQualified);
         if (targetType) {
           if (isRecursiveTypeDefinition(targetType)) {
             continue;
@@ -888,6 +904,7 @@ function resolveSCC(
         snapshot.localName,
         ps,
         exportIndex,
+        new Set(scc),
       );
 
       // Use cached hash if available, otherwise compute and cache

--- a/lib/minicore/fromTrip.ts
+++ b/lib/minicore/fromTrip.ts
@@ -243,6 +243,10 @@ function applyTermArgs(head: SystemFTerm, args: SystemFTerm[]): SystemFTerm {
   );
 }
 
+function isCallableBaseType(type: BaseType | undefined): boolean {
+  return type?.kind === "non-terminal";
+}
+
 class MiniCoreBuilder {
   private readonly modules: Map<string, SourceModule>;
   private readonly exportModulesByName = new Map<string, Set<string>>();
@@ -908,17 +912,29 @@ class MiniCoreBuilder {
               ) {
                 const calledCallable = this.analyzeCallableParams(calledQName);
                 const calledParams = this.functionParams(calledQName);
+                const calledParamTypes = (() => {
+                  try {
+                    return collectTopLevelParams(
+                      this.functionSource(calledQName).definition.term,
+                    ).paramTypes;
+                  } catch {
+                    return [];
+                  }
+                })();
                 for (
                   let i = 0;
                   i < Math.min(args.length, calledParams.length);
                   i++
                 ) {
-                  if (calledCallable.has(calledParams[i]!)) {
-                    const arg = stripTypeApps(args[i]!).term;
+                  const arg = stripTypeApps(args[i]!).term;
+                  if (
+                    arg.kind === "systemF-var" &&
+                    params.includes(arg.name) &&
+                    !shadowed.has(arg.name)
+                  ) {
                     if (
-                      arg.kind === "systemF-var" &&
-                      params.includes(arg.name) &&
-                      !shadowed.has(arg.name)
+                      calledCallable.has(calledParams[i]!) ||
+                      isCallableBaseType(calledParamTypes[i])
                     ) {
                       callable.add(arg.name);
                     }

--- a/lib/parser/systemFTerm.ts
+++ b/lib/parser/systemFTerm.ts
@@ -83,7 +83,7 @@ function isTerminator(state: ParserState): boolean {
     ch === RIGHT_BRACE ||
     ch === "]" ||
     ch === "|" ||
-    ch === LEFT_BRACE
+    ch === ","
   ) {
     return true;
   }
@@ -123,8 +123,8 @@ function parseMatchExpression(
 
     const [ch] = peek(currentState);
 
-    // SPECIAL CASE: Stop at '[' because it denotes the return type annotation
-    if (ch === "[") break;
+    // SPECIAL CASE: Stop at '[' or '{' because it denotes either the return type or the match block
+    if (ch === "[" || ch === "{") break;
 
     // Parse next term application
     const [atomLit, atomTerm, nextState] = parseAtomicSystemFTerm(currentState);
@@ -393,6 +393,21 @@ const buildU8List = (codes: number[]): SystemFTerm => {
   return term;
 };
 
+const buildListLiteral = (
+  elementType: BaseType,
+  elements: SystemFTerm[],
+): SystemFTerm => {
+  let term: SystemFTerm = mkSystemFTypeApp(mkSystemFVar("nil"), elementType);
+  for (let i = elements.length - 1; i >= 0; i--) {
+    const consTerm = mkSystemFTypeApp(mkSystemFVar("cons"), elementType);
+    term = createSystemFApplication(
+      createSystemFApplication(consTerm, elements[i]!),
+      term,
+    );
+  }
+  return term;
+};
+
 const parseCharLiteralTerm = (
   state: ParserState,
 ): [string, SystemFTerm, ParserState] => {
@@ -561,6 +576,95 @@ function parseAtomicSystemFTerm(
       parseSystemFTerm(stateAfterLP);
     const stateAfterRP = matchRP(stateAfterTerm);
     return [`(${innerLit})`, innerTerm, stateAfterRP];
+  }
+  // 3.5 List or Pair Literal: { Type | ... } OR { Type1, Type2 | ... }
+  else if (ch === "{") {
+    let currentState = matchCh(state, LEFT_BRACE);
+    currentState = skipWhitespace(currentState);
+
+    // Parse the first type
+    const [type1Lit, type1, stateAfterType1] = parseSystemFType(currentState);
+    currentState = skipWhitespace(stateAfterType1);
+
+    const [nextCh] = peek(currentState);
+    if (nextCh === ",") {
+      // It is a Pair Literal!
+      currentState = matchCh(currentState, ",");
+      currentState = skipWhitespace(currentState);
+
+      // Parse the second type
+      const [type2Lit, type2, stateAfterType2] = parseSystemFType(currentState);
+      currentState = skipWhitespace(stateAfterType2);
+
+      // Expect '|'
+      currentState = matchCh(currentState, "|");
+      currentState = skipWhitespace(currentState);
+
+      // Parse the first term (can be a full term since comma-separated)
+      const [term1Lit, term1, stateAfterTerm1] = parseSystemFTerm(currentState);
+      currentState = skipWhitespace(stateAfterTerm1);
+
+      // Expect ','
+      currentState = matchCh(currentState, ",");
+      currentState = skipWhitespace(currentState);
+
+      // Parse the second term
+      const [term2Lit, term2, stateAfterTerm2] = parseSystemFTerm(currentState);
+      currentState = skipWhitespace(stateAfterTerm2);
+
+      // Expect '}'
+      const [closing, sAfterInner] = peek(currentState);
+      if (closing !== "}") {
+        throw new ParseError(
+          withParserState(sAfterInner, "expected '}' to close pair literal"),
+        );
+      }
+      currentState = matchCh(currentState, "}");
+
+      // Construct the desugared MkPair application:
+      // MkPair [Type1] [Type2] term1 term2
+      const mkPairVar = mkSystemFVar("MkPair");
+      const typeApp1 = mkSystemFTypeApp(mkPairVar, type1);
+      const typeApp2 = mkSystemFTypeApp(typeApp1, type2);
+      const app1 = createSystemFApplication(typeApp2, term1);
+      const finalTerm = createSystemFApplication(app1, term2);
+
+      const literalStr = `{${type1Lit}, ${type2Lit} | ${term1Lit}, ${term2Lit}}`;
+      return [literalStr, finalTerm, currentState];
+    } else {
+      // It is a List Literal!
+      // Expect '|'
+      currentState = matchCh(currentState, "|");
+      currentState = skipWhitespace(currentState);
+
+      // Parse elements until '}'
+      const elementTerms: SystemFTerm[] = [];
+      const elementLits: string[] = [];
+
+      while (true) {
+        currentState = skipWhitespace(currentState);
+        const [nextCh] = peek(currentState);
+        if (nextCh === "}") {
+          currentState = matchCh(currentState, "}");
+          break;
+        }
+        if (nextCh === null) {
+          throw new ParseError(
+            withParserState(currentState, "unterminated list literal"),
+          );
+        }
+
+        const [atomLit, atomTerm, nextState] =
+          parseAtomicSystemFTerm(currentState);
+        elementLits.push(atomLit);
+        elementTerms.push(atomTerm);
+        currentState = nextState;
+      }
+
+      const finalTerm = buildListLiteral(type1, elementTerms);
+      const literalStr = `{${type1Lit} | ${elementLits.join(" ")}}`;
+      return [literalStr, finalTerm, currentState];
+    }
   } // 4. Literals
   else if (ch === "'") {
     return parseCharLiteralTerm(currentState);

--- a/lib/parser/systemFType.ts
+++ b/lib/parser/systemFType.ts
@@ -23,6 +23,7 @@ import {
   type ParserState,
   peek,
   peekArrow,
+  skipWhitespace,
   withParserState,
 } from "./parserState.ts";
 import {
@@ -122,14 +123,40 @@ function parseSimpleSystemFType(
     const stateAfterLP = matchLP(s);
     const [innerLit, innerType, stateAfterInner] =
       parseSystemFType(stateAfterLP);
-    const [closing, sAfterInner] = peek(stateAfterInner);
-    if (closing !== ")") {
-      throw new ParseError(
-        withParserState(sAfterInner, "expected ')' after type expression"),
+    let currentState = skipWhitespace(stateAfterInner);
+    const [nextCh] = peek(currentState);
+    if (nextCh === ",") {
+      currentState = matchCh(currentState, ",");
+      currentState = skipWhitespace(currentState);
+      const [secondLit, secondType, stateAfterSecond] =
+        parseSystemFType(currentState);
+      currentState = skipWhitespace(stateAfterSecond);
+      const [closing, sAfterInner] = peek(currentState);
+      if (closing !== ")") {
+        throw new ParseError(
+          withParserState(
+            sAfterInner,
+            "expected ')' after pair type expression",
+          ),
+        );
+      }
+      const stateAfterRP = matchRP(sAfterInner);
+      const literal = `(${innerLit}, ${secondLit})`;
+      const pairType = typeApp(
+        typeApp(mkTypeVariable("Pair"), innerType),
+        secondType,
       );
+      return [literal, pairType, stateAfterRP];
+    } else {
+      const [closing, sAfterInner] = peek(currentState);
+      if (closing !== ")") {
+        throw new ParseError(
+          withParserState(sAfterInner, "expected ')' after type expression"),
+        );
+      }
+      const stateAfterRP = matchRP(sAfterInner);
+      return [`(${innerLit})`, innerType, stateAfterRP];
     }
-    const stateAfterRP = matchRP(sAfterInner);
-    return [`(${innerLit})`, innerType, stateAfterRP];
   } else {
     // Must be a type variable (a single letter).
     const [varLit, stateAfterVar] = parseIdentifier(s);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/bootstrapParseLiterals.test.ts
+++ b/test/compiler/bootstrapParseLiterals.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Exercises the bootstrap (.trip) parser's `{}` list / pair-term literals and
+ * `()` tuple-type sugar through the host MiniCore evaluator (no clang).
+ *
+ * A small `Verify` module tokenizes source snippets, runs the real bootstrap
+ * `parseExpr` / `parseType`, and renders the resulting (type-erased) AST to a
+ * parenthesized s-expression. The sugar must desugar to exactly the same AST
+ * as the hand-written `cons`/`MkPair`/`Pair` forms.
+ */
+
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { compilerTripModuleSourcePath } from "../../lib/compiler/bootstrapModules.ts";
+import { compileMiniCoreModules } from "../../lib/minicore/fromTrip.ts";
+import { evaluateMiniCore } from "../../lib/minicore/evaluator.ts";
+import type { Value } from "../../lib/minicore/ast.ts";
+
+const MODULE_NAMES = ["Prelude", "Lexer", "Parser"] as const;
+
+const VERIFY_SOURCE = `module Verify
+
+import Prelude List
+import Prelude U8
+import Prelude append
+import Prelude fst
+import Prelude Ok
+import Prelude Err
+import Prelude nil
+import Prelude cons
+import Prelude matchList
+import Lexer tokenize
+import Lexer Token
+import Parser parseExpr
+import Parser parseType
+import Parser Expr
+import Parser E_Var
+import Parser E_App
+import Parser E_Lam
+import Parser E_Let
+import Parser E_Nat
+import Parser E_Match
+import Parser Type
+import Parser Ty_Var
+import Parser Ty_App
+import Parser Ty_Arrow
+import Parser Ty_Forall
+import Parser fstExprToken
+
+export main
+
+poly nl = cons [U8] #u8(10) (nil [U8])
+
+poly rec exprToSexp = \\e : Expr =>
+  match e [List U8] {
+    | E_Var n => n
+    | E_App f x =>
+        append [U8] "("
+          (append [U8] (exprToSexp f)
+            (append [U8] " "
+              (append [U8] (exprToSexp x) ")")))
+    | E_Lam n b => "<lam>"
+    | E_Let n v b => "<let>"
+    | E_Nat d => "<nat>"
+    | E_Match s arms => "<match>"
+  }
+
+poly rec typeToSexp = \\t : Type =>
+  match t [List U8] {
+    | Ty_Var n => n
+    | Ty_App f x =>
+        append [U8] "("
+          (append [U8] (typeToSexp f)
+            (append [U8] " "
+              (append [U8] (typeToSexp x) ")")))
+    | Ty_Arrow a b =>
+        append [U8] "(-> "
+          (append [U8] (typeToSexp a)
+            (append [U8] " "
+              (append [U8] (typeToSexp b) ")")))
+    | Ty_Forall n b => "<forall>"
+  }
+
+poly renderExprSrc = \\src : List U8 =>
+  match (tokenize src) [List U8] {
+    | Err e => "LEXERR"
+    | Ok toks =>
+        match (parseExpr toks) [List U8] {
+          | Err e => "PARSEERR"
+          | Ok res => exprToSexp (fstExprToken res)
+        }
+  }
+
+poly renderTypeSrc = \\src : List U8 =>
+  match (tokenize src) [List U8] {
+    | Err e => "LEXERR"
+    | Ok toks =>
+        match (parseType toks) [List U8] {
+          | Err e => "PARSEERR"
+          | Ok res => typeToSexp (fst [Type] [List Token] res)
+        }
+  }
+
+poly rec joinLines = \\xs : List (List U8) =>
+  matchList [List U8] [List U8] xs
+    (nil [U8])
+    (\\h : List U8 => \\t : List (List U8) =>
+      append [U8] h (append [U8] nl (joinLines t)))
+
+poly main =
+  joinLines
+    (cons [List U8] (renderExprSrc "{U8 | a b}")
+    (cons [List U8] (renderExprSrc "cons a (cons b nil)")
+    (cons [List U8] (renderExprSrc "{U8, U8 | a, b}")
+    (cons [List U8] (renderExprSrc "MkPair a b")
+    (cons [List U8] (renderExprSrc "{U8 | }")
+    (cons [List U8] (renderExprSrc "{U8 | (f x) y}")
+    (cons [List U8] (renderTypeSrc "(U8, U8)")
+    (cons [List U8] (renderTypeSrc "Pair U8 U8")
+    (cons [List U8] (renderTypeSrc "(U8)")
+    (cons [List U8] (renderTypeSrc "(U8 -> U8)")
+    (nil [List U8])))))))))))
+`;
+
+/** Decodes a Scott/ADT-encoded `List U8` MiniCore value to a byte array. */
+function valueToBytes(value: Value): number[] {
+  const bytes: number[] = [];
+  let cur: Value = value;
+  while (cur.kind === "con" && cur.fields.length === 2) {
+    const head = cur.fields[0];
+    const tail = cur.fields[1];
+    if (head === undefined || tail === undefined || head.kind !== "lit") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    const literal = head.value;
+    if (literal.kind !== "u8") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    bytes.push(literal.value);
+    cur = tail;
+  }
+  if (cur.kind !== "con" || cur.fields.length !== 0) {
+    throw new Error(`expected nil terminator, got ${JSON.stringify(cur)}`);
+  }
+  return bytes;
+}
+
+describe("bootstrap parser list/tuple literals", () => {
+  it("desugars {} list / pair literals and () tuple types via the .trip parser", async () => {
+    const modules: Array<{ name: string; source: string }> = await Promise.all(
+      MODULE_NAMES.map(async (name) => ({
+        name,
+        source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+      })),
+    );
+    modules.push({ name: "Verify", source: VERIFY_SOURCE });
+
+    const program = compileMiniCoreModules(modules, "Verify");
+    const result = evaluateMiniCore(program);
+    const text = Buffer.from(valueToBytes(result.value)).toString("utf8");
+    const lines = text.split("\n").filter((line) => line.length > 0);
+
+    const [
+      listLiteral,
+      listDesugared,
+      pairLiteral,
+      pairDesugared,
+      emptyList,
+      nestedList,
+      tupleType,
+      pairType,
+      parenType,
+      arrowType,
+    ] = lines;
+
+    // List literal `{T | e1 e2}` == `cons e1 (cons e2 nil)`.
+    assert.equal(listLiteral, "((cons a) ((cons b) nil))");
+    assert.equal(listLiteral, listDesugared);
+
+    // Pair-term literal `{T1, T2 | a, b}` == `MkPair a b`.
+    assert.equal(pairLiteral, "((MkPair a) b)");
+    assert.equal(pairLiteral, pairDesugared);
+
+    // Empty list desugars to bare `nil`.
+    assert.equal(emptyList, "nil");
+
+    // List elements are atoms; parentheses group sub-applications.
+    assert.equal(nestedList, "((cons (f x)) ((cons y) nil))");
+
+    // Tuple type `(T1, T2)` == `Pair T1 T2`.
+    assert.equal(tupleType, "((Pair U8) U8)");
+    assert.equal(tupleType, pairType);
+
+    // A single parenthesized type is unwrapped; arrows inside parens survive.
+    assert.equal(parenType, "U8");
+    assert.equal(arrowType, "(-> U8 U8)");
+  });
+});

--- a/test/compiler/inputs/testParseApp.trip
+++ b/test/compiler/inputs/testParseApp.trip
@@ -41,10 +41,7 @@ poly isVarNamed = \expr : Expr => \name : List Bin =>
 
 poly main =
   let input =
-    cons [Token] (T_Ident "f")
-      (cons [Token] (T_Ident "x")
-        (cons [Token] (T_Ident "y")
-          (cons [Token] T_EOF (nil [Token]))))
+    {Token | (T_Ident "f") (T_Ident "x") (T_Ident "y") T_EOF}
   in
   match (parseApp input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseAtom.trip
+++ b/test/compiler/inputs/testParseAtom.trip
@@ -31,8 +31,7 @@ export main
 
 poly main =
   let input =
-    cons [Token] (T_Ident "x")
-      (cons [Token] T_EOF (nil [Token]))
+    {Token | (T_Ident "x") T_EOF}
   in
   match (parseAtom input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseDefinitionKinds.trip
+++ b/test/compiler/inputs/testParseDefinitionKinds.trip
@@ -54,20 +54,13 @@ poly eqDefKind = \a : DefKind => \b : DefKind =>
   }
 
 poly main =
-  let t0 = nil [Token] in
-  let t1 = cons [Token] T_EOF t0 in
-  let t2 = cons [Token] T_Dot t1 in
-  let t3 = cons [Token] T_Comma t2 in
-  let t4 = cons [Token] T_Eq t3 in
-  let t5 = cons [Token] (T_Ident "c") t4 in
-  let t6 = cons [Token] T_KwCombinator t5 in
-  let t7 = cons [Token] (T_Ident "p") t6 in
-  let t8 = cons [Token] T_Eq t7 in
-  let t9 = cons [Token] (T_Ident "p") t8 in
-  let t10 = cons [Token] T_KwRec t9 in
-  let t11 = cons [Token] T_KwPoly t10 in
-  let t12 = cons [Token] (T_Ident "M") t11 in
-  let input = cons [Token] T_KwModule t12 in
+  let input =
+    {Token |
+      T_KwModule (T_Ident "M")
+      T_KwPoly T_KwRec (T_Ident "p") T_Eq (T_Ident "p")
+      T_KwCombinator (T_Ident "c") T_Eq T_Comma T_Dot
+      T_EOF}
+  in
   match (parseProgram input) [Bool] {
     | Err e => false
     | Ok decls =>

--- a/test/compiler/inputs/testParseExprCombinatorTokens.trip
+++ b/test/compiler/inputs/testParseExprCombinatorTokens.trip
@@ -41,9 +41,7 @@ poly isVarNamed = \expr : Expr => \name : List Bin =>
 
 poly main =
   let input =
-    cons [Token] T_Comma
-      (cons [Token] T_Dot
-        (cons [Token] T_EOF (nil [Token])))
+    {Token | T_Comma T_Dot T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseExprLambdaTyped.trip
+++ b/test/compiler/inputs/testParseExprLambdaTyped.trip
@@ -35,13 +35,7 @@ export main
 
 poly main =
   let input =
-    cons [Token] T_Backslash
-      (cons [Token] (T_Ident "x")
-        (cons [Token] T_Colon
-          (cons [Token] (T_Ident "Bin")
-            (cons [Token] T_FatArrow
-              (cons [Token] (T_Ident "x")
-                (cons [Token] T_EOF (nil [Token])))))))
+    {Token | T_Backslash (T_Ident "x") T_Colon (T_Ident "Bin") T_FatArrow (T_Ident "x") T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseExprLetTyped.trip
+++ b/test/compiler/inputs/testParseExprLetTyped.trip
@@ -47,15 +47,7 @@ poly isVarNamed = \expr : Expr => \name : List U8 =>
 
 poly main =
   let input =
-    cons [Token] T_KwLet
-      (cons [Token] (T_Ident "x")
-        (cons [Token] T_Colon
-          (cons [Token] (T_Ident "Bin")
-            (cons [Token] T_Eq
-              (cons [Token] (T_Nat "1")
-                (cons [Token] T_KwIn
-                  (cons [Token] (T_Ident "x")
-                    (cons [Token] T_EOF (nil [Token])))))))))
+    {Token | T_KwLet (T_Ident "x") T_Colon (T_Ident "Bin") T_Eq (T_Nat "1") T_KwIn (T_Ident "x") T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseExprMatchTyped.trip
+++ b/test/compiler/inputs/testParseExprMatchTyped.trip
@@ -65,25 +65,11 @@ poly isNoArgs = \args : List (List Bin) =>
 
 poly main =
   let input =
-    let t0 = nil [Token] in
-    let t1 = cons [Token] T_EOF t0 in
-    let t2 = cons [Token] T_RBrace t1 in
-    let t3 = cons [Token] (T_Ident "res") t2 in
-    let t4 = cons [Token] T_FatArrow t3 in
-    let t5 = cons [Token] (T_Ident "None") t4 in
-    let t6 = cons [Token] T_Pipe t5 in
-    let t7 = cons [Token] (T_Ident "x") t6 in
-    let t8 = cons [Token] T_FatArrow t7 in
-    let t9 = cons [Token] (T_Ident "x") t8 in
-    let t10 = cons [Token] (T_Ident "Some") t9 in
-    let t11 = cons [Token] T_Pipe t10 in
-    let t12 = cons [Token] T_LBrace t11 in
-    let t13 = cons [Token] T_RBracket t12 in
-    let t14 = cons [Token] (T_Ident "Token") t13 in
-    let t15 = cons [Token] (T_Ident "List") t14 in
-    let t16 = cons [Token] T_LBracket t15 in
-    let t17 = cons [Token] (T_Ident "res") t16 in
-    cons [Token] T_KwMatch t17
+    {Token |
+      T_KwMatch (T_Ident "res") T_LBracket (T_Ident "List") (T_Ident "Token") T_RBracket T_LBrace
+      T_Pipe (T_Ident "Some") (T_Ident "x") T_FatArrow (T_Ident "x")
+      T_Pipe (T_Ident "None") T_FatArrow (T_Ident "res")
+      T_RBrace T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseExprTypeAbstraction.trip
+++ b/test/compiler/inputs/testParseExprTypeAbstraction.trip
@@ -31,11 +31,7 @@ export main
 
 poly main =
   let input =
-    cons [Token] T_Hash
-      (cons [Token] (T_Ident "X")
-        (cons [Token] T_FatArrow
-          (cons [Token] (T_Ident "x")
-            (cons [Token] T_EOF (nil [Token])))))
+    {Token | T_Hash (T_Ident "X") T_FatArrow (T_Ident "x") T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseExprTypeApplication.trip
+++ b/test/compiler/inputs/testParseExprTypeApplication.trip
@@ -42,13 +42,7 @@ poly isVarNamed = \expr : Expr => \name : List Bin =>
 
 poly main =
   let input =
-    cons [Token] (T_Ident "n")
-      (cons [Token] T_LBracket
-        (cons [Token] (T_Ident "X")
-          (cons [Token] T_RBracket
-            (cons [Token] (T_Ident "s")
-              (cons [Token] (T_Ident "z")
-                (cons [Token] T_EOF (nil [Token])))))))
+    {Token | (T_Ident "n") T_LBracket (T_Ident "X") T_RBracket (T_Ident "s") (T_Ident "z") T_EOF}
   in
   match (parseExpr input) [Bool] {
     | Err e => false

--- a/test/compiler/inputs/testParseProgramForms.trip
+++ b/test/compiler/inputs/testParseProgramForms.trip
@@ -40,39 +40,17 @@ import Parser D_Def
 export main
 
 poly main =
-  let t0 = nil [Token] in
-  let t1 = cons [Token] T_EOF t0 in
-  let t2 = cons [Token] (T_Ident "id") t1 in
-  let t3 = cons [Token] T_Eq t2 in
-  let t4 = cons [Token] (T_Ident "main") t3 in
-  let t5 = cons [Token] T_KwRec t4 in
-  let t6 = cons [Token] T_KwPoly t5 in
-  let t7 = cons [Token] T_Dot t6 in
-  let t8 = cons [Token] T_Comma t7 in
-  let t9 = cons [Token] T_Eq t8 in
-  let t10 = cons [Token] (T_Ident "io") t9 in
-  let t11 = cons [Token] T_KwCombinator t10 in
-  let t12 = cons [Token] (T_Ident "A") t11 in
-  let t13 = cons [Token] (T_Ident "Some") t12 in
-  let t14 = cons [Token] (T_Ident "None") t13 in
-  let t15 = cons [Token] T_Eq t14 in
-  let t16 = cons [Token] (T_Ident "A") t15 in
-  let t17 = cons [Token] (T_Ident "Maybe") t16 in
-  let t18 = cons [Token] T_KwData t17 in
-  let t19 = cons [Token] (T_Ident "X") t18 in
-  let t20 = cons [Token] T_Arrow t19 in
-  let t21 = cons [Token] (T_Ident "X") t20 in
-  let t22 = cons [Token] T_Hash t21 in
-  let t23 = cons [Token] T_Eq t22 in
-  let t24 = cons [Token] (T_Ident "Nat") t23 in
-  let t25 = cons [Token] T_KwType t24 in
-  let t26 = cons [Token] (T_Ident "main") t25 in
-  let t27 = cons [Token] T_KwExport t26 in
-  let t28 = cons [Token] (T_Ident "id") t27 in
-  let t29 = cons [Token] (T_Ident "Prelude") t28 in
-  let t30 = cons [Token] T_KwImport t29 in
-  let t31 = cons [Token] (T_Ident "M") t30 in
-  let input = cons [Token] T_KwModule t31 in
+  let input =
+    {Token |
+      T_KwModule (T_Ident "M")
+      T_KwImport (T_Ident "Prelude") (T_Ident "id")
+      T_KwExport (T_Ident "main")
+      T_KwType (T_Ident "Nat") T_Eq T_Hash (T_Ident "X") T_Arrow (T_Ident "X")
+      T_KwData (T_Ident "Maybe") (T_Ident "A") T_Eq (T_Ident "None") (T_Ident "Some") (T_Ident "A")
+      T_KwCombinator (T_Ident "io") T_Eq T_Comma T_Dot
+      T_KwPoly T_KwRec (T_Ident "main") T_Eq (T_Ident "id")
+      T_EOF}
+  in
   match (parseProgram input) [Bool] {
     | Err e => false
     | Ok decls =>

--- a/test/compiler/inputs/testParseType.trip
+++ b/test/compiler/inputs/testParseType.trip
@@ -38,16 +38,7 @@ poly isVarNamed = \ty : Type => \name : List U8 =>
 
 poly main =
   let input =
-    cons [Token] T_Hash
-      (cons [Token] (T_Ident "A")
-        (cons [Token] T_Arrow
-          (cons [Token] (T_Ident "A")
-            (cons [Token] T_Arrow
-              (cons [Token] T_LParen
-                (cons [Token] (T_Ident "B")
-                  (cons [Token] (T_Ident "C")
-                    (cons [Token] T_RParen
-                      (cons [Token] T_EOF (nil [Token]))))))))))
+    {Token | T_Hash (T_Ident "A") T_Arrow (T_Ident "A") T_Arrow T_LParen (T_Ident "B") (T_Ident "C") T_RParen T_EOF}
   in
   match (parseType input) [Bool] {
     | Err e => false

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -354,7 +354,7 @@ import Lexer T_KwData
 import Lexer T_Ident
 import Lexer T_Nat
 import Lexer T_EOF
-exports 97
+exports 103
 export Pattern
 export P_Ctor
 export Expr
@@ -429,11 +429,17 @@ export parsePatternArgs
 export parseMatchArm
 export parseMatchArms
 export isAtomStart
+export parseLiteralAtomWith
+export buildListExpr
+export parseListElements
+export parseBraceBodyWith
 export skipTypeArg
 export parseCtorArity
 export parseAtomWith
 export parseAppLoopWith
 export parseAppWith
+export parseAppLoopNoBraceWith
+export parseAppNoBraceWith
 export parseMatchArmWith
 export parseMatchArmsWith
 export parseAtom
@@ -482,7 +488,7 @@ ctor D_Def 4
 type 0
 opaque 0
 native 0
-poly 94
+poly 95
 poly parseError
 poly checkedIncrementU8
 poly identTag
@@ -543,8 +549,9 @@ poly parseMatchArmsWith
 poly isAtomStartTag
 poly isAtomStart
 poly buildListExpr
+poly parseLiteralAtomWith
 poly parseListElements
-poly parseBraceBody
+poly parseBraceBodyWith
 poly parseAtomWith
 poly skipTypeArg
 poly parseSimpleTypeWith

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -482,7 +482,7 @@ ctor D_Def 4
 type 0
 opaque 0
 native 0
-poly 89
+poly 94
 poly parseError
 poly checkedIncrementU8
 poly identTag
@@ -542,6 +542,9 @@ poly parseMatchArmWith
 poly parseMatchArmsWith
 poly isAtomStartTag
 poly isAtomStart
+poly buildListExpr
+poly parseListElements
+poly parseBraceBody
 poly parseAtomWith
 poly skipTypeArg
 poly parseSimpleTypeWith
@@ -552,6 +555,8 @@ poly parseType
 poly parseSimpleType
 poly parseTypeApplication
 poly parseAppLoopWith
+poly parseAppLoopNoBraceWith
+poly parseAppNoBraceWith
 poly parseAppWith
 poly parseAtom
 poly parseApp

--- a/test/linker/inputs/preludeDataPrelude.trip
+++ b/test/linker/inputs/preludeDataPrelude.trip
@@ -20,7 +20,7 @@ poly two : Bin = B0 (B1 BZ)
 
 poly errVal = Err [Bin] [Bin] zeroBin
 poly okVal = Ok [Bin] [Bin] two
-poly pair : Pair Bin Bin = MkPair [Bin] [Bin] one two
+poly pair : (Bin, Bin) = {Bin, Bin | one, two}
 
 type Church = #X -> (X -> X) -> X -> X
 

--- a/test/linker/inputs/preludeListCombinators.trip
+++ b/test/linker/inputs/preludeListCombinators.trip
@@ -34,8 +34,8 @@ poly one : Bin = B1 BZ
 poly two : Bin = B0 (B1 BZ)
 poly three : Bin = B1 (B1 BZ)
 
-poly list1 = cons [Bin] one (cons [Bin] two (nil [Bin]))
-poly list2 = cons [Bin] three (nil [Bin])
+poly list1 = {Bin | one two}
+poly list2 = {Bin | three}
 poly mapped = map [Bin] [Bin] incBin list1
 poly combined = append [Bin] mapped list2
 poly main = binToChurch (foldl [Bin] [Bin] addBin zeroBin combined)

--- a/test/linker/inputs/preludeListHeadTail.trip
+++ b/test/linker/inputs/preludeListHeadTail.trip
@@ -29,6 +29,6 @@ poly rec binToChurch = \b : Bin =>
 poly one : Bin = B1 BZ
 poly two : Bin = B0 (B1 BZ)
 
-poly list = cons [Bin] one (cons [Bin] two (nil [Bin]))
+poly list = {Bin | one two}
 
 poly main = binToChurch (head [Bin] (tail [Bin] list))

--- a/test/linker/inputs/preludeListPrefix.trip
+++ b/test/linker/inputs/preludeListPrefix.trip
@@ -39,7 +39,7 @@ poly isLeadingZero = \n : Bin => isZeroBin n
 poly zeroBin : Bin = BZ
 poly one : Bin = B1 BZ
 
-poly sample = cons [Bin] zeroBin (cons [Bin] zeroBin (cons [Bin] one (nil [Bin])))
+poly sample = {Bin | zeroBin zeroBin one}
 poly taken = takeWhile [Bin] isLeadingZero sample
 poly dropped = dropWhile [Bin] isLeadingZero sample
 poly count = foldl [Bin] [Bin] (\acc : Bin => \_ : Bin => incBin acc) zeroBin taken

--- a/test/linker/inputs/preludeMatchList.trip
+++ b/test/linker/inputs/preludeMatchList.trip
@@ -27,8 +27,8 @@ poly rec binToChurch = \b : Bin =>
 poly zeroBin : Bin = BZ
 poly fortyTwo : Bin = B0 (B1 (B0 (B1 (B0 (B1 BZ)))))
 
-poly emptyResult = matchList [Bin] [Bin] (nil [Bin]) zeroBin (\h : Bin => \t : List => h)
-poly consResult = matchList [Bin] [Bin] (cons [Bin] fortyTwo (nil [Bin])) zeroBin
+poly emptyResult = matchList [Bin] [Bin] {Bin |} zeroBin (\h : Bin => \t : List => h)
+poly consResult = matchList [Bin] [Bin] {Bin | fortyTwo} zeroBin
   (\h : Bin => \t : List => h)
 
 poly main = binToChurch consResult

--- a/test/linker/inputs/testLists.trip
+++ b/test/linker/inputs/testLists.trip
@@ -15,6 +15,6 @@ poly one = succ zero
 poly two = succ one
 poly three = succ two
 
-poly list = cons [Nat] one (cons [Nat] two (cons [Nat] three (nil [Nat])))
+poly list = {Nat | one two three}
 
 poly main = foldl [Nat] [Nat] add zero list

--- a/test/parser/systemF.test.ts
+++ b/test/parser/systemF.test.ts
@@ -30,8 +30,13 @@ function parseU8CodeFromVar(name: string): number | null {
   if (Number.isNaN(code) || code < 0 || code > 255) return null;
   return code;
 }
-function extractListU8Bytes(term: SystemFTerm): number[] | null {
-  const result: number[] = [];
+// Walks a desugared list literal (cons [T] e … (nil [T])) and returns the
+// element terms, or null if the shape/element type doesn't match.
+function extractListElements(
+  term: SystemFTerm,
+  expectedTypeName: string,
+): SystemFTerm[] | null {
+  const result: SystemFTerm[] = [];
   let current: SystemFTerm = term;
   for (;;) {
     if (current.kind === "systemF-type-app") {
@@ -40,7 +45,7 @@ function extractListU8Bytes(term: SystemFTerm): number[] | null {
       }
       if (
         current.typeArg.kind !== "type-var" ||
-        current.typeArg.typeName !== "U8"
+        current.typeArg.typeName !== expectedTypeName
       )
         return null;
       return result;
@@ -59,15 +64,25 @@ function extractListU8Bytes(term: SystemFTerm): number[] | null {
       return null;
     if (
       consTypeApp.typeArg.kind !== "type-var" ||
-      consTypeApp.typeArg.typeName !== "U8"
+      consTypeApp.typeArg.typeName !== expectedTypeName
     )
       return null;
-    if (head.kind !== "systemF-var") return null;
-    const code = parseU8CodeFromVar(head.name);
-    if (code === null) return null;
-    result.push(code);
+    result.push(head);
     current = tail;
   }
+}
+
+function extractListU8Bytes(term: SystemFTerm): number[] | null {
+  const elements = extractListElements(term, "U8");
+  if (elements === null) return null;
+  const bytes: number[] = [];
+  for (const el of elements) {
+    if (el.kind !== "systemF-var") return null;
+    const code = parseU8CodeFromVar(el.name);
+    if (code === null) return null;
+    bytes.push(code);
+  }
+  return bytes;
 }
 const assertListU8 = (term: SystemFTerm, expected: number[]) => {
   const actual = extractListU8Bytes(term);
@@ -667,6 +682,42 @@ describe("System F Parser", () => {
       );
     });
   });
+
+  describe("list literals", () => {
+    it("parses an empty list literal", () => {
+      const [lit, ast] = parseSystemF("{U8 |}");
+      assert.equal(lit, "{U8 | }");
+      assertListU8(ast, []);
+    });
+
+    it("parses a simple U8 list literal", () => {
+      const [lit, ast] = parseSystemF("{U8 | 97 98}");
+      assert.equal(lit, "{U8 | 97 98}");
+      assertListU8(ast, [97, 98]);
+    });
+
+    it("parses nested applications inside a list literal via parentheses", () => {
+      const [lit, ast] = parseSystemF("{Nat | 1 (f x) 3}");
+      assert.equal(lit, "{Nat | 1 (f x) 3}");
+      // Desugars to cons [Nat] 1 (cons [Nat] (f x) (cons [Nat] 3 (nil [Nat]))).
+      const elements = extractListElements(ast, "Nat");
+      assert.ok(elements !== null, "expected a List Nat cons/nil chain");
+      assert.equal(elements.length, 3);
+
+      // First and last elements are U8-range numeric literals.
+      assertU8Literal(requiredAt(elements, 0, "first element"), 1);
+      assertU8Literal(requiredAt(elements, 2, "third element"), 3);
+
+      // The middle element keeps its parenthesized application (f x).
+      const mid = requiredAt(elements, 1, "second element");
+      assert.equal(mid.kind, "non-terminal");
+      if (mid.kind !== "non-terminal") throw new Error("expected (f x) app");
+      assert.equal(mid.lft.kind, "systemF-var");
+      assert.equal(mid.rgt.kind, "systemF-var");
+      if (mid.lft.kind === "systemF-var") assert.equal(mid.lft.name, "f");
+      if (mid.rgt.kind === "systemF-var") assert.equal(mid.rgt.name, "x");
+    });
+  });
 });
 
 /**
@@ -1111,5 +1162,70 @@ describe("System F type parser", () => {
       listNat,
     );
     assert.equal(unparseSystemFType(pair), "Pair A (List Nat)");
+  });
+
+  it("parses pair types", () => {
+    const [lit, ty] = parseWithEOF("(U8, List U8)", parseSystemFType);
+    const expected = typeApp(
+      typeApp(mkTypeVariable("Pair"), mkTypeVariable("U8")),
+      typeApp(mkTypeVariable("List"), mkTypeVariable("U8")),
+    );
+    assert.equal(lit, "(U8, List U8)");
+    assert.equal(typesLitEq(ty, expected), true);
+  });
+});
+
+describe("System F term parser tuple tests", () => {
+  it("parses and desugars tuple/pair terms", () => {
+    const [lit, term] = parseSystemF(`{U8, List U8 | 'a', "hello"}`);
+    // The literal is reconstructed as `{type1, type2 | term1, term2}`.
+    assert.equal(lit, `{U8, List U8 | 'a', "hello"}`);
+
+    // Desugars to MkPair [U8] [List U8] 'a' "hello", i.e.
+    // App(App(TypeApp(TypeApp(MkPair, U8), List U8), 'a'), "hello").
+    assert.equal(term.kind, "non-terminal");
+    if (term.kind !== "non-terminal") throw new Error("expected application");
+
+    const inner = term.lft;
+    assert.equal(inner.kind, "non-terminal");
+    if (inner.kind !== "non-terminal") throw new Error("expected application");
+
+    // inner.lft should be MkPair [U8] [List U8].
+    const mkPairWithTypes = inner.lft;
+    assert.equal(mkPairWithTypes.kind, "systemF-type-app");
+    if (mkPairWithTypes.kind !== "systemF-type-app") {
+      throw new Error("expected type application");
+    }
+    // Outer type argument is `List U8`.
+    assert.equal(mkPairWithTypes.typeArg.kind, "type-app");
+    if (mkPairWithTypes.typeArg.kind === "type-app") {
+      assert.equal(mkPairWithTypes.typeArg.fn.kind, "type-var");
+      if (mkPairWithTypes.typeArg.fn.kind === "type-var") {
+        assert.equal(mkPairWithTypes.typeArg.fn.typeName, "List");
+      }
+      assert.equal(mkPairWithTypes.typeArg.arg.kind, "type-var");
+      if (mkPairWithTypes.typeArg.arg.kind === "type-var") {
+        assert.equal(mkPairWithTypes.typeArg.arg.typeName, "U8");
+      }
+    }
+
+    // Inner type application is `MkPair [U8]`.
+    assert.equal(mkPairWithTypes.term.kind, "systemF-type-app");
+    if (mkPairWithTypes.term.kind !== "systemF-type-app") {
+      throw new Error("expected nested type application");
+    }
+    assert.equal(mkPairWithTypes.term.typeArg.kind, "type-var");
+    if (mkPairWithTypes.term.typeArg.kind === "type-var") {
+      assert.equal(mkPairWithTypes.term.typeArg.typeName, "U8");
+    }
+    assert.equal(mkPairWithTypes.term.term.kind, "systemF-var");
+    if (mkPairWithTypes.term.term.kind === "systemF-var") {
+      assert.equal(mkPairWithTypes.term.term.name, "MkPair");
+    }
+
+    // First component is the U8 literal 'a' (97).
+    assertU8Literal(inner.rgt, 97);
+    // Second component is the string "hello" desugared to a List U8.
+    assertListU8(term.rgt, [104, 101, 108, 108, 111]);
   });
 });

--- a/test/parser/tripLang.test.ts
+++ b/test/parser/tripLang.test.ts
@@ -630,3 +630,50 @@ describe("parse single poly", () => {
     assert.strictEqual(unparseSystemFType(nilApp.typeArg), "U8");
   });
 });
+
+describe("parse list literal", () => {
+  it("parses list literal in a poly definition", () => {
+    const input = "poly foo = {U8 | 102 111 111}";
+    const result = parseTripLang(input);
+
+    assert.strictEqual(result.kind, "program");
+    assert.strictEqual(result.terms.length, 1);
+    const term = requiredAt(result.terms, 0, "expected poly term");
+
+    if (term.kind !== "poly") {
+      throw new Error(`expected 'poly' term, got '${term.kind}'`);
+    }
+    assert.strictEqual(term.name, "foo");
+    assert.strictEqual(term.type, undefined);
+
+    const expectedCodes = [102, 111, 111];
+    const decodeU8Term = (t: SystemFTerm): number => {
+      if (t.kind !== "systemF-var") {
+        throw new Error(`expected systemF-var for u8 literal, got ${t.kind}`);
+      }
+      const u8Match = /^__trip_u8_(\d+)$/.exec(t.name);
+      if (!u8Match) {
+        throw new Error(`expected __trip_u8_ literal, got ${t.name}`);
+      }
+      return parseInt(u8Match[1]!, 10);
+    };
+    let current: SystemFTerm = term.term;
+    for (const code of expectedCodes) {
+      const outerApp = expectSystemFApp(current);
+      const consApp = expectSystemFApp(outerApp.lft);
+      const consTypeApp = expectSystemFTypeApp(consApp.lft);
+      const consVar = expectSystemFVar(consTypeApp.term);
+      assert.strictEqual(consVar.name, "cons");
+      assert.strictEqual(unparseSystemFType(consTypeApp.typeArg), "U8");
+
+      const decoded = decodeU8Term(consApp.rgt);
+      assert.strictEqual(decoded, code);
+      current = outerApp.rgt;
+    }
+
+    const nilApp = expectSystemFTypeApp(current);
+    const nilVar = expectSystemFVar(nilApp.term);
+    assert.strictEqual(nilVar.name, "nil");
+    assert.strictEqual(unparseSystemFType(nilApp.typeArg), "U8");
+  });
+});


### PR DESCRIPTION
## Summary

Adds TripLang syntactic sugar for list literals, pair literals, and pair types, then migrates noisy fixture code to the new syntax.

This also updates the self-hosted bootstrap parser so the new syntax works through the `.trip` parser path, fixes linker and MiniCore edge cases surfaced by that path, and bumps the package minor version to `0.22.0`.

## Syntax Added

### List literals

```trip
poly list1 = {Bin | one two}
poly list2 = {Bin | three}
````

Equivalent to:

```trip
poly list1 = cons [Bin] one (cons [Bin] two (nil [Bin]))
poly list2 = cons [Bin] three (nil [Bin])
```

### Empty lists

```trip
{Bin |}
```

Equivalent to:

```trip
nil [Bin]
```

### Pair types and pair literals

```trip
poly pair : (Bin, Bin) = {Bin, Bin | one, two}
```

Equivalent to:

```trip
poly pair : Pair Bin Bin = MkPair [Bin] [Bin] one two
```

## Fixture Cleanup

Replaces verbose token-list fixture construction like:

```trip
let input =
  cons [Token] (T_Ident "f")
    (cons [Token] (T_Ident "x")
      (cons [Token] (T_Ident "y")
        (cons [Token] T_EOF (nil [Token]))))
```

with:

```trip
let input =
  {Token | (T_Ident "f") (T_Ident "x") (T_Ident "y") T_EOF}
```

Also replaces longer staged parser fixture lists like:

```trip
let t0 = nil [Token] in
let t1 = cons [Token] T_EOF t0 in
let t2 = cons [Token] (T_Ident "id") t1 in
...
let input = cons [Token] T_KwModule t31 in
```

with compact literals:

```trip
let input =
  {Token |
    T_KwModule (T_Ident "M")
    T_KwImport (T_Ident "Prelude") (T_Ident "id")
    T_KwExport (T_Ident "main")
    T_KwType (T_Ident "Nat") T_Eq T_Hash (T_Ident "X") T_Arrow (T_Ident "X")
    T_EOF}
in
```

Bootstrap source cleanup follows the same pattern, for example:

```trip
poly tempPrefix = {U8 | '_' '_' 't'}
```

instead of:

```trip
poly tempPrefix = cons [U8] '_' (cons [U8] '_' (cons [U8] 't' (nil [U8])))
```

## Implementation Notes

* Adds host parser support for:

  * List terms: `{T | a b c}`
  * Empty lists: `{T |}`
  * Pair terms: `{A, B | a, b}`
  * Pair types: `(A, B)`
* Adds matching bootstrap `.trip` parser support.
* Keeps list literal elements atom-oriented, with parentheses available for grouped applications:

  ```trip
  {Nat | 1 (f x) 3}
  ```
* Exports new bootstrap parser helpers needed by self-hosted linking.
* Fixes MiniCore callable parameter analysis for parser helper callbacks.
* Avoids linker substitution inside the active SCC to preserve local recursive helper references.
