### PR TITLE
feat(improvize): add TripLang source tools

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -37,9 +37,8 @@ build --guard_against_concurrent_changes
 # Explicitly share repository downloads (npm packages, LLVM tarballs, etc.)
 common --repository_cache=~/bazel_repo_cache
 
-# Dynamic Resource Limits: Limit each Bazel instance to 50% of host CPU/RAM to prevent
-# system lockups, thrashing, and OOM crashes during concurrent agent builds.
-build --local_resources=cpu=HOST_CPUS*0.5
-build --local_resources=memory=HOST_RAM*0.5
+# Dynamic Resource Limits: Tweak limits to avoid premature CPU throttling
+build --local_resources=cpu=HOST_CPUS*1.0
+build --local_resources=memory=HOST_RAM*0.9
 
 

--- a/bin/improvize.ts
+++ b/bin/improvize.ts
@@ -1,0 +1,345 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning
+
+/**
+ * TripLang formatter and linter CLI.
+ */
+
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  discoverTripFiles,
+  formatTripSource,
+  lintTripSource,
+  type TripLintDiagnostic,
+  getTrainedLMSync,
+} from "../lib/improvize/index.ts";
+import { VERSION } from "../lib/shared/version.ts";
+
+type Command = "format" | "lint";
+
+interface ParsedArgs {
+  command?: Command;
+  help: boolean;
+  version: boolean;
+  check: boolean;
+  write: boolean;
+  fix: boolean;
+  verbose: boolean;
+  paths: string[];
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const parsed: ParsedArgs = {
+    help: false,
+    version: false,
+    check: false,
+    write: false,
+    fix: false,
+    verbose: false,
+    paths: [],
+  };
+
+  for (const arg of args) {
+    if (arg === "--help" || arg === "-h") {
+      parsed.help = true;
+      continue;
+    }
+    if (arg === "--version") {
+      parsed.version = true;
+      continue;
+    }
+    if (arg === "--verbose" || arg === "-v") {
+      parsed.verbose = true;
+      continue;
+    }
+    if (arg === "--check") {
+      parsed.check = true;
+      continue;
+    }
+    if (arg === "--write") {
+      parsed.write = true;
+      continue;
+    }
+    if (arg === "--fix") {
+      parsed.fix = true;
+      continue;
+    }
+    if (arg === "format" || arg === "lint") {
+      if (parsed.command !== undefined) {
+        throw new Error(`unexpected extra command: ${arg}`);
+      }
+      parsed.command = arg;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`unknown option: ${arg}`);
+    }
+    parsed.paths.push(arg);
+  }
+
+  if (parsed.check && parsed.write) {
+    throw new Error("--check cannot be combined with --write");
+  }
+  if (parsed.command === "format" && parsed.fix) {
+    throw new Error("--fix is only valid with lint");
+  }
+  if (parsed.command === "lint" && (parsed.check || parsed.write)) {
+    throw new Error("--check and --write are only valid with format");
+  }
+
+  return parsed;
+}
+
+function showHelp(): void {
+  console.log(`
+TripLang formatter and linter (improvize) v${VERSION}
+
+USAGE:
+    improvize format [--check|--write] <files-or-dirs...>
+    improvize lint [--fix] <files-or-dirs...>
+
+OPTIONS:
+    -h, --help       Show this help message
+    --version        Show version information
+    -v, --verbose    Print timing diagnostics
+    --check          Check formatting without writing files
+    --write          Rewrite files with formatted output
+    --fix            Apply safe lint rewrites, then format
+`);
+}
+
+function showVersion(): void {
+  console.log(`improvize v${VERSION}`);
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+async function collectFiles(paths: string[]): Promise<string[]> {
+  if (paths.length === 0) return [];
+  for (const path of paths) {
+    try {
+      await stat(resolve(path));
+    } catch {
+      throw new Error(`path not found: ${path}`);
+    }
+  }
+  return await discoverTripFiles(paths);
+}
+
+async function runFormat(
+  paths: string[],
+  check: boolean,
+  write: boolean,
+  verbose: boolean,
+) {
+  if (paths.length === 0) {
+    if (check || write) {
+      throw new Error("format --check/--write requires at least one path");
+    }
+    const input = await readStdin();
+    process.stdout.write(formatTripSource(input).formatted);
+    return 0;
+  }
+
+  const files = await collectFiles(paths);
+  if (files.length === 0) {
+    return 0;
+  }
+  if (!check && !write && files.length > 1) {
+    throw new Error("formatting multiple files requires --check or --write");
+  }
+
+  let changed = false;
+  const results = await Promise.all(
+    files.map(async (file) => {
+      const startFile = Date.now();
+      const input = await readFile(file, "utf8");
+      const timeRead = Date.now() - startFile;
+
+      const startFormat = Date.now();
+      const result = formatTripSource(input);
+      const timeFormat = Date.now() - startFormat;
+
+      if (verbose) {
+        console.log(
+          `[format] ${file}: read in ${timeRead}ms, formatted in ${timeFormat}ms`,
+        );
+      }
+
+      return { file, result };
+    }),
+  );
+
+  for (const { file, result } of results) {
+    if (!result.changed) {
+      if (!write && !check) {
+        process.stdout.write(result.formatted);
+      }
+      continue;
+    }
+    changed = true;
+    if (write) {
+      await writeFile(file, result.formatted, "utf8");
+      console.log(`${file}: formatted`);
+    } else if (check) {
+      console.log(`${file}: needs formatting`);
+    } else {
+      process.stdout.write(result.formatted);
+    }
+  }
+
+  return changed && check ? 1 : 0;
+}
+
+function formatDiagnostic(file: string, diag: TripLintDiagnostic): string {
+  return `${file}:${diag.line}:${diag.column}: ${diag.code}: ${diag.message}`;
+}
+
+async function runLint(paths: string[], fix: boolean, verbose: boolean) {
+  const startLM = Date.now();
+  const lm = getTrainedLMSync();
+  if (verbose) {
+    console.log(
+      `[init] Trained Kneser-Ney Language Model in ${Date.now() - startLM}ms`,
+    );
+  }
+
+  if (paths.length === 0) {
+    const input = await readStdin();
+    const result = lintTripSource(input, { fix, lm, verbose });
+    for (const diag of result.diagnostics) {
+      console.log(formatDiagnostic("<stdin>", diag));
+    }
+    if (fix) {
+      process.stdout.write(result.fixed);
+      const afterFix = lintTripSource(result.fixed, {
+        fix: false,
+        lm,
+        verbose,
+      });
+      return afterFix.diagnostics.length > 0 ? 1 : 0;
+    }
+    return result.diagnostics.length > 0 ? 1 : 0;
+  }
+
+  const files = await collectFiles(paths);
+  let hadDiagnostics = false;
+  let hadRemainingDiagnostics = false;
+
+  const results = await Promise.all(
+    files.map(async (file) => {
+      const startFile = Date.now();
+      const input = await readFile(file, "utf8");
+      const timeRead = Date.now() - startFile;
+
+      const startLint = Date.now();
+      const result = lintTripSource(input, { fix, lm, verbose });
+      const timeLint = Date.now() - startLint;
+
+      if (verbose) {
+        console.log(
+          `[lint] ${file}: read in ${timeRead}ms, linted in ${timeLint}ms`,
+        );
+      }
+
+      let afterFixResult = undefined;
+      let timeVerify = 0;
+      if (fix) {
+        const startSecond = Date.now();
+        afterFixResult = lintTripSource(result.changed ? result.fixed : input, {
+          fix: false,
+          lm,
+          verbose,
+        });
+        timeVerify = Date.now() - startSecond;
+      }
+
+      return { file, input, result, afterFixResult, timeVerify };
+    }),
+  );
+
+  for (const { file, input, result, afterFixResult, timeVerify } of results) {
+    if (result.diagnostics.length > 0) {
+      hadDiagnostics = true;
+    }
+    for (const diag of result.diagnostics) {
+      console.log(formatDiagnostic(file, diag));
+    }
+    if (fix && result.changed) {
+      await writeFile(file, result.fixed, "utf8");
+      console.log(`${file}: fixed`);
+    }
+    if (fix && afterFixResult) {
+      if (verbose) {
+        console.log(`[lint-verify] ${file}: verified in ${timeVerify}ms`);
+      }
+      if (afterFixResult.diagnostics.length > 0) {
+        hadRemainingDiagnostics = true;
+      }
+    }
+  }
+
+  if (fix) {
+    return hadRemainingDiagnostics ? 1 : 0;
+  }
+  return hadDiagnostics ? 1 : 0;
+}
+
+async function main(): Promise<void> {
+  let parsed: ParsedArgs;
+  try {
+    parsed = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+
+  if (parsed.version) {
+    showVersion();
+    return;
+  }
+  if (parsed.help || !parsed.command) {
+    showHelp();
+    return;
+  }
+
+  try {
+    const status =
+      parsed.command === "format"
+        ? await runFormat(
+            parsed.paths,
+            parsed.check,
+            parsed.write,
+            parsed.verbose,
+          )
+        : await runLint(parsed.paths, parsed.fix, parsed.verbose);
+    process.exit(status);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+}
+
+function isMain(importMetaUrl: string): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(process.argv[1]) ===
+      realpathSync(fileURLToPath(importMetaUrl))
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (isMain(import.meta.url)) {
+  await main();
+}

--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -1,56 +1,105 @@
 module Anf
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude U8
+
 import Prelude append
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin incBin
+
 import Bin binToDigits
+
 import CoreToMini MiniExpr
+
 import CoreToMini ME_Var
+
 import CoreToMini ME_Lam
+
 import CoreToMini ME_Call
+
 import CoreToMini ME_Con
+
 import CoreToMini ME_Let
+
 import CoreToMini ME_Native
+
 import CoreToMini ME_Match
+
 import MiniCore MiniFunc
+
 import MiniCore MkMiniFunc
+
 import MiniCore MiniProgram
+
 import MiniCore MkMiniProgram
+
 import Unparse Terminal
 
 export AnfExpr
+
 export AE_Var
+
 export AE_Native
+
 export AE_Lam
+
 export AE_Call
+
 export AE_Con
+
 export AE_Case
+
 export AE_Let
+
 export Pos
+
 export PAtom
+
 export PVal
+
 export PTail
+
 export Binding
+
 export MkBinding
+
 export NormResult
+
 export MkNormResult
+
 export normalize
+
 export AnfFunc
+
 export MkAnfFunc
+
 export AnfProgram
+
 export MkAnfProgram
+
 export normalizeProgram
 
 data AnfExpr =
@@ -62,118 +111,201 @@ data AnfExpr =
   | AE_Case AnfExpr (List AnfExpr)
   | AE_Let (List U8) AnfExpr AnfExpr
 
-data Pos = PAtom | PVal | PTail
+data Pos =
+  | PAtom
+  | PVal
+  | PTail
 
-data Binding = MkBinding (List U8) AnfExpr
+data Binding =
+  | MkBinding (List U8) AnfExpr
 
-data NormResult = MkNormResult Bin (List Binding) AnfExpr
+data NormResult =
+  | MkNormResult Bin (List Binding) AnfExpr
 
-data AtomList = MkAtomList Bin (List Binding) (List AnfExpr)
+data AtomList =
+  | MkAtomList Bin (List Binding) (List AnfExpr)
 
-data ArmsRes = MkArmsRes Bin (List AnfExpr)
+data ArmsRes =
+  | MkArmsRes Bin (List AnfExpr)
 
-data AnfFunc = MkAnfFunc (List U8) (List (List U8)) AnfExpr
+data AnfFunc =
+  | MkAnfFunc (List U8) (List (List U8)) AnfExpr
 
-data AnfProgram = MkAnfProgram (List AnfFunc) (List U8)
+data AnfProgram =
+  | MkAnfProgram (List AnfFunc) (List U8)
 
-poly tempPrefix = {U8 | '_' '_' 't'}
+poly tempPrefix =
+  {U8 | '_' '_' 't'}
 
-poly freshName = \counter : Bin => append [U8] tempPrefix (binToDigits counter)
+poly freshName =
+  \counter : Bin => append [U8] tempPrefix (binToDigits counter)
 
-poly rec applyBindings = \bindings : List Binding => \body : AnfExpr =>
-  matchList [Binding] [AnfExpr] bindings
-    body
-    (\h : Binding => \t : List Binding =>
-      match h [AnfExpr] { | MkBinding name val =>
-        applyBindings t (AE_Let name val body)
-      })
+poly rec applyBindings =
+  \bindings : List Binding =>
+    \body : AnfExpr =>
+      matchList
+        [Binding]
+        [AnfExpr]
+        bindings
+        body
+        (
+          \h : Binding =>
+            \t : List Binding =>
+              match h [AnfExpr] {
+                | MkBinding name val => applyBindings t (AE_Let name val body)
+              }
+        )
 
-poly wrapValue = \state : Bin => \binds : List Binding => \value : AnfExpr => \pos : Pos =>
-  match pos [NormResult] {
-    | PAtom =>
-        let nm = freshName state in
-        let s1 = incBin state in
-        MkNormResult s1 (cons [Binding] (MkBinding nm value) binds) (AE_Var nm)
-    | PVal => MkNormResult state binds value
-    | PTail => MkNormResult state (nil [Binding]) (applyBindings binds value)
-  }
+poly wrapValue =
+  \state : Bin =>
+    \binds : List Binding =>
+      \value : AnfExpr =>
+        \pos : Pos =>
+          match pos [NormResult] {
+            | PAtom =>
+              let nm = freshName state in
+              let s1 = incBin state in
+              MkNormResult
+                s1
+                (cons [Binding] (MkBinding nm value) binds)
+                (AE_Var nm)
+            | PVal => MkNormResult state binds value
+            | PTail =>
+              MkNormResult state (nil [Binding]) (applyBindings binds value)
+          }
 
-poly trivialAt = \state : Bin => \atom : AnfExpr => \pos : Pos =>
-  MkNormResult state (nil [Binding]) atom
+poly trivialAt =
+  \state : Bin =>
+    \atom : AnfExpr => \pos : Pos => MkNormResult state (nil [Binding]) atom
 
-poly rec atomizeArgs = \normFn : Bin -> MiniExpr -> Pos -> NormResult => \state : Bin => \args : List MiniExpr => \accBinds : List Binding =>
-  matchList [MiniExpr] [AtomList] args
-    (MkAtomList state accBinds (nil [AnfExpr]))
-    (\h : MiniExpr => \t : List MiniExpr =>
-      match (normFn state h PAtom) [AtomList] { | MkNormResult s1 hBinds hAtom =>
-        let combined = append [Binding] hBinds accBinds in
-        match (atomizeArgs normFn s1 t combined) [AtomList] { | MkAtomList s2 finalBinds restAtoms =>
-          MkAtomList s2 finalBinds (cons [AnfExpr] hAtom restAtoms)
-        }
-      })
+poly rec atomizeArgs =
+  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
+    \state : Bin =>
+      \args : List MiniExpr =>
+        \accBinds : List Binding =>
+          matchList
+            [MiniExpr]
+            [AtomList]
+            args
+            (MkAtomList state accBinds (nil [AnfExpr]))
+            (
+              \h : MiniExpr =>
+                \t : List MiniExpr =>
+                  match (normFn state h PAtom) [AtomList] {
+                    | MkNormResult s1 hBinds hAtom =>
+                      let combined = append [Binding] hBinds accBinds in
+                      match (atomizeArgs normFn s1 t combined) [AtomList] {
+                        | MkAtomList s2 finalBinds restAtoms =>
+                          MkAtomList
+                            s2
+                            finalBinds
+                            (cons [AnfExpr] hAtom restAtoms)
+                      }
+                  }
+            )
 
-poly rec normArms = \normFn : Bin -> MiniExpr -> Pos -> NormResult => \state : Bin => \arms : List MiniExpr => \acc : List AnfExpr =>
-  matchList [MiniExpr] [ArmsRes] arms
-    (MkArmsRes state (nil [AnfExpr]))
-    (\h : MiniExpr => \t : List MiniExpr =>
-      match (normFn state h PTail) [ArmsRes] { | MkNormResult s1 _ hExpr =>
-        match (normArms normFn s1 t acc) [ArmsRes] { | MkArmsRes s2 restArms =>
-          MkArmsRes s2 (cons [AnfExpr] hExpr restArms)
-        }
-      })
+poly rec normArms =
+  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
+    \state : Bin =>
+      \arms : List MiniExpr =>
+        \acc : List AnfExpr =>
+          matchList
+            [MiniExpr]
+            [ArmsRes]
+            arms
+            (MkArmsRes state (nil [AnfExpr]))
+            (
+              \h : MiniExpr =>
+                \t : List MiniExpr =>
+                  match (normFn state h PTail) [ArmsRes] {
+                    | MkNormResult s1 _ hExpr =>
+                      match (normArms normFn s1 t acc) [ArmsRes] {
+                        | MkArmsRes s2 restArms => MkArmsRes s2 (cons [AnfExpr] hExpr restArms)
+                      }
+                  }
+            )
 
-poly rec norm = \state : Bin => \expr : MiniExpr => \pos : Pos =>
-  match expr [NormResult] {
-    | ME_Var name => trivialAt state (AE_Var name) pos
-    | ME_Native t => trivialAt state (AE_Native t) pos
-    | ME_Lam n body =>
-        match (norm state body PTail) [NormResult] { | MkNormResult s1 _ bExpr =>
-          wrapValue s1 (nil [Binding]) (AE_Lam n bExpr) pos
-        }
-    | ME_Call f args =>
-        match (atomizeArgs norm state args (nil [Binding])) [NormResult] { | MkAtomList s1 binds atoms =>
-          wrapValue s1 binds (AE_Call f atoms) pos
-        }
-    | ME_Con tag total arity fields =>
-        match (atomizeArgs norm state fields (nil [Binding])) [NormResult] { | MkAtomList s1 binds atoms =>
-          wrapValue s1 binds (AE_Con tag total arity atoms) pos
-        }
-    | ME_Let name val body =>
-        match (norm state val PVal) [NormResult] { | MkNormResult s1 valBinds valExpr =>
-          match (norm s1 body pos) [NormResult] { | MkNormResult s2 bodyBinds bodyExpr =>
-            match pos [NormResult] {
-              | PAtom =>
-                  let combined = append [Binding] bodyBinds (cons [Binding] (MkBinding name valExpr) valBinds) in
-                  MkNormResult s2 combined bodyExpr
-              | PVal =>
-                  let combined = append [Binding] bodyBinds (cons [Binding] (MkBinding name valExpr) valBinds) in
-                  MkNormResult s2 combined bodyExpr
-              | PTail =>
-                  MkNormResult s2 (nil [Binding]) (applyBindings valBinds (AE_Let name valExpr bodyExpr))
+poly rec norm =
+  \state : Bin =>
+    \expr : MiniExpr =>
+      \pos : Pos =>
+        match expr [NormResult] {
+          | ME_Var name => trivialAt state (AE_Var name) pos
+          | ME_Native t => trivialAt state (AE_Native t) pos
+          | ME_Lam n body =>
+            match (norm state body PTail) [NormResult] {
+              | MkNormResult s1 _ bExpr => wrapValue s1 (nil [Binding]) (AE_Lam n bExpr) pos
             }
-          }
+          | ME_Call f args =>
+            match (atomizeArgs norm state args (nil [Binding])) [NormResult] {
+              | MkAtomList s1 binds atoms => wrapValue s1 binds (AE_Call f atoms) pos
+            }
+          | ME_Con tag total arity fields =>
+            match (atomizeArgs norm state fields (nil [Binding])) [NormResult] {
+              | MkAtomList s1 binds atoms =>
+                wrapValue s1 binds (AE_Con tag total arity atoms) pos
+            }
+          | ME_Let name val body =>
+            match (norm state val PVal) [NormResult] {
+              | MkNormResult s1 valBinds valExpr =>
+                match (norm s1 body pos) [NormResult] {
+                  | MkNormResult s2 bodyBinds bodyExpr =>
+                    match pos [NormResult] {
+                      | PAtom =>
+                        let combined = append [Binding] bodyBinds (cons [Binding] (MkBinding name valExpr) valBinds) in
+                        MkNormResult s2 combined bodyExpr
+                      | PVal =>
+                        let combined = append [Binding] bodyBinds (cons [Binding] (MkBinding name valExpr) valBinds) in
+                        MkNormResult s2 combined bodyExpr
+                      | PTail =>
+                        MkNormResult
+                          s2
+                          (nil [Binding])
+                          (
+                            applyBindings
+                              valBinds
+                              (AE_Let name valExpr bodyExpr)
+                          )
+                    }
+                }
+            }
+          | ME_Match scrut arms =>
+            match (norm state scrut PAtom) [NormResult] {
+              | MkNormResult s1 scrBinds scrAtom =>
+                match (normArms norm s1 arms (nil [AnfExpr])) [NormResult] {
+                  | MkArmsRes s2 normedArms =>
+                    wrapValue s2 scrBinds (AE_Case scrAtom normedArms) pos
+                }
+            }
         }
-    | ME_Match scrut arms =>
-        match (norm state scrut PAtom) [NormResult] { | MkNormResult s1 scrBinds scrAtom =>
-          match (normArms norm s1 arms (nil [AnfExpr])) [NormResult] { | MkArmsRes s2 normedArms =>
-            wrapValue s2 scrBinds (AE_Case scrAtom normedArms) pos
-          }
-        }
-  }
 
-poly normalize = \expr : MiniExpr =>
-  match (norm BZ expr PTail) [AnfExpr] { | MkNormResult s b e => e }
+poly normalize =
+  \expr : MiniExpr =>
+    match (norm BZ expr PTail) [AnfExpr] {
+      | MkNormResult s b e => e
+    }
 
-poly rec normalizeFuncs = \funcs : List MiniFunc =>
-  matchList [MiniFunc] [List AnfFunc] funcs
-    (nil [AnfFunc])
-    (\h : MiniFunc => \t : List MiniFunc =>
-      match h [List AnfFunc] {
-        | MkMiniFunc name params body =>
-            cons [AnfFunc] (MkAnfFunc name params (normalize body)) (normalizeFuncs t)
-      })
+poly rec normalizeFuncs =
+  \funcs : List MiniFunc =>
+    matchList
+      [MiniFunc]
+      [List AnfFunc]
+      funcs
+      (nil [AnfFunc])
+      (
+        \h : MiniFunc =>
+          \t : List MiniFunc =>
+            match h [List AnfFunc] {
+              | MkMiniFunc name params body =>
+                cons
+                  [AnfFunc]
+                  (MkAnfFunc name params (normalize body))
+                  (normalizeFuncs t)
+            }
+      )
 
-poly normalizeProgram = \prog : MiniProgram =>
-  match prog [AnfProgram] {
-    | MkMiniProgram funcs entry => MkAnfProgram (normalizeFuncs funcs) entry
-  }
+poly normalizeProgram =
+  \prog : MiniProgram =>
+    match prog [AnfProgram] {
+      | MkMiniProgram funcs entry => MkAnfProgram (normalizeFuncs funcs) entry
+    }

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -1,210 +1,346 @@
 module AnfLlvm
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude U8
+
 import Prelude eqListU8
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Bin incBin
+
 import Bin binToDigits
+
 import Lexer tokenize
+
 import Parser parseProgram
+
 import Bridge elaborateProgramToCore
+
 import MiniCore buildMiniProgram
+
 import Anf normalizeProgram
+
 import Anf AnfExpr
+
 import Anf AE_Var
+
 import Anf AE_Native
+
 import Anf AE_Lam
+
 import Anf AE_Call
+
 import Anf AE_Con
+
 import Anf AE_Case
+
 import Anf AE_Let
+
 import Anf AnfFunc
+
 import Anf MkAnfFunc
+
 import Anf AnfProgram
+
 import Anf MkAnfProgram
 
 export emitProgram
+
 export compileSourceToLlvmText
 
-data EmitRes = MkEmitRes Bin (List (List U8)) (List U8)
+data EmitRes =
+  | MkEmitRes Bin (List (List U8)) (List U8)
 
-poly rec lookupEnv = \env : List (Pair (List U8) (List U8)) => \name : List U8 =>
-  matchList [Pair (List U8) (List U8)] [Maybe (List U8)] env
-    (None [List U8])
-    (\h : Pair (List U8) (List U8) => \t : List (Pair (List U8) (List U8)) =>
-      if [Maybe (List U8)] (eqListU8 (fst [List U8] [List U8] h) name)
-        (\u : U8 => Some [List U8] (snd [List U8] [List U8] h))
-        (\u : U8 => lookupEnv t name))
+poly rec lookupEnv =
+  \env : List (Pair (List U8) (List U8)) =>
+    \name : List U8 =>
+      matchList
+        [Pair (List U8) (List U8)]
+        [Maybe (List U8)]
+        env
+        (None [List U8])
+        (
+          \h : Pair (List U8) (List U8) =>
+            \t : List (Pair (List U8) (List U8)) =>
+              if [Maybe (List U8)] (eqListU8 (fst [List U8] [List U8] h) name)
+                (\u : U8 => Some [List U8] (snd [List U8] [List U8] h))
+                (\u : U8 => lookupEnv t name)
+        )
 
-poly atomOperand = \env : List (Pair (List U8) (List U8)) => \e : AnfExpr =>
-  match e [Result (List U8) (List U8)] {
-    | AE_Var n =>
-        match (lookupEnv env n) [Result (List U8) (List U8)] {
-          | None => Err [List U8] [List U8] (append [U8] "Unbound variable: " n)
-          | Some op => Ok [List U8] [List U8] op
-        }
-    | AE_Native t => Err [List U8] [List U8] "Unsupported atom: native"
-    | AE_Lam n b => Err [List U8] [List U8] "Unsupported atom: lambda"
-    | AE_Call f args => Err [List U8] [List U8] "Unsupported atom: call"
-    | AE_Con tag total arity args => Err [List U8] [List U8] "Unsupported atom: constructor"
-    | AE_Case scrut arms => Err [List U8] [List U8] "Unsupported atom: case"
-    | AE_Let name val body => Err [List U8] [List U8] "Unsupported atom: let"
-  }
-
-poly rec emitArgsString = \env : List (Pair (List U8) (List U8)) => \args : List AnfExpr => \leading : Bool =>
-  matchList [AnfExpr] [Result (List U8) (List U8)] args
-    (Ok [List U8] [List U8] (nil [U8]))
-    (\h : AnfExpr => \t : List AnfExpr =>
-      match (atomOperand env h) [Result (List U8) (List U8)] {
-        | Err e => Err [List U8] [List U8] e
-        | Ok op =>
-            let piece =
-              if [List U8] leading
-                (\u : U8 => append [U8] "i8 " op)
-                (\u : U8 => append [U8] ", i8 " op) in
-            match (emitArgsString env t false) [Result (List U8) (List U8)] {
-              | Err e => Err [List U8] [List U8] e
-              | Ok rest => Ok [List U8] [List U8] (append [U8] piece rest)
-            }
-      })
-
-poly rec emitExpr = \env : List (Pair (List U8) (List U8)) => \counter : Bin => \instrs : List (List U8) => \e : AnfExpr =>
-  match e [Result (List U8) EmitRes] {
-    | AE_Var n =>
-        match (lookupEnv env n) [Result (List U8) EmitRes] {
-          | None => Err [List U8] [EmitRes] (append [U8] "Unbound variable: " n)
-          | Some op => Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
-        }
-    | AE_Native t => Err [List U8] [EmitRes] "Unsupported expression: native"
-    | AE_Lam n b => Err [List U8] [EmitRes] "Unsupported expression: lambda"
-    | AE_Call f args =>
-        match (emitArgsString env args true) [Result (List U8) EmitRes] {
-          | Err e => Err [List U8] [EmitRes] e
-          | Ok argStr =>
-              let dest = append [U8] "%__ll" (binToDigits counter) in
-              let counter1 = incBin counter in
-              let line =
-                append [U8] "  "
-                  (append [U8] dest
-                    (append [U8] " = call i8 @"
-                      (append [U8] f
-                        (append [U8] "("
-                          (append [U8] argStr ")\n"))))) in
-              Ok [List U8] [EmitRes] (MkEmitRes counter1 (cons [List U8] line instrs) dest)
-        }
-    | AE_Con tag total arity args => Err [List U8] [EmitRes] "Unsupported expression: constructor"
-    | AE_Case scrut arms => Err [List U8] [EmitRes] "Unsupported expression: case"
-    | AE_Let name val body =>
-        match (emitExpr env counter instrs val) [Result (List U8) EmitRes] {
-          | Err e => Err [List U8] [EmitRes] e
-          | Ok midRes =>
-              match midRes [Result (List U8) EmitRes] { | MkEmitRes c1 i1 vop =>
-                emitExpr
-                  (cons [Pair (List U8) (List U8)] (MkPair [List U8] [List U8] name vop) env)
-                  c1 i1 body
-              }
-        }
-  }
-
-poly rec paramDeclsString = \params : List (List U8) => \leading : Bool =>
-  matchList [List U8] [List U8] params
-    (nil [U8])
-    (\h : List U8 => \t : List (List U8) =>
-      let piece =
-        if [List U8] leading
-          (\u : U8 => append [U8] "i8 %" h)
-          (\u : U8 => append [U8] ", i8 %" h) in
-      append [U8] piece (paramDeclsString t false))
-
-poly rec paramEnv = \params : List (List U8) =>
-  matchList [List U8] [List (Pair (List U8) (List U8))] params
-    (nil [Pair (List U8) (List U8)])
-    (\h : List U8 => \t : List (List U8) =>
-      cons [Pair (List U8) (List U8)]
-        (MkPair [List U8] [List U8] h (append [U8] "%" h))
-        (paramEnv t))
-
-poly rec joinLines = \acc : List U8 => \lines : List (List U8) =>
-  matchList [List U8] [List U8] lines
-    acc
-    (\h : List U8 => \t : List (List U8) => joinLines (append [U8] h acc) t)
-
-poly emitFunc = \fn : AnfFunc =>
-  match fn [Result (List U8) (List U8)] { | MkAnfFunc name params body =>
-    match (emitExpr (paramEnv params) BZ (nil [List U8]) body) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok res =>
-          match res [Result (List U8) (List U8)] { | MkEmitRes c instrs op =>
-            let instrText = joinLines (nil [U8]) instrs in
-            Ok [List U8] [List U8]
-              (append [U8] "define i8 @"
-                (append [U8] name
-                  (append [U8] "("
-                    (append [U8] (paramDeclsString params true)
-                      (append [U8] ") {\nentry:\n"
-                        (append [U8] instrText
-                          (append [U8] "  ret i8 "
-                            (append [U8] op "\n}\n\n"))))))))
+poly atomOperand =
+  \env : List (Pair (List U8) (List U8)) =>
+    \e : AnfExpr =>
+      match e [Result (List U8) (List U8)] {
+        | AE_Var n =>
+          match (lookupEnv env n) [Result (List U8) (List U8)] {
+            | None =>
+              Err [List U8] [List U8] (append [U8] "Unbound variable: " n)
+            | Some op => Ok [List U8] [List U8] op
           }
-    }
-  }
+        | AE_Native t => Err [List U8] [List U8] "Unsupported atom: native"
+        | AE_Lam n b => Err [List U8] [List U8] "Unsupported atom: lambda"
+        | AE_Call f args => Err [List U8] [List U8] "Unsupported atom: call"
+        | AE_Con tag total arity args =>
+          Err [List U8] [List U8] "Unsupported atom: constructor"
+        | AE_Case scrut arms => Err [List U8] [List U8] "Unsupported atom: case"
+        | AE_Let name val body => Err [List U8] [List U8] "Unsupported atom: let"
+      }
 
-poly rec emitFuncs = \fns : List AnfFunc =>
-  matchList [AnfFunc] [Result (List U8) (List U8)] fns
-    (Ok [List U8] [List U8] (nil [U8]))
-    (\h : AnfFunc => \t : List AnfFunc =>
-      match (emitFunc h) [Result (List U8) (List U8)] {
-        | Err e => Err [List U8] [List U8] e
-        | Ok block =>
-            match (emitFuncs t) [Result (List U8) (List U8)] {
-              | Err e => Err [List U8] [List U8] e
-              | Ok rest => Ok [List U8] [List U8] (append [U8] block rest)
+poly rec emitArgsString =
+  \env : List (Pair (List U8) (List U8)) =>
+    \args : List AnfExpr =>
+      \leading : Bool =>
+        matchList
+          [AnfExpr]
+          [Result (List U8) (List U8)]
+          args
+          (Ok [List U8] [List U8] (nil [U8]))
+          (
+            \h : AnfExpr =>
+              \t : List AnfExpr =>
+                match (atomOperand env h) [Result (List U8) (List U8)] {
+                  | Err e => Err [List U8] [List U8] e
+                  | Ok op =>
+                    let piece = if [List U8] leading (\u : U8 => append [U8] "i8 " op) (\u : U8 => append [U8] ", i8 " op) in
+                    match (emitArgsString env t false) [Result (List U8) (List U8)] {
+                      | Err e => Err [List U8] [List U8] e
+                      | Ok rest => Ok [List U8] [List U8] (append [U8] piece rest)
+                    }
+                }
+          )
+
+poly rec emitExpr =
+  \env : List (Pair (List U8) (List U8)) =>
+    \counter : Bin =>
+      \instrs : List (List U8) =>
+        \e : AnfExpr =>
+          match e [Result (List U8) EmitRes] {
+            | AE_Var n =>
+              match (lookupEnv env n) [Result (List U8) EmitRes] {
+                | None =>
+                  Err [List U8] [EmitRes] (append [U8] "Unbound variable: " n)
+                | Some op =>
+                  Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
+              }
+            | AE_Native t =>
+              Err [List U8] [EmitRes] "Unsupported expression: native"
+            | AE_Lam n b =>
+              Err [List U8] [EmitRes] "Unsupported expression: lambda"
+            | AE_Call f args =>
+              match (emitArgsString env args true) [Result (List U8) EmitRes] {
+                | Err e => Err [List U8] [EmitRes] e
+                | Ok argStr =>
+                  let dest = append [U8] "%__ll" (binToDigits counter) in
+                  let counter1 = incBin counter in
+                  let line = append [U8] "  " (append [U8] dest (append [U8] " = call i8 @" (append [U8] f (append [U8] "(" (append [U8] argStr ")\n"))))) in
+                  Ok
+                    [List U8]
+                    [EmitRes]
+                    (MkEmitRes counter1 (cons [List U8] line instrs) dest)
+              }
+            | AE_Con tag total arity args =>
+              Err [List U8] [EmitRes] "Unsupported expression: constructor"
+            | AE_Case scrut arms =>
+              Err [List U8] [EmitRes] "Unsupported expression: case"
+            | AE_Let name val body =>
+              match (emitExpr env counter instrs val) [Result (List U8) EmitRes] {
+                | Err e => Err [List U8] [EmitRes] e
+                | Ok midRes =>
+                  match midRes [Result (List U8) EmitRes] {
+                    | MkEmitRes c1 i1 vop =>
+                      emitExpr
+                        (
+                          cons
+                            [Pair (List U8) (List U8)]
+                            (MkPair [List U8] [List U8] name vop)
+                            env
+                        )
+                        c1
+                        i1
+                        body
+                  }
+              }
+          }
+
+poly rec paramDeclsString =
+  \params : List (List U8) =>
+    \leading : Bool =>
+      matchList
+        [List U8]
+        [List U8]
+        params
+        (nil [U8])
+        (
+          \h : List U8 =>
+            \t : List (List U8) =>
+              let piece = if [List U8] leading (\u : U8 => append [U8] "i8 %" h) (\u : U8 => append [U8] ", i8 %" h) in
+              append [U8] piece (paramDeclsString t false)
+        )
+
+poly rec paramEnv =
+  \params : List (List U8) =>
+    matchList
+      [List U8]
+      [List (Pair (List U8) (List U8))]
+      params
+      (nil [Pair (List U8) (List U8)])
+      (
+        \h : List U8 =>
+          \t : List (List U8) =>
+            cons
+              [Pair (List U8) (List U8)]
+              (MkPair [List U8] [List U8] h (append [U8] "%" h))
+              (paramEnv t)
+      )
+
+poly rec joinLines =
+  \acc : List U8 =>
+    \lines : List (List U8) =>
+      matchList
+        [List U8]
+        [List U8]
+        lines
+        acc
+        (\h : List U8 => \t : List (List U8) => joinLines (append [U8] h acc) t)
+
+poly emitFunc =
+  \fn : AnfFunc =>
+    match fn [Result (List U8) (List U8)] {
+      | MkAnfFunc name params body =>
+        match (emitExpr (paramEnv params) BZ (nil [List U8]) body) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok res =>
+            match res [Result (List U8) (List U8)] {
+              | MkEmitRes c instrs op =>
+                let instrText = joinLines (nil [U8]) instrs in
+                Ok
+                  [List U8]
+                  [List U8]
+                  (
+                    append
+                      [U8]
+                      "define i8 @"
+                      (
+                        append
+                          [U8]
+                          name
+                          (
+                            append
+                              [U8]
+                              "("
+                              (
+                                append
+                                  [U8]
+                                  (paramDeclsString params true)
+                                  (
+                                    append
+                                      [U8]
+                                      ") {\nentry:\n"
+                                      (
+                                        append
+                                          [U8]
+                                          instrText
+                                          (
+                                            append
+                                              [U8]
+                                              "  ret i8 "
+                                              (append [U8] op "\n}\n\n")
+                                          )
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
             }
-      })
+        }
+    }
 
-poly emitProgram = \prog : AnfProgram =>
-  match prog [Result (List U8) (List U8)] { | MkAnfProgram funcs entry =>
-    emitFuncs funcs
-  }
+poly rec emitFuncs =
+  \fns : List AnfFunc =>
+    matchList
+      [AnfFunc]
+      [Result (List U8) (List U8)]
+      fns
+      (Ok [List U8] [List U8] (nil [U8]))
+      (
+        \h : AnfFunc =>
+          \t : List AnfFunc =>
+            match (emitFunc h) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] e
+              | Ok block =>
+                match (emitFuncs t) [Result (List U8) (List U8)] {
+                  | Err e => Err [List U8] [List U8] e
+                  | Ok rest => Ok [List U8] [List U8] (append [U8] block rest)
+                }
+            }
+      )
 
-poly compileSourceToLlvmText = \source : List U8 =>
-  match (tokenize source) [List U8] {
-    | Err e => append [U8] "ERR:" "Lex error"
-    | Ok toks =>
+poly emitProgram =
+  \prog : AnfProgram =>
+    match prog [Result (List U8) (List U8)] {
+      | MkAnfProgram funcs entry => emitFuncs funcs
+    }
+
+poly compileSourceToLlvmText =
+  \source : List U8 =>
+    match (tokenize source) [List U8] {
+      | Err e => append [U8] "ERR:" "Lex error"
+      | Ok toks =>
         match (parseProgram toks) [List U8] {
           | Err e => append [U8] "ERR:" "Parse error"
           | Ok decls =>
-              match (elaborateProgramToCore decls) [List U8] {
-                | Err e => append [U8] "ERR:" e
-                | Ok coreDefs =>
-                    match (buildMiniProgram coreDefs "main") [List U8] {
+            match (elaborateProgramToCore decls) [List U8] {
+              | Err e => append [U8] "ERR:" e
+              | Ok coreDefs =>
+                match (buildMiniProgram coreDefs "main") [List U8] {
+                  | Err e => append [U8] "ERR:" e
+                  | Ok prog =>
+                    match (emitProgram (normalizeProgram prog)) [List U8] {
                       | Err e => append [U8] "ERR:" e
-                      | Ok prog =>
-                          match (emitProgram (normalizeProgram prog)) [List U8] {
-                            | Err e => append [U8] "ERR:" e
-                            | Ok llvm => llvm
-                          }
+                      | Ok llvm => llvm
                     }
-              }
+                }
+            }
         }
-  }
+    }

--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -1,504 +1,894 @@
 module Bridge
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude if
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude U8
+
 import Prelude and
+
 import Prelude or
+
 import Prelude not
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Avl Avl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl insert
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
+
 import Parser Pattern
+
 import Parser P_Ctor
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Type
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Def
+
 import Parser D_Data
+
 import Core Core
+
 import Core Cr_Var
+
 import Core Cr_App
+
 import Core Cr_Lam
+
 import Core Cr_Native
+
 import Core Cr_Ctor
+
 import Core Cr_Match
+
 import CoreToLower coreToLower
+
 import DataEnv DataEnv
+
 import DataEnv MkDataEnv
+
 import DataEnv ctorTag
+
 import DataEnv ctorTotal
+
 import DataEnv ctorArity
+
 import DataEnv adtCtors
+
 import DataEnv datEnvCtors
+
 import DataEnv datEnvAdts
+
 import DataEnv CtorInfo
+
 import DataEnv MkCtorInfo
+
 import DataEnv ADTInfo
+
 import DataEnv MkADTInfo
+
 import Unparse Terminal
+
 import Unparse T_S
+
 import Unparse T_K
+
 import Unparse T_I
+
 import Unparse T_B
+
 import Unparse T_C
+
 import Unparse T_SPrime
+
 import Unparse T_BPrime
+
 import Unparse T_CPrime
+
 import Unparse T_WriteOne
+
 import Unparse T_ReadOne
+
 import Unparse T_EqU8
+
 import Unparse T_LtU8
+
 import Unparse T_DivU8
+
 import Unparse T_ModU8
+
 import Unparse T_AddU8
+
 import Unparse T_SubU8
+
 import Unparse T_Byte
+
 import Lowering Lower
+
 import Lowering L_Var
+
 import Lowering L_App
+
 import Lowering L_Lam
+
 import Lowering L_Native
 
 export elaborateProgram
+
 export elaborateProgramToCore
+
 export checkedLengthU8
 
-poly rec eqListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    (matchList [U8] [Bool] b true (\hb : U8 => \tb : List U8 => false))
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => eqListU8 ta tb)
-            (\u : U8 => false)))
+poly rec eqListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
+        (matchList [U8] [Bool] b true (\hb : U8 => \tb : List U8 => false))
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => eqListU8 ta tb)
+                        (\u : U8 => false)
+                )
+        )
 
-poly rec lteListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    true
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b
-        false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => lteListU8 ta tb)
-            (\u : U8 => ltU8 ha hb)))
-
-poly resolveNativeName = \name : List U8 =>
-  if [Maybe Lower] (eqListU8 name ".")
-    (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-    (\u : U8 =>
-      if [Maybe Lower] (eqListU8 name ",")
-        (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-        (\u : U8 =>
-          if [Maybe Lower] (eqListU8 name "writeOne")
-            (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-            (\u : U8 =>
-              if [Maybe Lower] (eqListU8 name "readOne")
-                (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-                (\u : U8 =>
-                  if [Maybe Lower] (eqListU8 name "addU8")
-                    (\u : U8 => Some [Lower] (L_Native T_AddU8))
-                    (\u : U8 =>
-                      if [Maybe Lower] (eqListU8 name "subU8")
-                        (\u : U8 => Some [Lower] (L_Native T_SubU8))
-                        (\u : U8 =>
-                          if [Maybe Lower] (eqListU8 name "divU8")
-                            (\u : U8 => Some [Lower] (L_Native T_DivU8))
-                            (\u : U8 =>
-                              if [Maybe Lower] (eqListU8 name "modU8")
-                                (\u : U8 => Some [Lower] (L_Native T_ModU8))
-                                (\u : U8 =>
-                                  if [Maybe Lower] (eqListU8 name "eqU8")
-                                    (\u : U8 => Some [Lower] (L_Native T_EqU8))
-                                    (\u : U8 =>
-                                      if [Maybe Lower] (eqListU8 name "ltU8")
-                                        (\u : U8 => Some [Lower] (L_Native T_LtU8))
-                                        (\u : U8 => None [Lower]))))))))))
-
-poly unboundNameError = \name : List U8 =>
-  append [U8] "Unbound variable: " name
-
-poly digitValue = \c : U8 =>
-  modU8 c #u8(16)
-
-poly mul10U8 = \n : U8 =>
-  let two = addU8 n n in
-  let four = addU8 two two in
-  let eight = addU8 four four in
-  addU8 eight two
-
-poly rec trimLeadingZeros = \digits : List U8 =>
-  matchList [U8] [List U8] digits
-    (nil [U8])
-    (\h : U8 => \t : List U8 =>
-      if [List U8] (eqU8 h '0')
-        (\u : U8 => trimLeadingZeros t)
-        (\u : U8 => cons [U8] h t))
-
-poly isByteDigits = \digits : List U8 =>
-  matchList [U8] [Bool] digits
-    true
-    (\h0 : U8 => \t0 : List U8 =>
-      matchList [U8] [Bool] t0
+poly rec lteListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
         true
-        (\h1 : U8 => \t1 : List U8 =>
-          matchList [U8] [Bool] t1
-            true
-            (\h2 : U8 => \t2 : List U8 =>
-              matchList [U8] [Bool] t2
-                (lteListU8 digits "255")
-                (\h3 : U8 => \t3 : List U8 => false))))
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => lteListU8 ta tb)
+                        (\u : U8 => ltU8 ha hb)
+                )
+        )
 
-poly rec parseByteDigitsAcc = \digits : List U8 => \acc : U8 =>
-  matchList [U8] [U8] digits acc
-    (\h : U8 => \t : List U8 =>
-      parseByteDigitsAcc t (addU8 (mul10U8 acc) (digitValue h)))
+poly resolveNativeName =
+  \name : List U8 =>
+    if [Maybe Lower] (eqListU8 name ".")
+      (\u : U8 => Some [Lower] (L_Native T_WriteOne))
+      (
+        \u : U8 =>
+          if [Maybe Lower] (eqListU8 name ",")
+            (\u : U8 => Some [Lower] (L_Native T_ReadOne))
+            (
+              \u : U8 =>
+                if [Maybe Lower] (eqListU8 name "writeOne")
+                  (\u : U8 => Some [Lower] (L_Native T_WriteOne))
+                  (
+                    \u : U8 =>
+                      if [Maybe Lower] (eqListU8 name "readOne")
+                        (\u : U8 => Some [Lower] (L_Native T_ReadOne))
+                        (
+                          \u : U8 =>
+                            if [Maybe Lower] (eqListU8 name "addU8")
+                              (\u : U8 => Some [Lower] (L_Native T_AddU8))
+                              (
+                                \u : U8 =>
+                                  if [Maybe Lower] (eqListU8 name "subU8")
+                                    (\u : U8 => Some [Lower] (L_Native T_SubU8))
+                                    (
+                                      \u : U8 =>
+                                        if [Maybe Lower] (eqListU8 name "divU8")
+                                          (
+                                            \u : U8 => Some [Lower] (L_Native T_DivU8)
+                                          )
+                                          (
+                                            \u : U8 =>
+                                              if [Maybe Lower] (eqListU8 name "modU8")
+                                                (
+                                                  \u : U8 => Some [Lower] (L_Native T_ModU8)
+                                                )
+                                                (
+                                                  \u : U8 =>
+                                                    if [Maybe Lower] (eqListU8 name "eqU8")
+                                                      (
+                                                        \u : U8 => Some [Lower] (L_Native T_EqU8)
+                                                      )
+                                                      (
+                                                        \u : U8 =>
+                                                          if [Maybe Lower] (eqListU8 name "ltU8")
+                                                            (
+                                                              \u : U8 => Some [Lower] (L_Native T_LtU8)
+                                                            )
+                                                            (
+                                                              \u : U8 => None [Lower]
+                                                            )
+                                                      )
+                                                )
+                                          )
+                                    )
+                              )
+                        )
+                  )
+            )
+      )
 
-poly parseByteDigits = \digits : List U8 =>
-  parseByteDigitsAcc digits #u8(0)
+poly unboundNameError =
+  \name : List U8 => append [U8] "Unbound variable: " name
 
-poly rec div2DigitsAcc = \digits : List U8 => \carry : U8 => \started : Bool => \accRev : List U8 =>
-  matchList [U8] [Pair (List U8) U8] digits
-    (MkPair [List U8] [U8] (reverse [U8] accRev) carry)
-    (\h : U8 => \t : List U8 =>
-      let current = if [U8] (eqU8 carry #u8(0))
-                      (\u : U8 => digitValue h)
-                      (\u : U8 => addU8 #u8(10) (digitValue h)) in
-      let quotientDigit = divU8 current #u8(2) in
-      let remainder = modU8 current #u8(2) in
-      let nextStarted = if [Bool] started
-                          (\u : U8 => true)
-                          (\u : U8 => not (eqU8 quotientDigit #u8(0))) in
-      let nextAccRev = if [List U8] nextStarted
-                         (\u : U8 => cons [U8] (addU8 quotientDigit #u8(48)) accRev)
-                         (\u : U8 => accRev) in
-      div2DigitsAcc t remainder nextStarted nextAccRev)
+poly digitValue =
+  \c : U8 => modU8 c #u8(16)
 
-poly div2Digits = \digits : List U8 =>
-  div2DigitsAcc digits #u8(0) false (nil [U8])
+poly mul10U8 =
+  \n : U8 =>
+    let two = addU8 n n in
+    let four = addU8 two two in
+    let eight = addU8 four four in
+    addU8 eight two
 
-poly rec collectBits = \digits : List U8 => \acc : List U8 =>
-  match (div2Digits digits) [Pair (List U8) U8] { | MkPair quotient remainder =>
-    let nextAcc = cons [U8] remainder acc in
-    matchList [U8] [List U8] quotient nextAcc
-      (\h : U8 => \t : List U8 => collectBits quotient nextAcc)
-  }
+poly rec trimLeadingZeros =
+  \digits : List U8 =>
+    matchList
+      [U8]
+      [List U8]
+      digits
+      (nil [U8])
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [List U8] (eqU8 h '0')
+              (\u : U8 => trimLeadingZeros t)
+              (\u : U8 => cons [U8] h t)
+      )
+
+poly isByteDigits =
+  \digits : List U8 =>
+    matchList
+      [U8]
+      [Bool]
+      digits
+      true
+      (
+        \h0 : U8 =>
+          \t0 : List U8 =>
+            matchList
+              [U8]
+              [Bool]
+              t0
+              true
+              (
+                \h1 : U8 =>
+                  \t1 : List U8 =>
+                    matchList
+                      [U8]
+                      [Bool]
+                      t1
+                      true
+                      (
+                        \h2 : U8 =>
+                          \t2 : List U8 =>
+                            matchList
+                              [U8]
+                              [Bool]
+                              t2
+                              (lteListU8 digits "255")
+                              (\h3 : U8 => \t3 : List U8 => false)
+                      )
+              )
+      )
+
+poly rec parseByteDigitsAcc =
+  \digits : List U8 =>
+    \acc : U8 =>
+      matchList
+        [U8]
+        [U8]
+        digits
+        acc
+        (
+          \h : U8 =>
+            \t : List U8 => parseByteDigitsAcc t (addU8 (mul10U8 acc) (digitValue h))
+        )
+
+poly parseByteDigits =
+  \digits : List U8 => parseByteDigitsAcc digits #u8(0)
+
+poly rec div2DigitsAcc =
+  \digits : List U8 =>
+    \carry : U8 =>
+      \started : Bool =>
+        \accRev : List U8 =>
+          matchList
+            [U8]
+            [Pair (List U8) U8]
+            digits
+            (MkPair [List U8] [U8] (reverse [U8] accRev) carry)
+            (
+              \h : U8 =>
+                \t : List U8 =>
+                  let current = if [U8] (eqU8 carry #u8(0)) (\u : U8 => digitValue h) (\u : U8 => addU8 #u8(10) (digitValue h)) in
+                  let quotientDigit = divU8 current #u8(2) in
+                  let remainder = modU8 current #u8(2) in
+                  let nextStarted = if [Bool] started (\u : U8 => true) (\u : U8 => not (eqU8 quotientDigit #u8(0))) in
+                  let nextAccRev = if [List U8] nextStarted (\u : U8 => cons [U8] (addU8 quotientDigit #u8(48)) accRev) (\u : U8 => accRev) in
+                  div2DigitsAcc t remainder nextStarted nextAccRev
+            )
+
+poly div2Digits =
+  \digits : List U8 => div2DigitsAcc digits #u8(0) false (nil [U8])
+
+poly rec collectBits =
+  \digits : List U8 =>
+    \acc : List U8 =>
+      match (div2Digits digits) [Pair (List U8) U8] {
+        | MkPair quotient remainder =>
+          let nextAcc = cons [U8] remainder acc in
+          matchList
+            [U8]
+            [List U8]
+            quotient
+            nextAcc
+            (\h : U8 => \t : List U8 => collectBits quotient nextAcc)
+      }
 
 poly binZeroCore =
   Cr_Lam "z" (Cr_Lam "b0" (Cr_Lam "b1" (Cr_Var "z")))
 
 poly binZeroCtorCore =
-  Cr_Lam "acc" (Cr_Lam "z" (Cr_Lam "b0" (Cr_Lam "b1" (Cr_App (Cr_Var "b0") (Cr_Var "acc")))))
+  Cr_Lam
+    "acc"
+    (
+      Cr_Lam
+        "z"
+        (Cr_Lam "b0" (Cr_Lam "b1" (Cr_App (Cr_Var "b0") (Cr_Var "acc"))))
+    )
 
 poly binOneCtorCore =
-  Cr_Lam "acc" (Cr_Lam "z" (Cr_Lam "b0" (Cr_Lam "b1" (Cr_App (Cr_Var "b1") (Cr_Var "acc")))))
+  Cr_Lam
+    "acc"
+    (
+      Cr_Lam
+        "z"
+        (Cr_Lam "b0" (Cr_Lam "b1" (Cr_App (Cr_Var "b1") (Cr_Var "acc"))))
+    )
 
-poly stepBinLiteralCore = \bit : U8 => \acc : Core =>
-  if [Core] (eqU8 bit #u8(0))
-    (\u : U8 => Cr_App binZeroCtorCore acc)
-    (\u : U8 => Cr_App binOneCtorCore acc)
+poly stepBinLiteralCore =
+  \bit : U8 =>
+    \acc : Core =>
+      if [Core] (eqU8 bit #u8(0))
+        (\u : U8 => Cr_App binZeroCtorCore acc)
+        (\u : U8 => Cr_App binOneCtorCore acc)
 
-poly rec buildBinLiteralCoreAcc = \bits : List U8 => \acc : Core =>
-  matchList [U8] [Core] bits acc
-    (\h : U8 => \t : List U8 =>
-      buildBinLiteralCoreAcc t (stepBinLiteralCore h acc))
+poly rec buildBinLiteralCoreAcc =
+  \bits : List U8 =>
+    \acc : Core =>
+      matchList
+        [U8]
+        [Core]
+        bits
+        acc
+        (
+          \h : U8 =>
+            \t : List U8 => buildBinLiteralCoreAcc t (stepBinLiteralCore h acc)
+        )
 
-poly buildBinLiteralCore = \digits : List U8 =>
-  buildBinLiteralCoreAcc (collectBits digits (nil [U8])) binZeroCore
+poly buildBinLiteralCore =
+  \digits : List U8 =>
+    buildBinLiteralCoreAcc (collectBits digits (nil [U8])) binZeroCore
 
-poly natToCore = \digits : List U8 =>
-  let trimmed = trimLeadingZeros digits in
-  matchList [U8] [Result (List U8) Core] trimmed
-    (Ok [List U8] [Core] (Cr_Native (T_Byte #u8(0))))
-    (\h : U8 => \t : List U8 =>
-      if [Result (List U8) Core] (isByteDigits trimmed)
-        (\u : U8 => Ok [List U8] [Core] (Cr_Native (T_Byte (parseByteDigits trimmed))))
-        (\u : U8 => Ok [List U8] [Core] (buildBinLiteralCore trimmed)))
-
+poly natToCore =
+  \digits : List U8 =>
+    let trimmed = trimLeadingZeros digits in
+    matchList
+      [U8]
+      [Result (List U8) Core]
+      trimmed
+      (Ok [List U8] [Core] (Cr_Native (T_Byte #u8(0))))
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [Result (List U8) Core] (isByteDigits trimmed)
+              (
+                \u : U8 =>
+                  Ok
+                    [List U8]
+                    [Core]
+                    (Cr_Native (T_Byte (parseByteDigits trimmed)))
+              )
+              (\u : U8 => Ok [List U8] [Core] (buildBinLiteralCore trimmed))
+      )
 
 poly zLower =
   let delayed = L_Lam (L_App (L_App (L_Var #u8(1)) (L_Var #u8(1))) (L_Var #u8(0))) in
   let inner = L_Lam (L_App (L_Var #u8(1)) delayed) in
   L_Lam (L_App inner inner)
 
-poly applyFixpoint = \body : Lower =>
-  L_App zLower (L_Lam body)
+poly applyFixpoint =
+  \body : Lower => L_App zLower (L_Lam body)
 
-poly resolveCoreName = \dEnv : DataEnv => \name : List U8 =>
-  match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Core] {
-    | Some info => Cr_Ctor (ctorTag info) (ctorTotal info) (ctorArity info)
-    | None => Cr_Var name
-  }
+poly resolveCoreName =
+  \dEnv : DataEnv =>
+    \name : List U8 =>
+      match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Core] {
+        | Some info =>
+          Cr_Ctor (ctorTag info) (ctorTotal info) (ctorArity info)
+        | None => Cr_Var name
+      }
 
-poly rec findCtorInfoInArms = \dEnv : DataEnv => \arms : List (Pair Pattern Expr) =>
-  matchList [Pair Pattern Expr] [Maybe CtorInfo] arms
-    (None [CtorInfo])
-    (\h : Pair Pattern Expr => \t : List (Pair Pattern Expr) =>
-      match (fst [Pattern] [Expr] h) [Maybe CtorInfo] { | P_Ctor name args =>
-        match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Maybe CtorInfo] {
-          | Some info => Some [CtorInfo] info
-          | None => findCtorInfoInArms dEnv t
-        }
-      })
-
-poly rec findArmByName = \name : List U8 => \arms : List (Pair Pattern Expr) =>
-  matchList [Pair Pattern Expr] [Pair Pattern Expr] arms
-    (MkPair [Pattern] [Expr] (P_Ctor name (nil [List U8])) (E_Var "MISSING_ARM"))
-    (\h : Pair Pattern Expr => \t : List (Pair Pattern Expr) =>
-      match (fst [Pattern] [Expr] h) [Pair Pattern Expr] { | P_Ctor cName args =>
-        if [Pair Pattern Expr] (eqListU8 name cName)
-          (\u : U8 => h)
-          (\u : U8 => findArmByName name t)
-      })
-
-poly rec sortArms = \expectedNames : List (List U8) => \arms : List (Pair Pattern Expr) =>
-  matchList [List U8] [List (Pair Pattern Expr)] expectedNames
-    (nil [Pair Pattern Expr])
-    (\name : List U8 => \tNames : List (List U8) =>
-      let arm = findArmByName name arms in
-      cons [Pair Pattern Expr] arm (sortArms tNames arms))
-
-poly rec wrapInLambdas = \args : List (List U8) => \body : Core =>
-  matchList [List U8] [Core] args
-    body
-    (\h : List U8 => \t : List (List U8) =>
-      Cr_Lam h (wrapInLambdas t body))
-
-poly rec prependAll = #A => \items : List A => \acc : List A =>
-  matchList [A] [List A] items acc (\h : A => \t : List A => prependAll [A] t (cons [A] h acc))
-
-poly rec elaborateArms = \elaborate : DataEnv -> Expr -> Result (List U8) Core => \dEnv : DataEnv => \arms : List (Pair Pattern Expr) =>
-  matchList [Pair Pattern Expr] [Result (List U8) (List Core)] arms
-    (Ok [List U8] [List Core] (nil [Core]))
-    (\h : Pair Pattern Expr => \t : List (Pair Pattern Expr) =>
-      match h [Result (List U8) (List Core)] { | MkPair pat body =>
-        match pat [Result (List U8) (List Core)] { | P_Ctor name args =>
-          match (elaborate dEnv body) [Result (List U8) (List Core)] {
-            | Err e => Err [List U8] [List Core] e
-            | Ok coreBody =>
-                let wrapped = wrapInLambdas args coreBody in
-                match (elaborateArms elaborate dEnv t) [Result (List U8) (List Core)] {
-                  | Err e => Err [List U8] [List Core] e
-                  | Ok rest => Ok [List U8] [List Core] (cons [Core] wrapped rest)
-                }
-          }
-        }
-      })
-
-poly elaborateMatchWith = \elaborate : DataEnv -> Expr -> Result (List U8) Core => \dEnv : DataEnv => \scrut : Expr => \arms : List (Pair Pattern Expr) =>
-  match (elaborate dEnv scrut) [Result (List U8) Core] {
-    | Err e => Err [List U8] [Core] e
-    | Ok coreScrut =>
-        match (findCtorInfoInArms dEnv arms) [Result (List U8) Core] {
-          | None => Err [List U8] [Core] "Could not identify ADT for match"
-          | Some info =>
-              let adtName = ctorAdtName info in
-              match (lookup [List U8] [ADTInfo] lteListU8 adtName (datEnvAdts dEnv)) [Result (List U8) Core] {
-                | None => Err [List U8] [Core] "ADT metadata not found"
-                | Some adtInfo =>
-                    let expectedNames = adtCtors adtInfo in
-                    let sortedArms = sortArms expectedNames arms in
-                    match (elaborateArms elaborate dEnv sortedArms) [Result (List U8) Core] {
-                      | Err e => Err [List U8] [Core] e
-                      | Ok coreArms => Ok [List U8] [Core] (Cr_Match coreScrut coreArms)
-                    }
+poly rec findCtorInfoInArms =
+  \dEnv : DataEnv =>
+    \arms : List (Pair Pattern Expr) =>
+      matchList
+        [Pair Pattern Expr]
+        [Maybe CtorInfo]
+        arms
+        (None [CtorInfo])
+        (
+          \h : Pair Pattern Expr =>
+            \t : List (Pair Pattern Expr) =>
+              match (fst [Pattern] [Expr] h) [Maybe CtorInfo] {
+                | P_Ctor name args =>
+                  match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Maybe CtorInfo] {
+                    | Some info => Some [CtorInfo] info
+                    | None => findCtorInfoInArms dEnv t
+                  }
               }
-        }
-  }
+        )
 
-poly rec elaborateExpr = \dEnv : DataEnv => \expr : Expr =>
-  match expr [Result (List U8) Core] {
-    | E_Var name => Ok [List U8] [Core] (resolveCoreName dEnv name)
-    | E_App l r =>
-        match (elaborateExpr dEnv l) [Result (List U8) Core] {
-          | Err e => Err [List U8] [Core] e
-          | Ok left =>
+poly rec findArmByName =
+  \name : List U8 =>
+    \arms : List (Pair Pattern Expr) =>
+      matchList
+        [Pair Pattern Expr]
+        [Pair Pattern Expr]
+        arms
+        (
+          MkPair
+            [Pattern]
+            [Expr]
+            (P_Ctor name (nil [List U8]))
+            (E_Var "MISSING_ARM")
+        )
+        (
+          \h : Pair Pattern Expr =>
+            \t : List (Pair Pattern Expr) =>
+              match (fst [Pattern] [Expr] h) [Pair Pattern Expr] {
+                | P_Ctor cName args =>
+                  if [Pair Pattern Expr] (eqListU8 name cName)
+                    (\u : U8 => h)
+                    (\u : U8 => findArmByName name t)
+              }
+        )
+
+poly rec sortArms =
+  \expectedNames : List (List U8) =>
+    \arms : List (Pair Pattern Expr) =>
+      matchList
+        [List U8]
+        [List (Pair Pattern Expr)]
+        expectedNames
+        (nil [Pair Pattern Expr])
+        (
+          \name : List U8 =>
+            \tNames : List (List U8) =>
+              let arm = findArmByName name arms in
+              cons [Pair Pattern Expr] arm (sortArms tNames arms)
+        )
+
+poly rec wrapInLambdas =
+  \args : List (List U8) =>
+    \body : Core =>
+      matchList
+        [List U8]
+        [Core]
+        args
+        body
+        (\h : List U8 => \t : List (List U8) => Cr_Lam h (wrapInLambdas t body))
+
+poly rec prependAll =
+  #A =>
+    \items : List A =>
+      \acc : List A =>
+        matchList
+          [A]
+          [List A]
+          items
+          acc
+          (\h : A => \t : List A => prependAll [A] t (cons [A] h acc))
+
+poly rec elaborateArms =
+  \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
+    \dEnv : DataEnv =>
+      \arms : List (Pair Pattern Expr) =>
+        matchList
+          [Pair Pattern Expr]
+          [Result (List U8) (List Core)]
+          arms
+          (Ok [List U8] [List Core] (nil [Core]))
+          (
+            \h : Pair Pattern Expr =>
+              \t : List (Pair Pattern Expr) =>
+                match h [Result (List U8) (List Core)] {
+                  | MkPair pat body =>
+                    match pat [Result (List U8) (List Core)] {
+                      | P_Ctor name args =>
+                        match (elaborate dEnv body) [Result (List U8) (List Core)] {
+                          | Err e => Err [List U8] [List Core] e
+                          | Ok coreBody =>
+                            let wrapped = wrapInLambdas args coreBody in
+                            match (elaborateArms elaborate dEnv t) [Result (List U8) (List Core)] {
+                              | Err e => Err [List U8] [List Core] e
+                              | Ok rest =>
+                                Ok
+                                  [List U8]
+                                  [List Core]
+                                  (cons [Core] wrapped rest)
+                            }
+                        }
+                    }
+                }
+          )
+
+poly elaborateMatchWith =
+  \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
+    \dEnv : DataEnv =>
+      \scrut : Expr =>
+        \arms : List (Pair Pattern Expr) =>
+          match (elaborate dEnv scrut) [Result (List U8) Core] {
+            | Err e => Err [List U8] [Core] e
+            | Ok coreScrut =>
+              match (findCtorInfoInArms dEnv arms) [Result (List U8) Core] {
+                | None =>
+                  Err [List U8] [Core] "Could not identify ADT for match"
+                | Some info =>
+                  let adtName = ctorAdtName info in
+                  match (lookup [List U8] [ADTInfo] lteListU8 adtName (datEnvAdts dEnv)) [Result (List U8) Core] {
+                    | None => Err [List U8] [Core] "ADT metadata not found"
+                    | Some adtInfo =>
+                      let expectedNames = adtCtors adtInfo in
+                      let sortedArms = sortArms expectedNames arms in
+                      match (elaborateArms elaborate dEnv sortedArms) [Result (List U8) Core] {
+                        | Err e => Err [List U8] [Core] e
+                        | Ok coreArms => Ok [List U8] [Core] (Cr_Match coreScrut coreArms)
+                      }
+                  }
+              }
+          }
+
+poly rec elaborateExpr =
+  \dEnv : DataEnv =>
+    \expr : Expr =>
+      match expr [Result (List U8) Core] {
+        | E_Var name => Ok [List U8] [Core] (resolveCoreName dEnv name)
+        | E_App l r =>
+          match (elaborateExpr dEnv l) [Result (List U8) Core] {
+            | Err e => Err [List U8] [Core] e
+            | Ok left =>
               match (elaborateExpr dEnv r) [Result (List U8) Core] {
                 | Err e => Err [List U8] [Core] e
                 | Ok right => Ok [List U8] [Core] (Cr_App left right)
               }
-        }
-    | E_Lam name body =>
-        match (elaborateExpr dEnv body) [Result (List U8) Core] {
-          | Err e => Err [List U8] [Core] e
-          | Ok coreBody => Ok [List U8] [Core] (Cr_Lam name coreBody)
-        }
-    | E_Let name val body =>
-        match (elaborateExpr dEnv val) [Result (List U8) Core] {
-          | Err e => Err [List U8] [Core] e
-          | Ok coreVal =>
+          }
+        | E_Lam name body =>
+          match (elaborateExpr dEnv body) [Result (List U8) Core] {
+            | Err e => Err [List U8] [Core] e
+            | Ok coreBody => Ok [List U8] [Core] (Cr_Lam name coreBody)
+          }
+        | E_Let name val body =>
+          match (elaborateExpr dEnv val) [Result (List U8) Core] {
+            | Err e => Err [List U8] [Core] e
+            | Ok coreVal =>
               match (elaborateExpr dEnv body) [Result (List U8) Core] {
                 | Err e => Err [List U8] [Core] e
-                | Ok coreBody => Ok [List U8] [Core] (Cr_App (Cr_Lam name coreBody) coreVal)
+                | Ok coreBody =>
+                  Ok [List U8] [Core] (Cr_App (Cr_Lam name coreBody) coreVal)
               }
-        }
-    | E_Nat digits => natToCore digits
-    | E_Match scrut arms =>
-        elaborateMatchWith elaborateExpr dEnv scrut arms
-  }
+          }
+        | E_Nat digits => natToCore digits
+        | E_Match scrut arms => elaborateMatchWith elaborateExpr dEnv scrut arms
+      }
 
-data State = MkState (Avl (List U8) Lower) DataEnv
+data State =
+  | MkState (Avl (List U8) Lower) DataEnv
 
-poly ctorCountOverflowError = "Data declaration has more than 255 constructors"
+poly ctorCountOverflowError =
+  "Data declaration has more than 255 constructors"
 
-poly rec checkedLengthU8 = #A => \l : List A => \acc : U8 =>
-  matchList [A] [Result (List U8) U8] l
-    (Ok [List U8] [U8] acc)
-    (\h : A => \t : List A =>
-      if [Result (List U8) U8] (ltU8 acc #u8(255))
-        (\u : U8 => checkedLengthU8 [A] t (addU8 acc #u8(1)))
-        (\u : U8 => Err [List U8] [U8] ctorCountOverflowError))
+poly rec checkedLengthU8 =
+  #A =>
+    \l : List A =>
+      \acc : U8 =>
+        matchList
+          [A]
+          [Result (List U8) U8]
+          l
+          (Ok [List U8] [U8] acc)
+          (
+            \h : A =>
+              \t : List A =>
+                if [Result (List U8) U8] (ltU8 acc #u8(255))
+                  (\u : U8 => checkedLengthU8 [A] t (addU8 acc #u8(1)))
+                  (\u : U8 => Err [List U8] [U8] ctorCountOverflowError)
+          )
 
-poly rec populateDataEnv = \adtName : List U8 => \ctors : List (Pair (List U8) U8) => \total : U8 => \idx : U8 => \datEnv : DataEnv =>
-  matchList [Pair (List U8) U8] [DataEnv] ctors
-    datEnv
-    (\h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) =>
-      let ctorName = fst [List U8] [U8] h in
-      let arity = snd [List U8] [U8] h in
-      let info = MkCtorInfo idx total arity adtName in
-      match datEnv [DataEnv] { | MkDataEnv cEnv aEnv =>
-        let nextDatEnv = MkDataEnv (insert [List U8] [CtorInfo] lteListU8 ctorName info cEnv) aEnv in
-        populateDataEnv adtName t total (addU8 idx #u8(1)) nextDatEnv
-      })
+poly rec populateDataEnv =
+  \adtName : List U8 =>
+    \ctors : List (Pair (List U8) U8) =>
+      \total : U8 =>
+        \idx : U8 =>
+          \datEnv : DataEnv =>
+            matchList
+              [Pair (List U8) U8]
+              [DataEnv]
+              ctors
+              datEnv
+              (
+                \h : Pair (List U8) U8 =>
+                  \t : List (Pair (List U8) U8) =>
+                    let ctorName = fst [List U8] [U8] h in
+                    let arity = snd [List U8] [U8] h in
+                    let info = MkCtorInfo idx total arity adtName in
+                    match datEnv [DataEnv] {
+                      | MkDataEnv cEnv aEnv =>
+                        let nextDatEnv = MkDataEnv (insert [List U8] [CtorInfo] lteListU8 ctorName info cEnv) aEnv in
+                        populateDataEnv
+                          adtName
+                          t
+                          total
+                          (addU8 idx #u8(1))
+                          nextDatEnv
+                    }
+              )
 
-poly rec getCtorNames = \ctors : List (Pair (List U8) U8) =>
-  matchList [Pair (List U8) U8] [List (List U8)] ctors
-    (nil [List U8])
-    (\h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) =>
-      cons [List U8] (fst [List U8] [U8] h) (getCtorNames t))
+poly rec getCtorNames =
+  \ctors : List (Pair (List U8) U8) =>
+    matchList
+      [Pair (List U8) U8]
+      [List (List U8)]
+      ctors
+      (nil [List U8])
+      (
+        \h : Pair (List U8) U8 =>
+          \t : List (Pair (List U8) U8) => cons [List U8] (fst [List U8] [U8] h) (getCtorNames t)
+      )
 
-poly rec filterElaboratableDecls = \decls : List Decl =>
-  matchList [Decl] [List Decl] decls
-    (nil [Decl])
-    (\h : Decl => \t : List Decl =>
-      match h [List Decl] {
-        | D_Def kind isRec name body =>
-            cons [Decl] h (filterElaboratableDecls t)
-        | D_Data name ctors =>
-            cons [Decl] h (filterElaboratableDecls t)
-        | D_Module name => filterElaboratableDecls t
-        | D_Import mod sym => filterElaboratableDecls t
-        | D_Export sym => filterElaboratableDecls t
-        | D_Opaque name => filterElaboratableDecls t
-        | D_Native name => filterElaboratableDecls t
-        | D_Type name => filterElaboratableDecls t
-      })
-
-poly elaborateElaboratableDecl = \state : State => \decl : Decl =>
-  match state [Result (List U8) State] { | MkState globals dEnv =>
-  match decl [Result (List U8) State] {
-    | D_Def kind isRec name body =>
-        let recName = if [Maybe (List U8)] isRec (Some [List U8] name) (None [List U8]) in
-        match (elaborateExpr dEnv body) [Result (List U8) State] {
-          | Err e => Err [List U8] [State] e
-          | Ok core =>
-              let finalLow = if [Lower] isRec
-                (\u : U8 => applyFixpoint (coreToLower globals (nil [List U8]) recName core))
-                (\u : U8 => coreToLower globals (nil [List U8]) recName core) in
-              Ok [List U8] [State] (MkState (insert [List U8] [Lower] lteListU8 name finalLow globals) dEnv)
-        }
-    | D_Data name ctors =>
-        match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) State] {
-          | Err e => Err [List U8] [State] e
-          | Ok total =>
-              let nextDEnv = populateDataEnv name ctors total #u8(0) dEnv in
-              match nextDEnv [Result (List U8) State] { | MkDataEnv cEnv aEnv =>
-                let adtInfo = MkADTInfo (getCtorNames ctors) in
-                let finalDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv) in
-                Ok [List U8] [State] (MkState globals finalDEnv)
-              }
-        }
-    | D_Module name => Ok [List U8] [State] state
-    | D_Import mod sym => Ok [List U8] [State] state
-    | D_Export sym => Ok [List U8] [State] state
-    | D_Opaque name => Ok [List U8] [State] state
-    | D_Native name => Ok [List U8] [State] state
-    | D_Type name => Ok [List U8] [State] state
-  }}
-
-poly rec elaborateProgramRec = \state : State => \decls : List Decl =>
-  matchList [Decl] [Result (List U8) (Avl (List U8) Lower)] decls
-    (match state [Result (List U8) (Avl (List U8) Lower)] { | MkState globals dEnv => Ok [List U8] [Avl (List U8) Lower] globals })
-    (\h : Decl => \t : List Decl =>
-      match (elaborateElaboratableDecl state h) [Result (List U8) State] {
-        | Err e => Err [List U8] [Avl (List U8) Lower] e
-        | Ok nextState => elaborateProgramRec nextState t
-      })
-
-poly elaborateProgram = \globals : Avl (List U8) Lower => \decls : List Decl =>
-  let initialState = MkState globals (MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo])) in
-  elaborateProgramRec initialState (filterElaboratableDecls decls)
-
-poly rec elaborateToCoreRec = \dEnv : DataEnv => \decls : List Decl =>
-  matchList [Decl] [Result (List U8) (List (Pair (List U8) Core))] decls
-    (Ok [List U8] [List (Pair (List U8) Core)] (nil [Pair (List U8) Core]))
-    (\h : Decl => \t : List Decl =>
-      match h [Result (List U8) (List (Pair (List U8) Core))] {
-        | D_Def kind isRec name body =>
-            match (elaborateExpr dEnv body) [Result (List U8) (List (Pair (List U8) Core))] {
-              | Err e => Err [List U8] [List (Pair (List U8) Core)] e
-              | Ok core =>
-                  match (elaborateToCoreRec dEnv t) [Result (List U8) (List (Pair (List U8) Core))] {
-                    | Err e2 => Err [List U8] [List (Pair (List U8) Core)] e2
-                    | Ok rest =>
-                        Ok [List U8] [List (Pair (List U8) Core)]
-                          (cons [Pair (List U8) Core] (MkPair [List U8] [Core] name core) rest)
-                  }
+poly rec filterElaboratableDecls =
+  \decls : List Decl =>
+    matchList
+      [Decl]
+      [List Decl]
+      decls
+      (nil [Decl])
+      (
+        \h : Decl =>
+          \t : List Decl =>
+            match h [List Decl] {
+              | D_Def kind isRec name body => cons [Decl] h (filterElaboratableDecls t)
+              | D_Data name ctors => cons [Decl] h (filterElaboratableDecls t)
+              | D_Module name => filterElaboratableDecls t
+              | D_Import mod sym => filterElaboratableDecls t
+              | D_Export sym => filterElaboratableDecls t
+              | D_Opaque name => filterElaboratableDecls t
+              | D_Native name => filterElaboratableDecls t
+              | D_Type name => filterElaboratableDecls t
             }
-        | D_Data name ctors =>
-            match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) (List (Pair (List U8) Core))] {
-              | Err e => Err [List U8] [List (Pair (List U8) Core)] e
-              | Ok total =>
-                  match (populateDataEnv name ctors total #u8(0) dEnv) [Result (List U8) (List (Pair (List U8) Core))] {
+      )
+
+poly elaborateElaboratableDecl =
+  \state : State =>
+    \decl : Decl =>
+      match state [Result (List U8) State] {
+        | MkState globals dEnv =>
+          match decl [Result (List U8) State] {
+            | D_Def kind isRec name body =>
+              let recName = if [Maybe (List U8)] isRec (Some [List U8] name) (None [List U8]) in
+              match (elaborateExpr dEnv body) [Result (List U8) State] {
+                | Err e => Err [List U8] [State] e
+                | Ok core =>
+                  let finalLow = if [Lower] isRec (\u : U8 => applyFixpoint (coreToLower globals (nil [List U8]) recName core)) (\u : U8 => coreToLower globals (nil [List U8]) recName core) in
+                  Ok
+                    [List U8]
+                    [State]
+                    (
+                      MkState
+                        (
+                          insert
+                            [List U8]
+                            [Lower]
+                            lteListU8
+                            name
+                            finalLow
+                            globals
+                        )
+                        dEnv
+                    )
+              }
+            | D_Data name ctors =>
+              match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) State] {
+                | Err e => Err [List U8] [State] e
+                | Ok total =>
+                  let nextDEnv = populateDataEnv name ctors total #u8(0) dEnv in
+                  match nextDEnv [Result (List U8) State] {
                     | MkDataEnv cEnv aEnv =>
-                        let adtInfo = MkADTInfo (getCtorNames ctors) in
-                        let nextDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv) in
-                        elaborateToCoreRec nextDEnv t
+                      let adtInfo = MkADTInfo (getCtorNames ctors) in
+                      let finalDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv) in
+                      Ok [List U8] [State] (MkState globals finalDEnv)
                   }
-            }
-        | D_Module name => elaborateToCoreRec dEnv t
-        | D_Import mod sym => elaborateToCoreRec dEnv t
-        | D_Export sym => elaborateToCoreRec dEnv t
-        | D_Opaque name => elaborateToCoreRec dEnv t
-        | D_Native name => elaborateToCoreRec dEnv t
-        | D_Type name => elaborateToCoreRec dEnv t
-      })
+              }
+            | D_Module name => Ok [List U8] [State] state
+            | D_Import mod sym => Ok [List U8] [State] state
+            | D_Export sym => Ok [List U8] [State] state
+            | D_Opaque name => Ok [List U8] [State] state
+            | D_Native name => Ok [List U8] [State] state
+            | D_Type name => Ok [List U8] [State] state
+          }
+      }
 
-poly elaborateProgramToCore = \decls : List Decl =>
-  elaborateToCoreRec
-    (MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo]))
-    (filterElaboratableDecls decls)
+poly rec elaborateProgramRec =
+  \state : State =>
+    \decls : List Decl =>
+      matchList
+        [Decl]
+        [Result (List U8) (Avl (List U8) Lower)]
+        decls
+        (
+          match state [Result (List U8) (Avl (List U8) Lower)] {
+            | MkState globals dEnv => Ok [List U8] [Avl (List U8) Lower] globals
+          }
+        )
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match (elaborateElaboratableDecl state h) [Result (List U8) State] {
+                | Err e => Err [List U8] [Avl (List U8) Lower] e
+                | Ok nextState => elaborateProgramRec nextState t
+              }
+        )
+
+poly elaborateProgram =
+  \globals : Avl (List U8) Lower =>
+    \decls : List Decl =>
+      let initialState = MkState globals (MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo])) in
+      elaborateProgramRec initialState (filterElaboratableDecls decls)
+
+poly rec elaborateToCoreRec =
+  \dEnv : DataEnv =>
+    \decls : List Decl =>
+      matchList
+        [Decl]
+        [Result (List U8) (List (Pair (List U8) Core))]
+        decls
+        (Ok [List U8] [List (Pair (List U8) Core)] (nil [Pair (List U8) Core]))
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Result (List U8) (List (Pair (List U8) Core))] {
+                | D_Def kind isRec name body =>
+                  match (elaborateExpr dEnv body) [Result (List U8) (List (Pair (List U8) Core))] {
+                    | Err e => Err [List U8] [List (Pair (List U8) Core)] e
+                    | Ok core =>
+                      match (elaborateToCoreRec dEnv t) [Result (List U8) (List (Pair (List U8) Core))] {
+                        | Err e2 => Err [List U8] [List (Pair (List U8) Core)] e2
+                        | Ok rest =>
+                          Ok
+                            [List U8]
+                            [List (Pair (List U8) Core)]
+                            (
+                              cons
+                                [Pair (List U8) Core]
+                                (MkPair [List U8] [Core] name core)
+                                rest
+                            )
+                      }
+                  }
+                | D_Data name ctors =>
+                  match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) (List (Pair (List U8) Core))] {
+                    | Err e => Err [List U8] [List (Pair (List U8) Core)] e
+                    | Ok total =>
+                      match (populateDataEnv name ctors total #u8(0) dEnv) [Result (List U8) (List (Pair (List U8) Core))] {
+                        | MkDataEnv cEnv aEnv =>
+                          let adtInfo = MkADTInfo (getCtorNames ctors) in
+                          let nextDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv) in
+                          elaborateToCoreRec nextDEnv t
+                      }
+                  }
+                | D_Module name => elaborateToCoreRec dEnv t
+                | D_Import mod sym => elaborateToCoreRec dEnv t
+                | D_Export sym => elaborateToCoreRec dEnv t
+                | D_Opaque name => elaborateToCoreRec dEnv t
+                | D_Native name => elaborateToCoreRec dEnv t
+                | D_Type name => elaborateToCoreRec dEnv t
+              }
+        )
+
+poly elaborateProgramToCore =
+  \decls : List Decl =>
+    elaborateToCoreRec
+      (MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo]))
+      (filterElaboratableDecls decls)

--- a/bootstrap/src/bundleInventory.trip
+++ b/bootstrap/src/bundleInventory.trip
@@ -1,375 +1,843 @@
 module BundleInventory
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude and
+
 import Prelude or
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude eqListU8
+
 import Prelude ltListU8
+
 import Prelude lteListU8
+
 import Prelude digitToAscii
+
 import Prelude singletonU8
+
 import Prelude u8ToDigits
+
 import Prelude writeOne
+
 import BundleSummary parseBundleSummary
+
 import BundleSummary BundleSummary
+
 import BundleSummary MkBundleSummary
+
 import BundleSummary ModuleRecord
+
 import BundleSummary MkModuleRecord
+
 import Lexer tokenize
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
+
 import Parser DefKind
+
 import Parser K_Poly
+
 import Parser K_Combinator
+
 import Parser parseProgram
 
 export main
 
-poly rec lookupMod = \key : List U8 => \table : List (Pair (List U8) (List Decl)) =>
-  matchList [(Pair (List U8) (List Decl))] [Maybe (List Decl)] table
-    (None [List Decl])
-    (\h : (Pair (List U8) (List Decl)) => \t : List (Pair (List U8) (List Decl)) =>
-      if [Maybe (List Decl)] (eqListU8 (fst [List U8] [List Decl] h) key)
-        (\u : U8 => Some [List Decl] (snd [List U8] [List Decl] h))
-        (\u : U8 => lookupMod key t))
+poly rec lookupMod =
+  \key : List U8 =>
+    \table : List (Pair (List U8) (List Decl)) =>
+      matchList
+        [(Pair (List U8) (List Decl))]
+        [Maybe (List Decl)]
+        table
+        (None [List Decl])
+        (
+          \h : (Pair (List U8) (List Decl)) =>
+            \t : List (Pair (List U8) (List Decl)) =>
+              if [Maybe (List Decl)] (eqListU8 (fst [List U8] [List Decl] h) key)
+                (\u : U8 => Some [List Decl] (snd [List U8] [List Decl] h))
+                (\u : U8 => lookupMod key t)
+        )
 
-poly rec lookupExp = \key : List U8 => \table : List (Pair (List U8) (List (List U8))) =>
-  matchList [(Pair (List U8) (List (List U8)))] [Maybe (List (List U8))] table
-    (None [List (List U8)])
-    (\h : (Pair (List U8) (List (List U8))) => \t : List (Pair (List U8) (List (List U8))) =>
-      if [Maybe (List (List U8))] (eqListU8 (fst [List U8] [List (List U8)] h) key)
-        (\u : U8 => Some [List (List U8)] (snd [List U8] [List (List U8)] h))
-        (\u : U8 => lookupExp key t))
+poly rec lookupExp =
+  \key : List U8 =>
+    \table : List (Pair (List U8) (List (List U8))) =>
+      matchList
+        [(Pair (List U8) (List (List U8)))]
+        [Maybe (List (List U8))]
+        table
+        (None [List (List U8)])
+        (
+          \h : (Pair (List U8) (List (List U8))) =>
+            \t : List (Pair (List U8) (List (List U8))) =>
+              if [Maybe (List (List U8))] (eqListU8 (fst [List U8] [List (List U8)] h) key)
+                (
+                  \u : U8 => Some [List (List U8)] (snd [List U8] [List (List U8)] h)
+                )
+                (\u : U8 => lookupExp key t)
+        )
 
-poly rec removeExpEntry = \k : List U8 => \tbl : List (Pair (List U8) (List (List U8))) =>
-  matchList [(Pair (List U8) (List (List U8)))] [List (Pair (List U8) (List (List U8)))] tbl
-    (nil [(Pair (List U8) (List (List U8)))])
-    (\hh : (Pair (List U8) (List (List U8))) => \tt : List (Pair (List U8) (List (List U8))) =>
-      if [List (Pair (List U8) (List (List U8)))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
-        (\u : U8 => tt)
-        (\u : U8 => cons [(Pair (List U8) (List (List U8)))] hh (removeExpEntry k tt)))
+poly rec removeExpEntry =
+  \k : List U8 =>
+    \tbl : List (Pair (List U8) (List (List U8))) =>
+      matchList
+        [(Pair (List U8) (List (List U8)))]
+        [List (Pair (List U8) (List (List U8)))]
+        tbl
+        (nil [(Pair (List U8) (List (List U8)))])
+        (
+          \hh : (Pair (List U8) (List (List U8))) =>
+            \tt : List (Pair (List U8) (List (List U8))) =>
+              if [List (Pair (List U8) (List (List U8)))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
+                (\u : U8 => tt)
+                (
+                  \u : U8 =>
+                    cons
+                      [(Pair (List U8) (List (List U8)))]
+                      hh
+                      (removeExpEntry k tt)
+                )
+        )
 
-poly rec updateGlobalTable = \exports : List (List U8) => \modName : List U8 => \table : List (Pair (List U8) (List (List U8))) =>
-  matchList [List U8] [List (Pair (List U8) (List (List U8)))] exports
-    table
-    (\h : List U8 => \t : List (List U8) =>
-      let current = lookupExp h table in
-      let nextList = 
-        match current [List (List U8)] {
-          | None => cons [List U8] modName (nil [List U8])
-          | Some mods => append [List U8] mods (cons [List U8] modName (nil [List U8]))
-        } in
-      let nextTable = cons [(Pair (List U8) (List (List U8)))] (MkPair [List U8] [List (List U8)] h nextList) (removeExpEntry h table) in
-      updateGlobalTable t modName nextTable)
+poly rec updateGlobalTable =
+  \exports : List (List U8) =>
+    \modName : List U8 =>
+      \table : List (Pair (List U8) (List (List U8))) =>
+        matchList
+          [List U8]
+          [List (Pair (List U8) (List (List U8)))]
+          exports
+          table
+          (
+            \h : List U8 =>
+              \t : List (List U8) =>
+                let current = lookupExp h table in
+                let nextList = match current [List (List U8)] {| None => cons [List U8] modName (nil [List U8]) | Some mods => append [List U8] mods (cons [List U8] modName (nil [List U8]))} in
+                let nextTable = cons [(Pair (List U8) (List (List U8)))] (MkPair [List U8] [List (List U8)] h nextList) (removeExpEntry h table) in
+                updateGlobalTable t modName nextTable
+          )
 
-poly rec collectModuleExports = \decls : List Decl => \acc : List (List U8) =>
-  matchList [Decl] [List (List U8)] decls (reverse [List U8] acc)
-    (\h : Decl => \t : List Decl =>
-      match h [List (List U8)] {
-        | D_Export name => collectModuleExports t (cons [List U8] name acc)
-        | D_Module n => collectModuleExports t acc
-        | D_Import f s => collectModuleExports t acc
-        | D_Opaque n => collectModuleExports t acc
-        | D_Native n => collectModuleExports t acc
-        | D_Type n => collectModuleExports t acc
-        | D_Data n cs => collectModuleExports t acc
-        | D_Def k r n e => collectModuleExports t acc
-      })
-
-poly rec populateInventoryAcc = \mods : List ModuleRecord => \modTable : List (Pair (List U8) (List Decl)) => \expTable : List (Pair (List U8) (List (List U8))) =>
-  matchList [ModuleRecord] [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] mods
-    (Ok [List U8] [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))] 
-       (MkPair [List (Pair (List U8) (List Decl))] [List (Pair (List U8) (List (List U8)))] modTable expTable))
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-       match h [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] { | MkModuleRecord name _ source =>
-         match (tokenize source) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
-           | Err e => Err [List U8] [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))] "Parse error"
-           | Ok toks =>
-             match (parseProgram toks) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
-               | Err e => Err [List U8] [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))] "Parse error"
-               | Ok decls =>
-                 let exports = collectModuleExports decls (nil [List U8]) in
-                 populateInventoryAcc t 
-                   (append [(Pair (List U8) (List Decl))] modTable (cons [(Pair (List U8) (List Decl))] (MkPair [List U8] [List Decl] name decls) (nil [(Pair (List U8) (List Decl))])))
-                   (updateGlobalTable exports name expTable)
-             }
-         }
-       })
-
-poly populateInventory = \mods : List ModuleRecord => \modTable : List (Pair (List U8) (List Decl)) => \expTable : List (Pair (List U8) (List (List U8))) =>
-  populateInventoryAcc mods modTable expTable
-
-poly rec symbolInList = \symbolName : List U8 => \exps : List (List U8) =>
-  matchList [List U8] [Bool] exps false
-    (\h : List U8 => \t : List (List U8) =>
-      if [Bool] (eqListU8 h symbolName)
-        (\u : U8 => true)
-        (\u : U8 => symbolInList symbolName t))
-
-poly isExported = \modName : List U8 => \symbolName : List U8 => \modTable : List (Pair (List U8) (List Decl)) =>
-  match (lookupMod modName modTable) [Bool] {
-    | None => false
-    | Some decls => 
-        let exports = collectModuleExports decls (nil [List U8]) in
-        symbolInList symbolName exports
-  }
-
-poly rec ctorNameInList = \name : List U8 => \cs : List (Pair (List U8) U8) =>
-  matchList [(Pair (List U8) U8)] [Bool] cs false
-    (\h : (Pair (List U8) U8) => \t : List (Pair (List U8) U8) =>
-      if [Bool] (eqListU8 (fst [List U8] [U8] h) name)
-        (\u : U8 => true)
-        (\u : U8 => ctorNameInList name t))
-
-poly rec isDefined = \symbolName : List U8 => \decls : List Decl =>
-  matchList [Decl] [Bool] decls false
-    (\h : Decl => \t : List Decl =>
-      let isMatch = 
-        match h [Bool] {
-          | D_Def k r n e => eqListU8 n symbolName
-          | D_Data n cs => or (eqListU8 n symbolName) (ctorNameInList symbolName cs)
-          | D_Type n => eqListU8 n symbolName
-          | D_Opaque n => eqListU8 n symbolName
-          | D_Native n => eqListU8 n symbolName
-          | D_Module n => false
-          | D_Import f s => false
-          | D_Export n => false
-        } in
-      if [Bool] isMatch (\u : U8 => true) (\u : U8 => isDefined symbolName t))
-
-poly emitImportStatus = \from : List U8 => \symbol : List U8 => \modTable : List (Pair (List U8) (List Decl)) =>
-  match (lookupMod from modTable) [List U8] {
-    | None => "MISSING_MODULE"
-    | Some decls =>
-        if [List U8] (isExported from symbol modTable)
-          (\u : U8 => "RESOLVED")
-          (\u : U8 => "NOT_EXPORTED")
-  }
-
-poly emitExportStatus = \symbol : List U8 => \expTable : List (Pair (List U8) (List (List U8))) => \decls : List Decl =>
-  match (lookupExp symbol expTable) [List U8] {
-    | None => "OK"
-    | Some origins =>
-        matchList [List U8] [List U8] origins
-          "OK"
-          (\h : List U8 => \t : List (List U8) =>
-            matchList [List U8] [List U8] t
-              (if [List U8] (isDefined symbol decls)
-                (\u : U8 => "OK")
-                (\u : U8 => "EXPORT_UNDEFINED"))
-              (\hh : List U8 => \tt : List (List U8) => "AMBIGUOUS"))
-  }
-
-poly rec filterDeclsAcc = \kind : U8 => \decls : List Decl => \acc : List Decl =>
-  matchList [Decl] [List Decl] decls (reverse [Decl] acc)
-    (\h : Decl => \t : List Decl =>
-      let isMatch = 
-        match h [Bool] {
-          | D_Module n => eqU8 kind #u8(0)
-          | D_Import f s => eqU8 kind #u8(1)
-          | D_Export n => eqU8 kind #u8(2)
-          | D_Data n cs => eqU8 kind #u8(3)
-          | D_Type n => eqU8 kind #u8(4)
-          | D_Opaque n => eqU8 kind #u8(5)
-          | D_Native n => eqU8 kind #u8(6)
-          | D_Def k r n e => 
-              match k [Bool] {
-                | K_Poly => eqU8 kind #u8(7)
-                | K_Combinator => eqU8 kind #u8(8)
+poly rec collectModuleExports =
+  \decls : List Decl =>
+    \acc : List (List U8) =>
+      matchList
+        [Decl]
+        [List (List U8)]
+        decls
+        (reverse [List U8] acc)
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List (List U8)] {
+                | D_Export name => collectModuleExports t (cons [List U8] name acc)
+                | D_Module n => collectModuleExports t acc
+                | D_Import f s => collectModuleExports t acc
+                | D_Opaque n => collectModuleExports t acc
+                | D_Native n => collectModuleExports t acc
+                | D_Type n => collectModuleExports t acc
+                | D_Data n cs => collectModuleExports t acc
+                | D_Def k r n e => collectModuleExports t acc
               }
-        } in
-      if [List Decl] isMatch
-        (\u : U8 => filterDeclsAcc kind t (cons [Decl] h acc))
-        (\u : U8 => filterDeclsAcc kind t acc))
+        )
 
-poly filterDecls = \kind : U8 => \decls : List Decl =>
-  filterDeclsAcc kind decls (nil [Decl])
-
-poly rec countList = #A => \xs : List A => \acc : U8 =>
-  matchList [A] [U8] xs acc
-    (\h : A => \t : List A => countList [A] t (addU8 acc #u8(1)))
-
-poly rec emitImportsSummary = \decls : List Decl => \modTable : List (Pair (List U8) (List Decl)) =>
-  matchList [Decl] [List U8] decls ""
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Import from symbol => 
-            append [U8] "import " (append [U8] from (append [U8] " " (append [U8] symbol (append [U8] " " (append [U8] (emitImportStatus from symbol modTable) (append [U8] "\n" (emitImportsSummary t modTable)))))))
-        | D_Module n => emitImportsSummary t modTable
-        | D_Export n => emitImportsSummary t modTable
-        | D_Opaque n => emitImportsSummary t modTable
-        | D_Native n => emitImportsSummary t modTable
-        | D_Type n => emitImportsSummary t modTable
-        | D_Data n cs => emitImportsSummary t modTable
-        | D_Def k r n e => emitImportsSummary t modTable
-      })
-
-poly rec emitExportsSummary = \decls : List Decl => \expTable : List (Pair (List U8) (List (List U8))) => \allDecls : List Decl =>
-  matchList [Decl] [List U8] decls ""
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Export symbol =>
-            append [U8] "export " (append [U8] symbol (append [U8] " " (append [U8] (emitExportStatus symbol expTable allDecls) (append [U8] "\n" (emitExportsSummary t expTable allDecls)))))
-        | D_Module n => emitExportsSummary t expTable allDecls
-        | D_Import f s => emitExportsSummary t expTable allDecls
-        | D_Opaque n => emitExportsSummary t expTable allDecls
-        | D_Native n => emitExportsSummary t expTable allDecls
-        | D_Type n => emitExportsSummary t expTable allDecls
-        | D_Data n cs => emitExportsSummary t expTable allDecls
-        | D_Def k r n e => emitExportsSummary t expTable allDecls
-      })
-
-poly rec emitCtors = \cs : List (Pair (List U8) U8) =>
-  matchList [(Pair (List U8) U8)] [List U8] cs ""
-    (\h : (Pair (List U8) U8) => \t : List (Pair (List U8) U8) =>
-      append [U8] "ctor " (append [U8] (fst [List U8] [U8] h) (append [U8] " " (append [U8] (u8ToDigits (snd [List U8] [U8] h)) (append [U8] "\n" (emitCtors t))))))
-
-poly rec emitDataSummary = \decls : List Decl =>
-  matchList [Decl] [List U8] decls ""
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Data name ctors => 
-            append [U8] "data " (append [U8] name (append [U8] "\n" (append [U8] (emitCtors ctors) (emitDataSummary t))))
-        | D_Module n => emitDataSummary t
-        | D_Import f s => emitDataSummary t
-        | D_Export n => emitDataSummary t
-        | D_Opaque n => emitDataSummary t
-        | D_Native n => emitDataSummary t
-        | D_Type n => emitDataSummary t
-        | D_Def k r n e => emitDataSummary t
-      })
-
-poly rec emitNamesSummary = \decls : List Decl => \prefix : List U8 =>
-  matchList [Decl] [List U8] decls ""
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Type n => append [U8] prefix (append [U8] n (append [U8] "\n" (emitNamesSummary t prefix)))
-        | D_Opaque n => append [U8] prefix (append [U8] n (append [U8] "\n" (emitNamesSummary t prefix)))
-        | D_Native n => append [U8] prefix (append [U8] n (append [U8] "\n" (emitNamesSummary t prefix)))
-        | D_Def k r n e => 
-            match k [Bool] {
-              | K_Poly => append [U8] "poly " (append [U8] n (append [U8] "\n" (emitNamesSummary t prefix)))
-              | K_Combinator => append [U8] "combinator " (append [U8] n (append [U8] "\n" (emitNamesSummary t prefix)))
-            }
-        | D_Module n => emitNamesSummary t prefix
-        | D_Import f s => emitNamesSummary t prefix
-        | D_Export n => emitNamesSummary t prefix
-        | D_Data n cs => emitNamesSummary t prefix
-      })
-
-poly rec getDeclared = \decls : List Decl =>
-  matchList [Decl] [List U8] decls "Main"
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Module n => n
-        | D_Import f s => getDeclared t
-        | D_Export n => getDeclared t
-        | D_Opaque n => getDeclared t
-        | D_Native n => getDeclared t
-        | D_Type n => getDeclared t
-        | D_Data n cs => getDeclared t
-        | D_Def k r n e => getDeclared t
-      })
-
-poly emitModuleInventory = \name : List U8 => \decls : List Decl => \modTable : List (Pair (List U8) (List Decl)) => \expTable : List (Pair (List U8) (List (List U8))) =>
-  let declared = getDeclared decls in
-  let imps = filterDecls #u8(1) decls in
-  let exps = filterDecls #u8(2) decls in
-  let datas = filterDecls #u8(3) decls in
-  let types = filterDecls #u8(4) decls in
-  let opaques = filterDecls #u8(5) decls in
-  let natives = filterDecls #u8(6) decls in
-  let polys = filterDecls #u8(7) decls in
-  let combinators = filterDecls #u8(8) decls in
-  
-  let s1 = append [U8] "module " (append [U8] name "\n") in
-  let s2 = append [U8] "declared " (append [U8] declared "\n") in
-  let s3 = append [U8] "imports " (append [U8] (u8ToDigits (countList [Decl] imps #u8(0))) "\n") in
-  let s4 = emitImportsSummary imps modTable in
-  let s5 = append [U8] "exports " (append [U8] (u8ToDigits (countList [Decl] exps #u8(0))) "\n") in
-  let s6 = emitExportsSummary exps expTable decls in
-  let s7 = append [U8] "data " (append [U8] (u8ToDigits (countList [Decl] datas #u8(0))) "\n") in
-  let s8 = emitDataSummary datas in
-  let s9 = append [U8] "type " (append [U8] (u8ToDigits (countList [Decl] types #u8(0))) "\n") in
-  let s10 = emitNamesSummary types "type " in
-  let s11 = append [U8] "opaque " (append [U8] (u8ToDigits (countList [Decl] opaques #u8(0))) "\n") in
-  let s12 = emitNamesSummary opaques "opaque " in
-  let s13 = append [U8] "native " (append [U8] (u8ToDigits (countList [Decl] natives #u8(0))) "\n") in
-  let s14 = emitNamesSummary natives "native " in
-  let s15 = append [U8] "poly " (append [U8] (u8ToDigits (countList [Decl] polys #u8(0))) "\n") in
-  let s16 = emitNamesSummary polys "poly " in
-  let s17 = append [U8] "combinator " (append [U8] (u8ToDigits (countList [Decl] combinators #u8(0))) "\n") in
-  let s18 = emitNamesSummary combinators "combinator " in
-  
-  append [U8] s1 (append [U8] s2 (append [U8] s3 (append [U8] s4 (append [U8] s5 (append [U8] s6 (append [U8] s7 (append [U8] s8 (append [U8] s9 (append [U8] s10 (append [U8] s11 (append [U8] s12 (append [U8] s13 (append [U8] s14 (append [U8] s15 (append [U8] s16 (append [U8] s17 s18))))))))))))))))
-
-poly rec emitInventorySummary = \mods : List ModuleRecord => \modTable : List (Pair (List U8) (List Decl)) => \expTable : List (Pair (List U8) (List (List U8))) =>
-  matchList [ModuleRecord] [List U8] mods ""
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-       match h [List U8] { | MkModuleRecord name _ _ =>
-         match (lookupMod name modTable) [List U8] {
-           | None => append [U8] "module " (append [U8] name "\n  error: not found\n")
-           | Some decls =>
-               append [U8] (emitModuleInventory name decls modTable expTable) (emitInventorySummary t modTable expTable)
-         }
-       })
-
-poly main = \source : List U8 =>
-  match (parseBundleSummary source) [U8] {
-    | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
-    | Ok bundle =>
-        match bundle [U8] { | MkBundleSummary entry target wrapper modsCountDigits mods =>
-          match (populateInventory mods (nil [(Pair (List U8) (List Decl))]) (nil [(Pair (List U8) (List (List U8)))])) [U8] {
-            | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
-            | Ok inv =>
-                match inv [U8] { | MkPair modTable expTable =>
-                  let header = append [U8] "OK\nversion bundle-inventory-v1\nentry "
-                                (append [U8] entry
-                                  (append [U8] "\ntarget "
-                                    (append [U8] target
-                                      (append [U8] "\nwrapper "
-                                        (append [U8] wrapper
-                                          (append [U8] "\nmodules "
-                                            (append [U8] modsCountDigits "\n"))))))) in
-                  writeAll (append [U8] header (emitInventorySummary mods modTable expTable))
+poly rec populateInventoryAcc =
+  \mods : List ModuleRecord =>
+    \modTable : List (Pair (List U8) (List Decl)) =>
+      \expTable : List (Pair (List U8) (List (List U8))) =>
+        matchList
+          [ModuleRecord]
+          [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))]
+          mods
+          (
+            Ok
+              [List U8]
+              [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+              (
+                MkPair
+                  [List (Pair (List U8) (List Decl))]
+                  [List (Pair (List U8) (List (List U8)))]
+                  modTable
+                  expTable
+              )
+          )
+          (
+            \h : ModuleRecord =>
+              \t : List ModuleRecord =>
+                match h [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                  | MkModuleRecord name _ source =>
+                    match (tokenize source) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                      | Err e =>
+                        Err
+                          [List U8]
+                          [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+                          "Parse error"
+                      | Ok toks =>
+                        match (parseProgram toks) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                          | Err e =>
+                            Err
+                              [List U8]
+                              [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+                              "Parse error"
+                          | Ok decls =>
+                            let exports = collectModuleExports decls (nil [List U8]) in
+                            populateInventoryAcc
+                              t
+                              (
+                                append
+                                  [(Pair (List U8) (List Decl))]
+                                  modTable
+                                  (
+                                    cons
+                                      [(Pair (List U8) (List Decl))]
+                                      (MkPair [List U8] [List Decl] name decls)
+                                      (nil [(Pair (List U8) (List Decl))])
+                                  )
+                              )
+                              (updateGlobalTable exports name expTable)
+                        }
+                    }
                 }
-          }
-        }
-  }
+          )
 
-poly rec writeAll = \bytes : List U8 =>
-  matchList [U8] [U8] bytes
-    #u8(0)
-    (\h : U8 => \t : List U8 =>
-      writeOne h [U8] (\u : U8 => writeAll t))
+poly populateInventory =
+  \mods : List ModuleRecord =>
+    \modTable : List (Pair (List U8) (List Decl)) =>
+      \expTable : List (Pair (List U8) (List (List U8))) => populateInventoryAcc mods modTable expTable
+
+poly rec symbolInList =
+  \symbolName : List U8 =>
+    \exps : List (List U8) =>
+      matchList
+        [List U8]
+        [Bool]
+        exps
+        false
+        (
+          \h : List U8 =>
+            \t : List (List U8) =>
+              if [Bool] (eqListU8 h symbolName)
+                (\u : U8 => true)
+                (\u : U8 => symbolInList symbolName t)
+        )
+
+poly isExported =
+  \modName : List U8 =>
+    \symbolName : List U8 =>
+      \modTable : List (Pair (List U8) (List Decl)) =>
+        match (lookupMod modName modTable) [Bool] {
+          | None => false
+          | Some decls =>
+            let exports = collectModuleExports decls (nil [List U8]) in
+            symbolInList symbolName exports
+        }
+
+poly rec ctorNameInList =
+  \name : List U8 =>
+    \cs : List (Pair (List U8) U8) =>
+      matchList
+        [(Pair (List U8) U8)]
+        [Bool]
+        cs
+        false
+        (
+          \h : (Pair (List U8) U8) =>
+            \t : List (Pair (List U8) U8) =>
+              if [Bool] (eqListU8 (fst [List U8] [U8] h) name)
+                (\u : U8 => true)
+                (\u : U8 => ctorNameInList name t)
+        )
+
+poly rec isDefined =
+  \symbolName : List U8 =>
+    \decls : List Decl =>
+      matchList
+        [Decl]
+        [Bool]
+        decls
+        false
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              let isMatch = match h [Bool] {| D_Def k r n e => eqListU8 n symbolName | D_Data n cs => or (eqListU8 n symbolName) (ctorNameInList symbolName cs) | D_Type n => eqListU8 n symbolName | D_Opaque n => eqListU8 n symbolName | D_Native n => eqListU8 n symbolName | D_Module n => false | D_Import f s => false | D_Export n => false} in
+              if [Bool] isMatch
+                (\u : U8 => true)
+                (\u : U8 => isDefined symbolName t)
+        )
+
+poly emitImportStatus =
+  \from : List U8 =>
+    \symbol : List U8 =>
+      \modTable : List (Pair (List U8) (List Decl)) =>
+        match (lookupMod from modTable) [List U8] {
+          | None => "MISSING_MODULE"
+          | Some decls =>
+            if [List U8] (isExported from symbol modTable)
+              (\u : U8 => "RESOLVED")
+              (\u : U8 => "NOT_EXPORTED")
+        }
+
+poly emitExportStatus =
+  \symbol : List U8 =>
+    \expTable : List (Pair (List U8) (List (List U8))) =>
+      \decls : List Decl =>
+        match (lookupExp symbol expTable) [List U8] {
+          | None => "OK"
+          | Some origins =>
+            matchList
+              [List U8]
+              [List U8]
+              origins
+              "OK"
+              (
+                \h : List U8 =>
+                  \t : List (List U8) =>
+                    matchList
+                      [List U8]
+                      [List U8]
+                      t
+                      (
+                        if [List U8] (isDefined symbol decls)
+                          (\u : U8 => "OK")
+                          (\u : U8 => "EXPORT_UNDEFINED")
+                      )
+                      (\hh : List U8 => \tt : List (List U8) => "AMBIGUOUS")
+              )
+        }
+
+poly rec filterDeclsAcc =
+  \kind : U8 =>
+    \decls : List Decl =>
+      \acc : List Decl =>
+        matchList
+          [Decl]
+          [List Decl]
+          decls
+          (reverse [Decl] acc)
+          (
+            \h : Decl =>
+              \t : List Decl =>
+                let isMatch = match h [Bool] {| D_Module n => eqU8 kind #u8(0) | D_Import f s => eqU8 kind #u8(1) | D_Export n => eqU8 kind #u8(2) | D_Data n cs => eqU8 kind #u8(3) | D_Type n => eqU8 kind #u8(4) | D_Opaque n => eqU8 kind #u8(5) | D_Native n => eqU8 kind #u8(6) | D_Def k r n e => match k [Bool] {| K_Poly => eqU8 kind #u8(7) | K_Combinator => eqU8 kind #u8(8)}} in
+                if [List Decl] isMatch
+                  (\u : U8 => filterDeclsAcc kind t (cons [Decl] h acc))
+                  (\u : U8 => filterDeclsAcc kind t acc)
+          )
+
+poly filterDecls =
+  \kind : U8 => \decls : List Decl => filterDeclsAcc kind decls (nil [Decl])
+
+poly rec countList =
+  #A =>
+    \xs : List A =>
+      \acc : U8 =>
+        matchList
+          [A]
+          [U8]
+          xs
+          acc
+          (\h : A => \t : List A => countList [A] t (addU8 acc #u8(1)))
+
+poly rec emitImportsSummary =
+  \decls : List Decl =>
+    \modTable : List (Pair (List U8) (List Decl)) =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        ""
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Import from symbol =>
+                  append
+                    [U8]
+                    "import "
+                    (
+                      append
+                        [U8]
+                        from
+                        (
+                          append
+                            [U8]
+                            " "
+                            (
+                              append
+                                [U8]
+                                symbol
+                                (
+                                  append
+                                    [U8]
+                                    " "
+                                    (
+                                      append
+                                        [U8]
+                                        (emitImportStatus from symbol modTable)
+                                        (
+                                          append
+                                            [U8]
+                                            "\n"
+                                            (emitImportsSummary t modTable)
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                | D_Module n => emitImportsSummary t modTable
+                | D_Export n => emitImportsSummary t modTable
+                | D_Opaque n => emitImportsSummary t modTable
+                | D_Native n => emitImportsSummary t modTable
+                | D_Type n => emitImportsSummary t modTable
+                | D_Data n cs => emitImportsSummary t modTable
+                | D_Def k r n e => emitImportsSummary t modTable
+              }
+        )
+
+poly rec emitExportsSummary =
+  \decls : List Decl =>
+    \expTable : List (Pair (List U8) (List (List U8))) =>
+      \allDecls : List Decl =>
+        matchList
+          [Decl]
+          [List U8]
+          decls
+          ""
+          (
+            \h : Decl =>
+              \t : List Decl =>
+                match h [List U8] {
+                  | D_Export symbol =>
+                    append
+                      [U8]
+                      "export "
+                      (
+                        append
+                          [U8]
+                          symbol
+                          (
+                            append
+                              [U8]
+                              " "
+                              (
+                                append
+                                  [U8]
+                                  (emitExportStatus symbol expTable allDecls)
+                                  (
+                                    append
+                                      [U8]
+                                      "\n"
+                                      (emitExportsSummary t expTable allDecls)
+                                  )
+                              )
+                          )
+                      )
+                  | D_Module n => emitExportsSummary t expTable allDecls
+                  | D_Import f s => emitExportsSummary t expTable allDecls
+                  | D_Opaque n => emitExportsSummary t expTable allDecls
+                  | D_Native n => emitExportsSummary t expTable allDecls
+                  | D_Type n => emitExportsSummary t expTable allDecls
+                  | D_Data n cs => emitExportsSummary t expTable allDecls
+                  | D_Def k r n e => emitExportsSummary t expTable allDecls
+                }
+          )
+
+poly rec emitCtors =
+  \cs : List (Pair (List U8) U8) =>
+    matchList
+      [(Pair (List U8) U8)]
+      [List U8]
+      cs
+      ""
+      (
+        \h : (Pair (List U8) U8) =>
+          \t : List (Pair (List U8) U8) =>
+            append
+              [U8]
+              "ctor "
+              (
+                append
+                  [U8]
+                  (fst [List U8] [U8] h)
+                  (
+                    append
+                      [U8]
+                      " "
+                      (
+                        append
+                          [U8]
+                          (u8ToDigits (snd [List U8] [U8] h))
+                          (append [U8] "\n" (emitCtors t))
+                      )
+                  )
+              )
+      )
+
+poly rec emitDataSummary =
+  \decls : List Decl =>
+    matchList
+      [Decl]
+      [List U8]
+      decls
+      ""
+      (
+        \h : Decl =>
+          \t : List Decl =>
+            match h [List U8] {
+              | D_Data name ctors =>
+                append
+                  [U8]
+                  "data "
+                  (
+                    append
+                      [U8]
+                      name
+                      (
+                        append
+                          [U8]
+                          "\n"
+                          (append [U8] (emitCtors ctors) (emitDataSummary t))
+                      )
+                  )
+              | D_Module n => emitDataSummary t
+              | D_Import f s => emitDataSummary t
+              | D_Export n => emitDataSummary t
+              | D_Opaque n => emitDataSummary t
+              | D_Native n => emitDataSummary t
+              | D_Type n => emitDataSummary t
+              | D_Def k r n e => emitDataSummary t
+            }
+      )
+
+poly rec emitNamesSummary =
+  \decls : List Decl =>
+    \prefix : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        ""
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Type n =>
+                  append
+                    [U8]
+                    prefix
+                    (
+                      append
+                        [U8]
+                        n
+                        (append [U8] "\n" (emitNamesSummary t prefix))
+                    )
+                | D_Opaque n =>
+                  append
+                    [U8]
+                    prefix
+                    (
+                      append
+                        [U8]
+                        n
+                        (append [U8] "\n" (emitNamesSummary t prefix))
+                    )
+                | D_Native n =>
+                  append
+                    [U8]
+                    prefix
+                    (
+                      append
+                        [U8]
+                        n
+                        (append [U8] "\n" (emitNamesSummary t prefix))
+                    )
+                | D_Def k r n e =>
+                  match k [Bool] {
+                    | K_Poly =>
+                      append
+                        [U8]
+                        "poly "
+                        (
+                          append
+                            [U8]
+                            n
+                            (append [U8] "\n" (emitNamesSummary t prefix))
+                        )
+                    | K_Combinator =>
+                      append
+                        [U8]
+                        "combinator "
+                        (
+                          append
+                            [U8]
+                            n
+                            (append [U8] "\n" (emitNamesSummary t prefix))
+                        )
+                  }
+                | D_Module n => emitNamesSummary t prefix
+                | D_Import f s => emitNamesSummary t prefix
+                | D_Export n => emitNamesSummary t prefix
+                | D_Data n cs => emitNamesSummary t prefix
+              }
+        )
+
+poly rec getDeclared =
+  \decls : List Decl =>
+    matchList
+      [Decl]
+      [List U8]
+      decls
+      "Main"
+      (
+        \h : Decl =>
+          \t : List Decl =>
+            match h [List U8] {
+              | D_Module n => n
+              | D_Import f s => getDeclared t
+              | D_Export n => getDeclared t
+              | D_Opaque n => getDeclared t
+              | D_Native n => getDeclared t
+              | D_Type n => getDeclared t
+              | D_Data n cs => getDeclared t
+              | D_Def k r n e => getDeclared t
+            }
+      )
+
+poly emitModuleInventory =
+  \name : List U8 =>
+    \decls : List Decl =>
+      \modTable : List (Pair (List U8) (List Decl)) =>
+        \expTable : List (Pair (List U8) (List (List U8))) =>
+          let declared = getDeclared decls in
+          let imps = filterDecls #u8(1) decls in
+          let exps = filterDecls #u8(2) decls in
+          let datas = filterDecls #u8(3) decls in
+          let types = filterDecls #u8(4) decls in
+          let opaques = filterDecls #u8(5) decls in
+          let natives = filterDecls #u8(6) decls in
+          let polys = filterDecls #u8(7) decls in
+          let combinators = filterDecls #u8(8) decls in
+          let s1 = append [U8] "module " (append [U8] name "\n") in
+          let s2 = append [U8] "declared " (append [U8] declared "\n") in
+          let s3 = append [U8] "imports " (append [U8] (u8ToDigits (countList [Decl] imps #u8(0))) "\n") in
+          let s4 = emitImportsSummary imps modTable in
+          let s5 = append [U8] "exports " (append [U8] (u8ToDigits (countList [Decl] exps #u8(0))) "\n") in
+          let s6 = emitExportsSummary exps expTable decls in
+          let s7 = append [U8] "data " (append [U8] (u8ToDigits (countList [Decl] datas #u8(0))) "\n") in
+          let s8 = emitDataSummary datas in
+          let s9 = append [U8] "type " (append [U8] (u8ToDigits (countList [Decl] types #u8(0))) "\n") in
+          let s10 = emitNamesSummary types "type " in
+          let s11 = append [U8] "opaque " (append [U8] (u8ToDigits (countList [Decl] opaques #u8(0))) "\n") in
+          let s12 = emitNamesSummary opaques "opaque " in
+          let s13 = append [U8] "native " (append [U8] (u8ToDigits (countList [Decl] natives #u8(0))) "\n") in
+          let s14 = emitNamesSummary natives "native " in
+          let s15 = append [U8] "poly " (append [U8] (u8ToDigits (countList [Decl] polys #u8(0))) "\n") in
+          let s16 = emitNamesSummary polys "poly " in
+          let s17 = append [U8] "combinator " (append [U8] (u8ToDigits (countList [Decl] combinators #u8(0))) "\n") in
+          let s18 = emitNamesSummary combinators "combinator " in
+          append
+            [U8]
+            s1
+            (
+              append
+                [U8]
+                s2
+                (
+                  append
+                    [U8]
+                    s3
+                    (
+                      append
+                        [U8]
+                        s4
+                        (
+                          append
+                            [U8]
+                            s5
+                            (
+                              append
+                                [U8]
+                                s6
+                                (
+                                  append
+                                    [U8]
+                                    s7
+                                    (
+                                      append
+                                        [U8]
+                                        s8
+                                        (
+                                          append
+                                            [U8]
+                                            s9
+                                            (
+                                              append
+                                                [U8]
+                                                s10
+                                                (
+                                                  append
+                                                    [U8]
+                                                    s11
+                                                    (
+                                                      append
+                                                        [U8]
+                                                        s12
+                                                        (
+                                                          append
+                                                            [U8]
+                                                            s13
+                                                            (
+                                                              append
+                                                                [U8]
+                                                                s14
+                                                                (
+                                                                  append
+                                                                    [U8]
+                                                                    s15
+                                                                    (
+                                                                      append
+                                                                        [U8]
+                                                                        s16
+                                                                        (
+                                                                          append
+                                                                            [U8]
+                                                                            s17
+                                                                            s18
+                                                                        )
+                                                                    )
+                                                                )
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+
+poly rec emitInventorySummary =
+  \mods : List ModuleRecord =>
+    \modTable : List (Pair (List U8) (List Decl)) =>
+      \expTable : List (Pair (List U8) (List (List U8))) =>
+        matchList
+          [ModuleRecord]
+          [List U8]
+          mods
+          ""
+          (
+            \h : ModuleRecord =>
+              \t : List ModuleRecord =>
+                match h [List U8] {
+                  | MkModuleRecord name _ _ =>
+                    match (lookupMod name modTable) [List U8] {
+                      | None =>
+                        append
+                          [U8]
+                          "module "
+                          (append [U8] name "\n  error: not found\n")
+                      | Some decls =>
+                        append
+                          [U8]
+                          (emitModuleInventory name decls modTable expTable)
+                          (emitInventorySummary t modTable expTable)
+                    }
+                }
+          )
+
+poly main =
+  \source : List U8 =>
+    match (parseBundleSummary source) [U8] {
+      | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
+      | Ok bundle =>
+        match bundle [U8] {
+          | MkBundleSummary entry target wrapper modsCountDigits mods =>
+            match (populateInventory mods (nil [(Pair (List U8) (List Decl))]) (nil [(Pair (List U8) (List (List U8)))])) [U8] {
+              | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
+              | Ok inv =>
+                match inv [U8] {
+                  | MkPair modTable expTable =>
+                    let header = append [U8] "OK\nversion bundle-inventory-v1\nentry " (append [U8] entry (append [U8] "\ntarget " (append [U8] target (append [U8] "\nwrapper " (append [U8] wrapper (append [U8] "\nmodules " (append [U8] modsCountDigits "\n"))))))) in
+                    writeAll
+                      (
+                        append
+                          [U8]
+                          header
+                          (emitInventorySummary mods modTable expTable)
+                      )
+                }
+            }
+        }
+    }
+
+poly rec writeAll =
+  \bytes : List U8 =>
+    matchList [U8] [U8] bytes #u8(0) (\h : U8 => \t : List U8 => writeOne h [U8] (\u : U8 => writeAll t))

--- a/bootstrap/src/bundleParseSummary.trip
+++ b/bootstrap/src/bundleParseSummary.trip
@@ -1,454 +1,753 @@
 module BundleParseSummary
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude eqListU8
+
 import Prelude ltListU8
+
 import Prelude digitToAscii
+
 import Prelude singletonU8
+
 import Prelude u8ToDigits
+
 import Prelude writeOne
+
 import BundleSummary parseBundleSummary
+
 import BundleSummary BundleSummary
+
 import BundleSummary MkBundleSummary
+
 import BundleSummary ModuleRecord
+
 import BundleSummary MkModuleRecord
+
 import Lexer tokenize
+
 import Lexer ParseError
+
 import Lexer MkParseError
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
+
 import Parser DefKind
+
 import Parser K_Poly
+
 import Parser K_Combinator
+
 import Parser parseProgram
 
 export emitBundleParseSummary
+
 export main
 
-poly prefixModule : List U8 = "module "
-poly prefixDeclared : List U8 = "declared "
-poly prefixImport : List U8 = "import "
-poly prefixExport : List U8 = "export "
-poly prefixData : List U8 = "data "
-poly prefixType : List U8 = "type "
-poly prefixOpaque : List U8 = "opaque "
-poly prefixCtor : List U8 = "ctor "
-poly prefixPoly : List U8 = "poly "
-poly prefixCombinator : List U8 = "combinator "
-poly prefixImportsCount : List U8 = "imports "
-poly prefixExportsCount : List U8 = "exports "
-poly prefixNative : List U8 = "native "
-poly prefixSummaryEntry : List U8 = "OK\nversion bundle-parse-summary-v1\nentry "
-poly prefixSummaryTarget : List U8 = "\ntarget "
-poly prefixSummaryWrapper : List U8 = "\nwrapper "
-poly prefixSummaryModules : List U8 = "\nmodules "
-poly newline : List U8 = "\n"
-poly space : List U8 = " "
+poly prefixModule : List U8 =
+  "module "
 
-poly inc = \n : U8 =>
-  addU8 n #u8(1)
+poly prefixDeclared : List U8 =
+  "declared "
 
-poly rec declaredModuleAcc = \decls : List Decl => \seen : Maybe (List U8) =>
-  matchList [Decl] [Result (List U8) (List U8)] decls
-    (match seen [Result (List U8) (List U8)] {
-      | None => Err [List U8] [List U8] "missing module declaration"
-      | Some name => Ok [List U8] [List U8] name
-    })
-    (\h : Decl => \t : List Decl =>
-      match h [Result (List U8) (List U8)] {
-        | D_Module name =>
-            match seen [Result (List U8) (List U8)] {
-              | None => declaredModuleAcc t (Some [List U8] name)
-              | Some prev => Err [List U8] [List U8] "multiple module declarations"
-            }
-        | D_Import fromName symbolName => declaredModuleAcc t seen
-        | D_Export name => declaredModuleAcc t seen
-        | D_Opaque name => declaredModuleAcc t seen
-        | D_Native name => declaredModuleAcc t seen
-        | D_Type name => declaredModuleAcc t seen
-        | D_Data name ctors => declaredModuleAcc t seen
-        | D_Def kind isRec name body => declaredModuleAcc t seen
-      })
+poly prefixImport : List U8 =
+  "import "
 
-poly declaredModule = \decls : List Decl =>
-  declaredModuleAcc decls (None [List U8])
+poly prefixExport : List U8 =
+  "export "
 
-poly rec countImports = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Import fromName symbolName => countImports t (inc count)
-        | D_Module name => countImports t count
-        | D_Export name => countImports t count
-        | D_Opaque name => countImports t count
-        | D_Native name => countImports t count
-        | D_Type name => countImports t count
-        | D_Data name ctors => countImports t count
-        | D_Def kind isRec name body => countImports t count
-      })
+poly prefixData : List U8 =
+  "data "
 
-poly rec countExports = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Export name => countExports t (inc count)
-        | D_Module name => countExports t count
-        | D_Import fromName symbolName => countExports t count
-        | D_Opaque name => countExports t count
-        | D_Native name => countExports t count
-        | D_Type name => countExports t count
-        | D_Data name ctors => countExports t count
-        | D_Def kind isRec name body => countExports t count
-      })
+poly prefixType : List U8 =
+  "type "
 
-poly rec countData = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Data name ctors => countData t (inc count)
-        | D_Module name => countData t count
-        | D_Import fromName symbolName => countData t count
-        | D_Export name => countData t count
-        | D_Opaque name => countData t count
-        | D_Native name => countData t count
-        | D_Type name => countData t count
-        | D_Def kind isRec name body => countData t count
-      })
+poly prefixOpaque : List U8 =
+  "opaque "
 
-poly rec countTypes = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Type name => countTypes t (inc count)
-        | D_Module name => countTypes t count
-        | D_Import fromName symbolName => countTypes t count
-        | D_Export name => countTypes t count
-        | D_Opaque name => countTypes t count
-        | D_Native name => countTypes t count
-        | D_Data name ctors => countTypes t count
-        | D_Def kind isRec name body => countTypes t count
-      })
+poly prefixCtor : List U8 =
+  "ctor "
 
-poly rec countOpaque = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Opaque name => countOpaque t (inc count)
-        | D_Module name => countOpaque t count
-        | D_Import fromName symbolName => countOpaque t count
-        | D_Export name => countOpaque t count
-        | D_Native name => countOpaque t count
-        | D_Type name => countOpaque t count
-        | D_Data name ctors => countOpaque t count
-        | D_Def kind isRec name body => countOpaque t count
-      })
+poly prefixPoly : List U8 =
+  "poly "
 
-poly rec countNative = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Native name => countNative t (inc count)
-        | D_Module name => countNative t count
-        | D_Import fromName symbolName => countNative t count
-        | D_Export name => countNative t count
-        | D_Opaque name => countNative t count
-        | D_Type name => countNative t count
-        | D_Data name ctors => countNative t count
-        | D_Def kind isRec name body => countNative t count
-      })
+poly prefixCombinator : List U8 =
+  "combinator "
 
-poly isPolyKind = \kind : DefKind =>
-  match kind [Bool] {
-    | K_Poly => true
-    | K_Combinator => false
-  }
+poly prefixImportsCount : List U8 =
+  "imports "
 
-poly isCombinatorKind = \kind : DefKind =>
-  match kind [Bool] {
-    | K_Poly => false
-    | K_Combinator => true
-  }
+poly prefixExportsCount : List U8 =
+  "exports "
 
-poly emitOneNameLine = \prefix : List U8 => \name : List U8 =>
-  append [U8] prefix (append [U8] name newline)
+poly prefixNative : List U8 =
+  "native "
 
-poly emitTwoNameLine = \prefix : List U8 => \left : List U8 => \right : List U8 =>
-  append [U8] prefix (append [U8] left (append [U8] space (append [U8] right newline)))
+poly prefixSummaryEntry : List U8 =
+  "OK\nversion bundle-parse-summary-v1\nentry "
 
-poly emitNameCountLine = \prefix : List U8 => \name : List U8 => \count : U8 =>
-  append [U8] prefix (append [U8] name (append [U8] space (append [U8] (u8ToDigits count) newline)))
+poly prefixSummaryTarget : List U8 =
+  "\ntarget "
 
-poly emitCountLine = \prefix : List U8 => \count : U8 =>
-  append [U8] prefix (append [U8] (u8ToDigits count) newline)
+poly prefixSummaryWrapper : List U8 =
+  "\nwrapper "
 
-poly rec countPoly = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Def kind isRec name body =>
-            if [U8] (isPolyKind kind)
-              (\u : U8 => countPoly t (inc count))
-              (\u : U8 => countPoly t count)
-        | D_Module name => countPoly t count
-        | D_Import fromName symbolName => countPoly t count
-        | D_Export name => countPoly t count
-        | D_Opaque name => countPoly t count
-        | D_Native name => countPoly t count
-        | D_Type name => countPoly t count
-        | D_Data name ctors => countPoly t count
-      })
+poly prefixSummaryModules : List U8 =
+  "\nmodules "
 
-poly rec countCombinator = \decls : List Decl => \count : U8 =>
-  matchList [Decl] [U8] decls
-    count
-    (\h : Decl => \t : List Decl =>
-      match h [U8] {
-        | D_Def kind isRec name body =>
-            if [U8] (isCombinatorKind kind)
-              (\u : U8 => countCombinator t (inc count))
-              (\u : U8 => countCombinator t count)
-        | D_Module name => countCombinator t count
-        | D_Import fromName symbolName => countCombinator t count
-        | D_Export name => countCombinator t count
-        | D_Opaque name => countCombinator t count
-        | D_Native name => countCombinator t count
-        | D_Type name => countCombinator t count
-        | D_Data name ctors => countCombinator t count
-      })
+poly newline : List U8 =
+  "\n"
 
-poly rec emitImportsAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Import fromName symbolName =>
-            emitImportsAcc t (append [U8] (emitTwoNameLine prefixImport fromName symbolName) acc)
-        | D_Module name => emitImportsAcc t acc
-        | D_Export name => emitImportsAcc t acc
-        | D_Opaque name => emitImportsAcc t acc
-        | D_Native name => emitImportsAcc t acc
-        | D_Type name => emitImportsAcc t acc
-        | D_Data name ctors => emitImportsAcc t acc
-        | D_Def kind isRec name body => emitImportsAcc t acc
-      })
+poly space : List U8 =
+  " "
 
-poly emitImports = \decls : List Decl =>
-  emitImportsAcc (reverse [Decl] decls) (nil [U8])
+poly inc =
+  \n : U8 => addU8 n #u8(1)
 
-poly rec emitExportsAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Export name => emitExportsAcc t (append [U8] (emitOneNameLine prefixExport name) acc)
-        | D_Module name => emitExportsAcc t acc
-        | D_Import fromName symbolName => emitExportsAcc t acc
-        | D_Opaque name => emitExportsAcc t acc
-        | D_Native name => emitExportsAcc t acc
-        | D_Type name => emitExportsAcc t acc
-        | D_Data name ctors => emitExportsAcc t acc
-        | D_Def kind isRec name body => emitExportsAcc t acc
-      })
-
-poly emitExports = \decls : List Decl =>
-  emitExportsAcc (reverse [Decl] decls) (nil [U8])
-
-poly emitCtor = \ctor : Pair (List U8) U8 =>
-  let name = fst [List U8] [U8] ctor in
-  let arity = snd [List U8] [U8] ctor in
-  emitNameCountLine prefixCtor name arity
-
-poly rec emitCtorsAcc = \ctors : List (Pair (List U8) U8) => \acc : List U8 =>
-  matchList [Pair (List U8) U8] [List U8] ctors
-    acc
-    (\h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) =>
-      emitCtorsAcc t (append [U8] (emitCtor h) acc))
-
-poly emitCtors = \ctors : List (Pair (List U8) U8) =>
-  emitCtorsAcc (reverse [Pair (List U8) U8] ctors) (nil [U8])
-
-poly rec emitDataDefsAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Data name ctors =>
-            let dataLine = emitOneNameLine prefixData name in
-            let ctorsText = emitCtors ctors in
-            emitDataDefsAcc t (append [U8] (append [U8] dataLine ctorsText) acc)
-        | D_Module name => emitDataDefsAcc t acc
-        | D_Import fromName symbolName => emitDataDefsAcc t acc
-        | D_Export name => emitDataDefsAcc t acc
-        | D_Opaque name => emitDataDefsAcc t acc
-        | D_Native name => emitDataDefsAcc t acc
-        | D_Type name => emitDataDefsAcc t acc
-        | D_Def kind isRec name body => emitDataDefsAcc t acc
-      })
-
-poly emitDataDefs = \decls : List Decl =>
-  emitDataDefsAcc (reverse [Decl] decls) (nil [U8])
-
-poly rec emitTypesAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Type name => emitTypesAcc t (append [U8] (emitOneNameLine prefixType name) acc)
-        | D_Module name => emitTypesAcc t acc
-        | D_Import fromName symbolName => emitTypesAcc t acc
-        | D_Export name => emitTypesAcc t acc
-        | D_Opaque name => emitTypesAcc t acc
-        | D_Native name => emitTypesAcc t acc
-        | D_Data name ctors => emitTypesAcc t acc
-        | D_Def kind isRec name body => emitTypesAcc t acc
-      })
-
-poly emitTypes = \decls : List Decl =>
-  emitTypesAcc (reverse [Decl] decls) (nil [U8])
-
-poly rec emitOpaquesAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Opaque name => emitOpaquesAcc t (append [U8] (emitOneNameLine prefixOpaque name) acc)
-        | D_Module name => emitOpaquesAcc t acc
-        | D_Import fromName symbolName => emitOpaquesAcc t acc
-        | D_Export name => emitOpaquesAcc t acc
-        | D_Native name => emitOpaquesAcc t acc
-        | D_Type name => emitOpaquesAcc t acc
-        | D_Data name ctors => emitOpaquesAcc t acc
-        | D_Def kind isRec name body => emitOpaquesAcc t acc
-      })
-
-poly emitOpaques = \decls : List Decl =>
-  emitOpaquesAcc (reverse [Decl] decls) (nil [U8])
-
-poly rec emitNativesAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Native name => emitNativesAcc t (append [U8] (emitOneNameLine prefixNative name) acc)
-        | D_Module name => emitNativesAcc t acc
-        | D_Import fromName symbolName => emitNativesAcc t acc
-        | D_Export name => emitNativesAcc t acc
-        | D_Opaque name => emitNativesAcc t acc
-        | D_Type name => emitNativesAcc t acc
-        | D_Data name ctors => emitNativesAcc t acc
-        | D_Def kind isRec name body => emitNativesAcc t acc
-      })
-
-poly emitNatives = \decls : List Decl =>
-  emitNativesAcc (reverse [Decl] decls) (nil [U8])
-
-poly rec emitPolyDefsAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Def kind isRec name body =>
-            if [List U8] (isPolyKind kind)
-              (\u : U8 => emitPolyDefsAcc t (append [U8] (emitOneNameLine prefixPoly name) acc))
-              (\u : U8 => emitPolyDefsAcc t acc)
-        | D_Module name => emitPolyDefsAcc t acc
-        | D_Import fromName symbolName => emitPolyDefsAcc t acc
-        | D_Export name => emitPolyDefsAcc t acc
-        | D_Opaque name => emitPolyDefsAcc t acc
-        | D_Native name => emitPolyDefsAcc t acc
-        | D_Type name => emitPolyDefsAcc t acc
-        | D_Data name ctors => emitPolyDefsAcc t acc
-      })
-
-poly emitPolyDefs = \decls : List Decl =>
-  emitPolyDefsAcc (reverse [Decl] decls) (nil [U8])
-
-poly rec emitCombinatorDefsAcc = \decls : List Decl => \acc : List U8 =>
-  matchList [Decl] [List U8] decls
-    acc
-    (\h : Decl => \t : List Decl =>
-      match h [List U8] {
-        | D_Def kind isRec name body =>
-            if [List U8] (isCombinatorKind kind)
-              (\u : U8 => emitCombinatorDefsAcc t (append [U8] (emitOneNameLine prefixCombinator name) acc))
-              (\u : U8 => emitCombinatorDefsAcc t acc)
-        | D_Module name => emitCombinatorDefsAcc t acc
-        | D_Import fromName symbolName => emitCombinatorDefsAcc t acc
-        | D_Export name => emitCombinatorDefsAcc t acc
-        | D_Opaque name => emitCombinatorDefsAcc t acc
-        | D_Native name => emitCombinatorDefsAcc t acc
-        | D_Type name => emitCombinatorDefsAcc t acc
-        | D_Data name ctors => emitCombinatorDefsAcc t acc
-      })
-
-poly emitCombinatorDefs = \decls : List Decl =>
-  emitCombinatorDefsAcc (reverse [Decl] decls) (nil [U8])
-
-poly parseModuleSource = \bundleName : List U8 => \source : List U8 =>
-  match (tokenize source) [Result (List U8) (List Decl)] {
-    | Err e => Err [List U8] [List Decl] "Lex error"
-    | Ok toks =>
-        match (parseProgram toks) [Result (List U8) (List Decl)] {
-          | Err e =>
-              match e [Result (List U8) (List Decl)] { | MkParseError msg =>
-                Err [List U8] [List Decl] msg
+poly rec declaredModuleAcc =
+  \decls : List Decl =>
+    \seen : Maybe (List U8) =>
+      matchList
+        [Decl]
+        [Result (List U8) (List U8)]
+        decls
+        (
+          match seen [Result (List U8) (List U8)] {
+            | None =>
+              Err [List U8] [List U8] "missing module declaration"
+            | Some name => Ok [List U8] [List U8] name
+          }
+        )
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Result (List U8) (List U8)] {
+                | D_Module name =>
+                  match seen [Result (List U8) (List U8)] {
+                    | None => declaredModuleAcc t (Some [List U8] name)
+                    | Some prev =>
+                      Err [List U8] [List U8] "multiple module declarations"
+                  }
+                | D_Import fromName symbolName => declaredModuleAcc t seen
+                | D_Export name => declaredModuleAcc t seen
+                | D_Opaque name => declaredModuleAcc t seen
+                | D_Native name => declaredModuleAcc t seen
+                | D_Type name => declaredModuleAcc t seen
+                | D_Data name ctors => declaredModuleAcc t seen
+                | D_Def kind isRec name body => declaredModuleAcc t seen
               }
-          | Ok decls =>
+        )
+
+poly declaredModule =
+  \decls : List Decl => declaredModuleAcc decls (None [List U8])
+
+poly rec countImports =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Import fromName symbolName => countImports t (inc count)
+                | D_Module name => countImports t count
+                | D_Export name => countImports t count
+                | D_Opaque name => countImports t count
+                | D_Native name => countImports t count
+                | D_Type name => countImports t count
+                | D_Data name ctors => countImports t count
+                | D_Def kind isRec name body => countImports t count
+              }
+        )
+
+poly rec countExports =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Export name => countExports t (inc count)
+                | D_Module name => countExports t count
+                | D_Import fromName symbolName => countExports t count
+                | D_Opaque name => countExports t count
+                | D_Native name => countExports t count
+                | D_Type name => countExports t count
+                | D_Data name ctors => countExports t count
+                | D_Def kind isRec name body => countExports t count
+              }
+        )
+
+poly rec countData =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Data name ctors => countData t (inc count)
+                | D_Module name => countData t count
+                | D_Import fromName symbolName => countData t count
+                | D_Export name => countData t count
+                | D_Opaque name => countData t count
+                | D_Native name => countData t count
+                | D_Type name => countData t count
+                | D_Def kind isRec name body => countData t count
+              }
+        )
+
+poly rec countTypes =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Type name => countTypes t (inc count)
+                | D_Module name => countTypes t count
+                | D_Import fromName symbolName => countTypes t count
+                | D_Export name => countTypes t count
+                | D_Opaque name => countTypes t count
+                | D_Native name => countTypes t count
+                | D_Data name ctors => countTypes t count
+                | D_Def kind isRec name body => countTypes t count
+              }
+        )
+
+poly rec countOpaque =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Opaque name => countOpaque t (inc count)
+                | D_Module name => countOpaque t count
+                | D_Import fromName symbolName => countOpaque t count
+                | D_Export name => countOpaque t count
+                | D_Native name => countOpaque t count
+                | D_Type name => countOpaque t count
+                | D_Data name ctors => countOpaque t count
+                | D_Def kind isRec name body => countOpaque t count
+              }
+        )
+
+poly rec countNative =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Native name => countNative t (inc count)
+                | D_Module name => countNative t count
+                | D_Import fromName symbolName => countNative t count
+                | D_Export name => countNative t count
+                | D_Opaque name => countNative t count
+                | D_Type name => countNative t count
+                | D_Data name ctors => countNative t count
+                | D_Def kind isRec name body => countNative t count
+              }
+        )
+
+poly isPolyKind =
+  \kind : DefKind =>
+    match kind [Bool] {
+      | K_Poly => true
+      | K_Combinator => false
+    }
+
+poly isCombinatorKind =
+  \kind : DefKind =>
+    match kind [Bool] {
+      | K_Poly => false
+      | K_Combinator => true
+    }
+
+poly emitOneNameLine =
+  \prefix : List U8 =>
+    \name : List U8 => append [U8] prefix (append [U8] name newline)
+
+poly emitTwoNameLine =
+  \prefix : List U8 =>
+    \left : List U8 =>
+      \right : List U8 =>
+        append
+          [U8]
+          prefix
+          (append [U8] left (append [U8] space (append [U8] right newline)))
+
+poly emitNameCountLine =
+  \prefix : List U8 =>
+    \name : List U8 =>
+      \count : U8 =>
+        append
+          [U8]
+          prefix
+          (
+            append
+              [U8]
+              name
+              (append [U8] space (append [U8] (u8ToDigits count) newline))
+          )
+
+poly emitCountLine =
+  \prefix : List U8 =>
+    \count : U8 => append [U8] prefix (append [U8] (u8ToDigits count) newline)
+
+poly rec countPoly =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Def kind isRec name body =>
+                  if [U8] (isPolyKind kind)
+                    (\u : U8 => countPoly t (inc count))
+                    (\u : U8 => countPoly t count)
+                | D_Module name => countPoly t count
+                | D_Import fromName symbolName => countPoly t count
+                | D_Export name => countPoly t count
+                | D_Opaque name => countPoly t count
+                | D_Native name => countPoly t count
+                | D_Type name => countPoly t count
+                | D_Data name ctors => countPoly t count
+              }
+        )
+
+poly rec countCombinator =
+  \decls : List Decl =>
+    \count : U8 =>
+      matchList
+        [Decl]
+        [U8]
+        decls
+        count
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [U8] {
+                | D_Def kind isRec name body =>
+                  if [U8] (isCombinatorKind kind)
+                    (\u : U8 => countCombinator t (inc count))
+                    (\u : U8 => countCombinator t count)
+                | D_Module name => countCombinator t count
+                | D_Import fromName symbolName => countCombinator t count
+                | D_Export name => countCombinator t count
+                | D_Opaque name => countCombinator t count
+                | D_Native name => countCombinator t count
+                | D_Type name => countCombinator t count
+                | D_Data name ctors => countCombinator t count
+              }
+        )
+
+poly rec emitImportsAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Import fromName symbolName =>
+                  emitImportsAcc
+                    t
+                    (
+                      append
+                        [U8]
+                        (emitTwoNameLine prefixImport fromName symbolName)
+                        acc
+                    )
+                | D_Module name => emitImportsAcc t acc
+                | D_Export name => emitImportsAcc t acc
+                | D_Opaque name => emitImportsAcc t acc
+                | D_Native name => emitImportsAcc t acc
+                | D_Type name => emitImportsAcc t acc
+                | D_Data name ctors => emitImportsAcc t acc
+                | D_Def kind isRec name body => emitImportsAcc t acc
+              }
+        )
+
+poly emitImports =
+  \decls : List Decl => emitImportsAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitExportsAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Export name =>
+                  emitExportsAcc
+                    t
+                    (append [U8] (emitOneNameLine prefixExport name) acc)
+                | D_Module name => emitExportsAcc t acc
+                | D_Import fromName symbolName => emitExportsAcc t acc
+                | D_Opaque name => emitExportsAcc t acc
+                | D_Native name => emitExportsAcc t acc
+                | D_Type name => emitExportsAcc t acc
+                | D_Data name ctors => emitExportsAcc t acc
+                | D_Def kind isRec name body => emitExportsAcc t acc
+              }
+        )
+
+poly emitExports =
+  \decls : List Decl => emitExportsAcc (reverse [Decl] decls) (nil [U8])
+
+poly emitCtor =
+  \ctor : Pair (List U8) U8 =>
+    let name = fst [List U8] [U8] ctor in
+    let arity = snd [List U8] [U8] ctor in
+    emitNameCountLine prefixCtor name arity
+
+poly rec emitCtorsAcc =
+  \ctors : List (Pair (List U8) U8) =>
+    \acc : List U8 =>
+      matchList
+        [Pair (List U8) U8]
+        [List U8]
+        ctors
+        acc
+        (
+          \h : Pair (List U8) U8 =>
+            \t : List (Pair (List U8) U8) => emitCtorsAcc t (append [U8] (emitCtor h) acc)
+        )
+
+poly emitCtors =
+  \ctors : List (Pair (List U8) U8) => emitCtorsAcc (reverse [Pair (List U8) U8] ctors) (nil [U8])
+
+poly rec emitDataDefsAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Data name ctors =>
+                  let dataLine = emitOneNameLine prefixData name in
+                  let ctorsText = emitCtors ctors in
+                  emitDataDefsAcc
+                    t
+                    (append [U8] (append [U8] dataLine ctorsText) acc)
+                | D_Module name => emitDataDefsAcc t acc
+                | D_Import fromName symbolName => emitDataDefsAcc t acc
+                | D_Export name => emitDataDefsAcc t acc
+                | D_Opaque name => emitDataDefsAcc t acc
+                | D_Native name => emitDataDefsAcc t acc
+                | D_Type name => emitDataDefsAcc t acc
+                | D_Def kind isRec name body => emitDataDefsAcc t acc
+              }
+        )
+
+poly emitDataDefs =
+  \decls : List Decl => emitDataDefsAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitTypesAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Type name =>
+                  emitTypesAcc
+                    t
+                    (append [U8] (emitOneNameLine prefixType name) acc)
+                | D_Module name => emitTypesAcc t acc
+                | D_Import fromName symbolName => emitTypesAcc t acc
+                | D_Export name => emitTypesAcc t acc
+                | D_Opaque name => emitTypesAcc t acc
+                | D_Native name => emitTypesAcc t acc
+                | D_Data name ctors => emitTypesAcc t acc
+                | D_Def kind isRec name body => emitTypesAcc t acc
+              }
+        )
+
+poly emitTypes =
+  \decls : List Decl => emitTypesAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitOpaquesAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Opaque name =>
+                  emitOpaquesAcc
+                    t
+                    (append [U8] (emitOneNameLine prefixOpaque name) acc)
+                | D_Module name => emitOpaquesAcc t acc
+                | D_Import fromName symbolName => emitOpaquesAcc t acc
+                | D_Export name => emitOpaquesAcc t acc
+                | D_Native name => emitOpaquesAcc t acc
+                | D_Type name => emitOpaquesAcc t acc
+                | D_Data name ctors => emitOpaquesAcc t acc
+                | D_Def kind isRec name body => emitOpaquesAcc t acc
+              }
+        )
+
+poly emitOpaques =
+  \decls : List Decl => emitOpaquesAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitNativesAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Native name =>
+                  emitNativesAcc
+                    t
+                    (append [U8] (emitOneNameLine prefixNative name) acc)
+                | D_Module name => emitNativesAcc t acc
+                | D_Import fromName symbolName => emitNativesAcc t acc
+                | D_Export name => emitNativesAcc t acc
+                | D_Opaque name => emitNativesAcc t acc
+                | D_Type name => emitNativesAcc t acc
+                | D_Data name ctors => emitNativesAcc t acc
+                | D_Def kind isRec name body => emitNativesAcc t acc
+              }
+        )
+
+poly emitNatives =
+  \decls : List Decl => emitNativesAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitPolyDefsAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Def kind isRec name body =>
+                  if [List U8] (isPolyKind kind)
+                    (
+                      \u : U8 =>
+                        emitPolyDefsAcc
+                          t
+                          (append [U8] (emitOneNameLine prefixPoly name) acc)
+                    )
+                    (\u : U8 => emitPolyDefsAcc t acc)
+                | D_Module name => emitPolyDefsAcc t acc
+                | D_Import fromName symbolName => emitPolyDefsAcc t acc
+                | D_Export name => emitPolyDefsAcc t acc
+                | D_Opaque name => emitPolyDefsAcc t acc
+                | D_Native name => emitPolyDefsAcc t acc
+                | D_Type name => emitPolyDefsAcc t acc
+                | D_Data name ctors => emitPolyDefsAcc t acc
+              }
+        )
+
+poly emitPolyDefs =
+  \decls : List Decl => emitPolyDefsAcc (reverse [Decl] decls) (nil [U8])
+
+poly rec emitCombinatorDefsAcc =
+  \decls : List Decl =>
+    \acc : List U8 =>
+      matchList
+        [Decl]
+        [List U8]
+        decls
+        acc
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [List U8] {
+                | D_Def kind isRec name body =>
+                  if [List U8] (isCombinatorKind kind)
+                    (
+                      \u : U8 =>
+                        emitCombinatorDefsAcc
+                          t
+                          (
+                            append
+                              [U8]
+                              (emitOneNameLine prefixCombinator name)
+                              acc
+                          )
+                    )
+                    (\u : U8 => emitCombinatorDefsAcc t acc)
+                | D_Module name => emitCombinatorDefsAcc t acc
+                | D_Import fromName symbolName => emitCombinatorDefsAcc t acc
+                | D_Export name => emitCombinatorDefsAcc t acc
+                | D_Opaque name => emitCombinatorDefsAcc t acc
+                | D_Native name => emitCombinatorDefsAcc t acc
+                | D_Type name => emitCombinatorDefsAcc t acc
+                | D_Data name ctors => emitCombinatorDefsAcc t acc
+              }
+        )
+
+poly emitCombinatorDefs =
+  \decls : List Decl => emitCombinatorDefsAcc (reverse [Decl] decls) (nil [U8])
+
+poly parseModuleSource =
+  \bundleName : List U8 =>
+    \source : List U8 =>
+      match (tokenize source) [Result (List U8) (List Decl)] {
+        | Err e => Err [List U8] [List Decl] "Lex error"
+        | Ok toks =>
+          match (parseProgram toks) [Result (List U8) (List Decl)] {
+            | Err e =>
+              match e [Result (List U8) (List Decl)] {
+                | MkParseError msg => Err [List U8] [List Decl] msg
+              }
+            | Ok decls =>
               match (declaredModule decls) [Result (List U8) (List Decl)] {
                 | Err e => Err [List U8] [List Decl] e
                 | Ok declared =>
-                    if [Result (List U8) (List Decl)] (eqListU8 declared bundleName)
-                      (\u : U8 => Ok [List U8] [List Decl] decls)
-                      (\u : U8 => Err [List U8] [List Decl] "source module mismatch")
+                  if [Result (List U8) (List Decl)] (eqListU8 declared bundleName)
+                    (\u : U8 => Ok [List U8] [List Decl] decls)
+                    (
+                      \u : U8 => Err [List U8] [List Decl] "source module mismatch"
+                    )
               }
-        }
-  }
+          }
+      }
 
-poly emitParsedModule = \record : ModuleRecord =>
-  match record [Result (List U8) (List U8)] { | MkModuleRecord name lengthDigits source =>
-    match (parseModuleSource name source) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok decls =>
-          match (declaredModule decls) [Result (List U8) (List U8)] {
-            | Err e => Err [List U8] [List U8] e
-            | Ok declared =>
+poly emitParsedModule =
+  \record : ModuleRecord =>
+    match record [Result (List U8) (List U8)] {
+      | MkModuleRecord name lengthDigits source =>
+        match (parseModuleSource name source) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok decls =>
+            match (declaredModule decls) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] e
+              | Ok declared =>
                 let modLine = emitOneNameLine prefixModule name in
                 let declaredLine = emitOneNameLine prefixDeclared declared in
                 let impBlock = append [U8] (emitCountLine prefixImportsCount (countImports decls #u8(0))) (emitImports decls) in
@@ -467,55 +766,62 @@ poly emitParsedModule = \record : ModuleRecord =>
                 let tail5 = append [U8] expBlock tail4 in
                 let tail6 = append [U8] impBlock tail5 in
                 let tail7 = append [U8] declaredLine tail6 in
-                Ok [List U8] [List U8]
-                  (append [U8] modLine tail7)
-          }
-    }
-  }
-
-poly rec emitParsedModules = \recs : List ModuleRecord =>
-  matchList [ModuleRecord] [Result (List U8) (List U8)] recs
-    (Ok [List U8] [List U8] (nil [U8]))
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-      match (emitParsedModule h) [Result (List U8) (List U8)] {
-        | Err e => Err [List U8] [List U8] e
-        | Ok headText =>
-            match (emitParsedModules t) [Result (List U8) (List U8)] {
-              | Err e => Err [List U8] [List U8] e
-              | Ok tailText => Ok [List U8] [List U8] (append [U8] headText tailText)
+                Ok [List U8] [List U8] (append [U8] modLine tail7)
             }
-      })
-
-poly emitBundleParseSummary = \bundle : BundleSummary =>
-  match bundle [Result (List U8) (List U8)] { | MkBundleSummary entry target wrapper modsCountDigits mods =>
-    match (emitParsedModules mods) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok modsText =>
-          let tail0 = append [U8] newline modsText in
-          let tail1 = append [U8] modsCountDigits tail0 in
-          let tail2 = append [U8] prefixSummaryModules tail1 in
-          let tail3 = append [U8] wrapper tail2 in
-          let tail4 = append [U8] prefixSummaryWrapper tail3 in
-          let tail5 = append [U8] target tail4 in
-          let tail6 = append [U8] prefixSummaryTarget tail5 in
-          let tail7 = append [U8] entry tail6 in
-          Ok [List U8] [List U8]
-            (append [U8] prefixSummaryEntry tail7)
+        }
     }
-  }
 
-poly rec writeAll = \bytes : List U8 =>
-  matchList [U8] [U8] bytes
-    #u8(0)
-    (\h : U8 => \t : List U8 =>
-      writeOne h [U8] (\u : U8 => writeAll t))
+poly rec emitParsedModules =
+  \recs : List ModuleRecord =>
+    matchList
+      [ModuleRecord]
+      [Result (List U8) (List U8)]
+      recs
+      (Ok [List U8] [List U8] (nil [U8]))
+      (
+        \h : ModuleRecord =>
+          \t : List ModuleRecord =>
+            match (emitParsedModule h) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] e
+              | Ok headText =>
+                match (emitParsedModules t) [Result (List U8) (List U8)] {
+                  | Err e => Err [List U8] [List U8] e
+                  | Ok tailText =>
+                    Ok [List U8] [List U8] (append [U8] headText tailText)
+                }
+            }
+      )
 
-poly main = \source : List U8 =>
-  match (parseBundleSummary source) [U8] {
-    | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
-    | Ok bundle =>
+poly emitBundleParseSummary =
+  \bundle : BundleSummary =>
+    match bundle [Result (List U8) (List U8)] {
+      | MkBundleSummary entry target wrapper modsCountDigits mods =>
+        match (emitParsedModules mods) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok modsText =>
+            let tail0 = append [U8] newline modsText in
+            let tail1 = append [U8] modsCountDigits tail0 in
+            let tail2 = append [U8] prefixSummaryModules tail1 in
+            let tail3 = append [U8] wrapper tail2 in
+            let tail4 = append [U8] prefixSummaryWrapper tail3 in
+            let tail5 = append [U8] target tail4 in
+            let tail6 = append [U8] prefixSummaryTarget tail5 in
+            let tail7 = append [U8] entry tail6 in
+            Ok [List U8] [List U8] (append [U8] prefixSummaryEntry tail7)
+        }
+    }
+
+poly rec writeAll =
+  \bytes : List U8 =>
+    matchList [U8] [U8] bytes #u8(0) (\h : U8 => \t : List U8 => writeOne h [U8] (\u : U8 => writeAll t))
+
+poly main =
+  \source : List U8 =>
+    match (parseBundleSummary source) [U8] {
+      | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
+      | Ok bundle =>
         match (emitBundleParseSummary bundle) [U8] {
           | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
           | Ok summary => writeAll summary
         }
-  }
+    }

--- a/bootstrap/src/bundleSummary.trip
+++ b/bootstrap/src/bundleSummary.trip
@@ -1,458 +1,822 @@
 module BundleSummary
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude and
+
 import Prelude or
+
 import Prelude not
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude lteU8
+
 import Prelude eqListU8
+
 import Prelude ltListU8
+
 import Prelude digitToAscii
+
 import Prelude singletonU8
+
 import Prelude u8ToDigits
+
 import Prelude writeOne
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin addBin
+
 import Bin mulBin
+
 import Bin predBin
+
 import Bin isZeroBin
 
 export parseBundleSummary
+
 export emitBundleSummary
+
 export BundleSummary
+
 export MkBundleSummary
+
 export ModuleRecord
+
 export MkModuleRecord
+
 export main
 
-poly directiveEntry : List U8 = "entry"
-poly directiveTarget : List U8 = "target"
-poly directiveWrapper : List U8 = "wrapper"
-poly directiveModules : List U8 = "modules"
+poly directiveEntry : List U8 =
+  "entry"
 
-data Line = MkLine (List U8) (List U8)
-data Word = MkWord (List U8) (List U8)
-data ModuleRecord = MkModuleRecord (List U8) (List U8) (List U8)
-data BundleSummary = MkBundleSummary (List U8) (List U8) (List U8) (List U8) (List ModuleRecord)
-data ModuleHeader = MkModuleHeader (List U8) (List U8) Bin
-data SourcePayload = MkSourcePayload (List U8) (List U8)
-data ParsedModules = MkParsedModules Bool (List ModuleRecord) (List U8)
+poly directiveTarget : List U8 =
+  "target"
 
-poly binOne = B1 BZ
-poly binTwo = B0 (B1 BZ)
-poly binThree = B1 (B1 BZ)
-poly binFour = B0 (B0 (B1 BZ))
-poly binFive = B1 (B0 (B1 BZ))
-poly binSix = B0 (B1 (B1 BZ))
-poly binSeven = B1 (B1 (B1 BZ))
-poly binEight = B0 (B0 (B0 (B1 BZ)))
-poly binNine = B1 (B0 (B0 (B1 BZ)))
-poly binTen : Bin = B0 (B1 (B0 (B1 BZ)))
+poly directiveWrapper : List U8 =
+  "wrapper"
 
-poly isAscii = \b : U8 =>
-  ltU8 b #u8(128)
+poly directiveModules : List U8 =
+  "modules"
 
-poly isDigit = \b : U8 =>
-  and (lteU8 '0' b) (lteU8 b '9')
+data Line =
+  | MkLine (List U8) (List U8)
 
-poly isUpper = \b : U8 =>
-  and (lteU8 'A' b) (lteU8 b 'Z')
+data Word =
+  | MkWord (List U8) (List U8)
 
-poly isLower = \b : U8 =>
-  and (lteU8 'a' b) (lteU8 b 'z')
+data ModuleRecord =
+  | MkModuleRecord (List U8) (List U8) (List U8)
 
-poly isAlpha = \b : U8 =>
-  or (isUpper b) (isLower b)
+data BundleSummary =
+  | MkBundleSummary (List U8) (List U8) (List U8) (List U8) (List ModuleRecord)
 
-poly isNameStart = \b : U8 =>
-  or (isAlpha b) (eqU8 b '_')
+data ModuleHeader =
+  | MkModuleHeader (List U8) (List U8) Bin
 
-poly isNameChar = \b : U8 =>
-  or (isNameStart b) (isDigit b)
+data SourcePayload =
+  | MkSourcePayload (List U8) (List U8)
 
-poly rec validateNameRest = \name : List U8 =>
-  matchList [U8] [Bool] name
-    true
-    (\h : U8 => \t : List U8 =>
-      and (isNameChar h) (validateNameRest t))
+data ParsedModules =
+  | MkParsedModules Bool (List ModuleRecord) (List U8)
 
-poly validateName = \name : List U8 =>
-  matchList [U8] [Bool] name
-    false
-    (\h : U8 => \t : List U8 =>
-      and (isNameStart h) (validateNameRest t))
+poly binOne =
+  B1 BZ
 
-poly rec readLineAcc = \input : List U8 => \acc : List U8 =>
-  matchList [U8] [Result (List U8) Line] input
-    (Ok [List U8] [Line] (MkLine (reverse [U8] acc) (nil [U8])))
-    (\h : U8 => \t : List U8 =>
-      if [Result (List U8) Line] (not (isAscii h))
-        (\u : U8 => Err [List U8] [Line] "non-ascii byte")
-        (\u : U8 =>
-          if [Result (List U8) Line] (eqU8 h '\n')
-            (\u : U8 => Ok [List U8] [Line] (MkLine (reverse [U8] acc) t))
-            (\u : U8 => readLineAcc t (cons [U8] h acc))))
+poly binTwo =
+  B0 (B1 BZ)
 
-poly readLine = \input : List U8 =>
-  readLineAcc input (nil [U8])
+poly binThree =
+  B1 (B1 BZ)
 
-poly rec stripPrefix = \prefix : List U8 => \input : List U8 =>
-  matchList [U8] [Result (List U8) (List U8)] prefix
-    (Ok [List U8] [List U8] input)
-    (\ph : U8 => \pt : List U8 =>
-      matchList [U8] [Result (List U8) (List U8)] input
-        (Err [List U8] [List U8] "bad directive")
-        (\ih : U8 => \it : List U8 =>
-          if [Result (List U8) (List U8)] (eqU8 ph ih)
-            (\u : U8 => stripPrefix pt it)
-            (\u : U8 => Err [List U8] [List U8] "bad directive")))
+poly binFour =
+  B0 (B0 (B1 BZ))
 
-poly requireDirective = \name : List U8 => \line : List U8 =>
-  match (stripPrefix (append [U8] name " ") line) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [List U8] e
-    | Ok value =>
-        if [Result (List U8) (List U8)] (listIsEmpty [U8] value)
-          (\u : U8 => Err [List U8] [List U8] "empty directive")
-          (\u : U8 => Ok [List U8] [List U8] value)
-  }
+poly binFive =
+  B1 (B0 (B1 BZ))
 
-poly requireEntry = \line : List U8 =>
-  requireDirective directiveEntry line
+poly binSix =
+  B0 (B1 (B1 BZ))
 
-poly requireTarget = \line : List U8 =>
-  requireDirective directiveTarget line
+poly binSeven =
+  B1 (B1 (B1 BZ))
 
-poly requireWrapper = \line : List U8 =>
-  requireDirective directiveWrapper line
+poly binEight =
+  B0 (B0 (B0 (B1 BZ)))
 
-poly requireModules = \line : List U8 =>
-  requireDirective directiveModules line
+poly binNine =
+  B1 (B0 (B0 (B1 BZ)))
 
-poly rec readWordAcc = \input : List U8 => \acc : List U8 =>
-  matchList [U8] [Word] input
-    (MkWord (reverse [U8] acc) (nil [U8]))
-    (\h : U8 => \t : List U8 =>
-      if [Word] (eqU8 h ' ')
-        (\u : U8 => MkWord (reverse [U8] acc) t)
-        (\u : U8 => readWordAcc t (cons [U8] h acc)))
+poly binTen : Bin =
+  B0 (B1 (B0 (B1 BZ)))
 
-poly readWord = \input : List U8 =>
-  readWordAcc input (nil [U8])
+poly isAscii =
+  \b : U8 => ltU8 b #u8(128)
 
-poly rec decimalDigitValue = \digit : U8 =>
-  if [Bin] (eqU8 digit '0')
-    (\u : U8 => BZ)
-    (\u : U8 =>
-      if [Bin] (eqU8 digit '1')
-        (\u : U8 => binOne)
-        (\u : U8 =>
-          if [Bin] (eqU8 digit '2')
-            (\u : U8 => binTwo)
-            (\u : U8 =>
-              if [Bin] (eqU8 digit '3')
-                (\u : U8 => binThree)
-                (\u : U8 =>
-                  if [Bin] (eqU8 digit '4')
-                    (\u : U8 => binFour)
-                    (\u : U8 =>
-                      if [Bin] (eqU8 digit '5')
-                        (\u : U8 => binFive)
-                        (\u : U8 =>
-                          if [Bin] (eqU8 digit '6')
-                            (\u : U8 => binSix)
-                            (\u : U8 =>
-                              if [Bin] (eqU8 digit '7')
-                                (\u : U8 => binSeven)
-                                (\u : U8 =>
-                                  if [Bin] (eqU8 digit '8')
-                                    (\u : U8 => binEight)
-                                    (\u : U8 => binNine)))))))))
+poly isDigit =
+  \b : U8 => and (lteU8 '0' b) (lteU8 b '9')
 
-poly rec parseDecimalAcc = \digits : List U8 => \acc : Bin =>
-  matchList [U8] [Result (List U8) Bin] digits
-    (Ok [List U8] [Bin] acc)
-    (\h : U8 => \t : List U8 =>
-      if [Result (List U8) Bin] (isDigit h)
-        (\u : U8 =>
-          parseDecimalAcc t (addBin (mulBin acc binTen) (decimalDigitValue h)))
-        (\u : U8 => Err [List U8] [Bin] "bad decimal"))
+poly isUpper =
+  \b : U8 => and (lteU8 'A' b) (lteU8 b 'Z')
 
-poly parseDecimal = \digits : List U8 =>
-  matchList [U8] [Result (List U8) Bin] digits
-    (Err [List U8] [Bin] "empty decimal")
-    (\h : U8 => \t : List U8 =>
-      if [Result (List U8) Bin] (eqU8 h '0')
-        (\u : U8 =>
-          if [Result (List U8) Bin] (listIsEmpty [U8] t)
-            (\u : U8 => Ok [List U8] [Bin] BZ)
-            (\u : U8 => Err [List U8] [Bin] "non-canonical decimal"))
-        (\u : U8 =>
-          if [Result (List U8) Bin] (isDigit h)
-            (\u : U8 => parseDecimalAcc t (decimalDigitValue h))
-            (\u : U8 => Err [List U8] [Bin] "bad decimal")))
+poly isLower =
+  \b : U8 => and (lteU8 'a' b) (lteU8 b 'z')
 
-poly parseModuleHeader = \line : List U8 =>
-  match (stripPrefix "module " line) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [ModuleHeader] "bad module header"
-    | Ok rest =>
-        match (readWord rest) [Result (List U8) ModuleHeader] { | MkWord name lengthDigits =>
-          if [Result (List U8) ModuleHeader] (validateName name)
-            (\u : U8 =>
-              match (parseDecimal lengthDigits) [Result (List U8) ModuleHeader] {
-                | Err e => Err [List U8] [ModuleHeader] e
-                | Ok length =>
-                    Ok [List U8] [ModuleHeader] (MkModuleHeader name lengthDigits length)
-              })
-            (\u : U8 => Err [List U8] [ModuleHeader] "bad module name")
+poly isAlpha =
+  \b : U8 => or (isUpper b) (isLower b)
+
+poly isNameStart =
+  \b : U8 => or (isAlpha b) (eqU8 b '_')
+
+poly isNameChar =
+  \b : U8 => or (isNameStart b) (isDigit b)
+
+poly rec validateNameRest =
+  \name : List U8 =>
+    matchList
+      [U8]
+      [Bool]
+      name
+      true
+      (\h : U8 => \t : List U8 => and (isNameChar h) (validateNameRest t))
+
+poly validateName =
+  \name : List U8 =>
+    matchList
+      [U8]
+      [Bool]
+      name
+      false
+      (\h : U8 => \t : List U8 => and (isNameStart h) (validateNameRest t))
+
+poly rec readLineAcc =
+  \input : List U8 =>
+    \acc : List U8 =>
+      matchList
+        [U8]
+        [Result (List U8) Line]
+        input
+        (Ok [List U8] [Line] (MkLine (reverse [U8] acc) (nil [U8])))
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Result (List U8) Line] (not (isAscii h))
+                (\u : U8 => Err [List U8] [Line] "non-ascii byte")
+                (
+                  \u : U8 =>
+                    if [Result (List U8) Line] (eqU8 h '\n')
+                      (
+                        \u : U8 => Ok [List U8] [Line] (MkLine (reverse [U8] acc) t)
+                      )
+                      (\u : U8 => readLineAcc t (cons [U8] h acc))
+                )
+        )
+
+poly readLine =
+  \input : List U8 => readLineAcc input (nil [U8])
+
+poly rec stripPrefix =
+  \prefix : List U8 =>
+    \input : List U8 =>
+      matchList
+        [U8]
+        [Result (List U8) (List U8)]
+        prefix
+        (Ok [List U8] [List U8] input)
+        (
+          \ph : U8 =>
+            \pt : List U8 =>
+              matchList
+                [U8]
+                [Result (List U8) (List U8)]
+                input
+                (Err [List U8] [List U8] "bad directive")
+                (
+                  \ih : U8 =>
+                    \it : List U8 =>
+                      if [Result (List U8) (List U8)] (eqU8 ph ih)
+                        (\u : U8 => stripPrefix pt it)
+                        (\u : U8 => Err [List U8] [List U8] "bad directive")
+                )
+        )
+
+poly requireDirective =
+  \name : List U8 =>
+    \line : List U8 =>
+      match (stripPrefix (append [U8] name " ") line) [Result (List U8) (List U8)] {
+        | Err e => Err [List U8] [List U8] e
+        | Ok value =>
+          if [Result (List U8) (List U8)] (listIsEmpty [U8] value)
+            (\u : U8 => Err [List U8] [List U8] "empty directive")
+            (\u : U8 => Ok [List U8] [List U8] value)
+      }
+
+poly requireEntry =
+  \line : List U8 => requireDirective directiveEntry line
+
+poly requireTarget =
+  \line : List U8 => requireDirective directiveTarget line
+
+poly requireWrapper =
+  \line : List U8 => requireDirective directiveWrapper line
+
+poly requireModules =
+  \line : List U8 => requireDirective directiveModules line
+
+poly rec readWordAcc =
+  \input : List U8 =>
+    \acc : List U8 =>
+      matchList
+        [U8]
+        [Word]
+        input
+        (MkWord (reverse [U8] acc) (nil [U8]))
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Word] (eqU8 h ' ')
+                (\u : U8 => MkWord (reverse [U8] acc) t)
+                (\u : U8 => readWordAcc t (cons [U8] h acc))
+        )
+
+poly readWord =
+  \input : List U8 => readWordAcc input (nil [U8])
+
+poly rec decimalDigitValue =
+  \digit : U8 =>
+    if [Bin] (eqU8 digit '0')
+      (\u : U8 => BZ)
+      (
+        \u : U8 =>
+          if [Bin] (eqU8 digit '1')
+            (\u : U8 => binOne)
+            (
+              \u : U8 =>
+                if [Bin] (eqU8 digit '2')
+                  (\u : U8 => binTwo)
+                  (
+                    \u : U8 =>
+                      if [Bin] (eqU8 digit '3')
+                        (\u : U8 => binThree)
+                        (
+                          \u : U8 =>
+                            if [Bin] (eqU8 digit '4')
+                              (\u : U8 => binFour)
+                              (
+                                \u : U8 =>
+                                  if [Bin] (eqU8 digit '5')
+                                    (\u : U8 => binFive)
+                                    (
+                                      \u : U8 =>
+                                        if [Bin] (eqU8 digit '6')
+                                          (\u : U8 => binSix)
+                                          (
+                                            \u : U8 =>
+                                              if [Bin] (eqU8 digit '7')
+                                                (\u : U8 => binSeven)
+                                                (
+                                                  \u : U8 =>
+                                                    if [Bin] (eqU8 digit '8')
+                                                      (\u : U8 => binEight)
+                                                      (\u : U8 => binNine)
+                                                )
+                                          )
+                                    )
+                              )
+                        )
+                  )
+            )
+      )
+
+poly rec parseDecimalAcc =
+  \digits : List U8 =>
+    \acc : Bin =>
+      matchList
+        [U8]
+        [Result (List U8) Bin]
+        digits
+        (Ok [List U8] [Bin] acc)
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Result (List U8) Bin] (isDigit h)
+                (
+                  \u : U8 =>
+                    parseDecimalAcc
+                      t
+                      (addBin (mulBin acc binTen) (decimalDigitValue h))
+                )
+                (\u : U8 => Err [List U8] [Bin] "bad decimal")
+        )
+
+poly parseDecimal =
+  \digits : List U8 =>
+    matchList
+      [U8]
+      [Result (List U8) Bin]
+      digits
+      (Err [List U8] [Bin] "empty decimal")
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [Result (List U8) Bin] (eqU8 h '0')
+              (
+                \u : U8 =>
+                  if [Result (List U8) Bin] (listIsEmpty [U8] t)
+                    (\u : U8 => Ok [List U8] [Bin] BZ)
+                    (\u : U8 => Err [List U8] [Bin] "non-canonical decimal")
+              )
+              (
+                \u : U8 =>
+                  if [Result (List U8) Bin] (isDigit h)
+                    (\u : U8 => parseDecimalAcc t (decimalDigitValue h))
+                    (\u : U8 => Err [List U8] [Bin] "bad decimal")
+              )
+      )
+
+poly parseModuleHeader =
+  \line : List U8 =>
+    match (stripPrefix "module " line) [Result (List U8) (List U8)] {
+      | Err e => Err [List U8] [ModuleHeader] "bad module header"
+      | Ok rest =>
+        match (readWord rest) [Result (List U8) ModuleHeader] {
+          | MkWord name lengthDigits =>
+            if [Result (List U8) ModuleHeader] (validateName name)
+              (
+                \u : U8 =>
+                  match (parseDecimal lengthDigits) [Result (List U8) ModuleHeader] {
+                    | Err e => Err [List U8] [ModuleHeader] e
+                    | Ok length =>
+                      Ok
+                        [List U8]
+                        [ModuleHeader]
+                        (MkModuleHeader name lengthDigits length)
+                  }
+              )
+              (\u : U8 => Err [List U8] [ModuleHeader] "bad module name")
         }
-  }
+    }
 
-poly rec consumeSourceAcc = \count : Bin => \input : List U8 => \acc : List U8 =>
-  if [Result (List U8) SourcePayload] (isZeroBin count)
-    (\u : U8 => Ok [List U8] [SourcePayload] (MkSourcePayload (reverse [U8] acc) input))
-    (\u : U8 =>
-      matchList [U8] [Result (List U8) SourcePayload] input
-        (Err [List U8] [SourcePayload] "source ended early")
-        (\h : U8 => \t : List U8 =>
-          if [Result (List U8) SourcePayload] (isAscii h)
-            (\u : U8 => consumeSourceAcc (predBin count) t (cons [U8] h acc))
-            (\u : U8 => Err [List U8] [SourcePayload] "non-ascii byte")))
+poly rec consumeSourceAcc =
+  \count : Bin =>
+    \input : List U8 =>
+      \acc : List U8 =>
+        if [Result (List U8) SourcePayload] (isZeroBin count)
+          (
+            \u : U8 =>
+              Ok
+                [List U8]
+                [SourcePayload]
+                (MkSourcePayload (reverse [U8] acc) input)
+          )
+          (
+            \u : U8 =>
+              matchList
+                [U8]
+                [Result (List U8) SourcePayload]
+                input
+                (Err [List U8] [SourcePayload] "source ended early")
+                (
+                  \h : U8 =>
+                    \t : List U8 =>
+                      if [Result (List U8) SourcePayload] (isAscii h)
+                        (
+                          \u : U8 => consumeSourceAcc (predBin count) t (cons [U8] h acc)
+                        )
+                        (
+                          \u : U8 => Err [List U8] [SourcePayload] "non-ascii byte"
+                        )
+                )
+          )
 
-poly consumeSource = \count : Bin => \input : List U8 =>
-  consumeSourceAcc count input (nil [U8])
+poly consumeSource =
+  \count : Bin => \input : List U8 => consumeSourceAcc count input (nil [U8])
 
-poly declaredModuleName = \source : List U8 =>
-  match (readLine source) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [List U8] e
-    | Ok lineRes =>
-        match lineRes [Result (List U8) (List U8)] { | MkLine line rest =>
-          match (stripPrefix "module " line) [Result (List U8) (List U8)] {
-            | Err e => Err [List U8] [List U8] "bad source module"
-            | Ok name =>
+poly declaredModuleName =
+  \source : List U8 =>
+    match (readLine source) [Result (List U8) (List U8)] {
+      | Err e => Err [List U8] [List U8] e
+      | Ok lineRes =>
+        match lineRes [Result (List U8) (List U8)] {
+          | MkLine line rest =>
+            match (stripPrefix "module " line) [Result (List U8) (List U8)] {
+              | Err e => Err [List U8] [List U8] "bad source module"
+              | Ok name =>
                 if [Result (List U8) (List U8)] (validateName name)
                   (\u : U8 => Ok [List U8] [List U8] name)
                   (\u : U8 => Err [List U8] [List U8] "bad source module")
-          }
-        }
-  }
-
-poly parseTarget = \value : List U8 =>
-  if [Result (List U8) (List U8)] (eqListU8 value "generic")
-    (\u : U8 => Ok [List U8] [List U8] value)
-    (\u : U8 =>
-      if [Result (List U8) (List U8)] (eqListU8 value "x86_64-unknown-linux-gnu")
-        (\u : U8 => Ok [List U8] [List U8] value)
-        (\u : U8 =>
-          if [Result (List U8) (List U8)] (eqListU8 value "arm64-apple-darwin")
-            (\u : U8 => Ok [List U8] [List U8] value)
-            (\u : U8 =>
-              if [Result (List U8) (List U8)] (eqListU8 value "x86_64-pc-windows-msvc")
-                (\u : U8 => Ok [List U8] [List U8] value)
-                (\u : U8 => Err [List U8] [List U8] "bad target"))))
-
-poly parseWrapper = \value : List U8 =>
-  if [Result (List U8) (List U8)] (eqListU8 value "none")
-    (\u : U8 => Ok [List U8] [List U8] value)
-    (\u : U8 =>
-      if [Result (List U8) (List U8)] (eqListU8 value "enabled")
-        (\u : U8 => Ok [List U8] [List U8] value)
-        (\u : U8 => Err [List U8] [List U8] "bad wrapper"))
-
-poly rec parseModules = \remaining : List U8 => \count : Bin => \entry : List U8 => \previous : Maybe (List U8) => \entryFound : Bool => \accRev : List ModuleRecord =>
-  if [Result (List U8) ParsedModules] (isZeroBin count)
-    (\u : U8 =>
-      if [Result (List U8) ParsedModules] (listIsEmpty [U8] remaining)
-        (\u : U8 =>
-          if [Result (List U8) ParsedModules] entryFound
-            (\u : U8 => Ok [List U8] [ParsedModules] (MkParsedModules entryFound (reverse [ModuleRecord] accRev) remaining))
-            (\u : U8 => Err [List U8] [ParsedModules] "missing entry"))
-        (\u : U8 => Err [List U8] [ParsedModules] "trailing bytes"))
-    (\u : U8 =>
-      match (readLine remaining) [Result (List U8) ParsedModules] {
-        | Err e => Err [List U8] [ParsedModules] e
-        | Ok lineRes =>
-            match lineRes [Result (List U8) ParsedModules] { | MkLine line afterHeader =>
-              match (parseModuleHeader line) [Result (List U8) ParsedModules] {
-                | Err e => Err [List U8] [ParsedModules] e
-                | Ok header =>
-                    match header [Result (List U8) ParsedModules] { | MkModuleHeader name lengthDigits length =>
-                      let orderOk =
-                        match previous [Bool] {
-                          | None => true
-                          | Some prev => ltListU8 prev name
-                        } in
-                      if [Result (List U8) ParsedModules] orderOk
-                        (\u : U8 =>
-                          match (consumeSource length afterHeader) [Result (List U8) ParsedModules] {
-                            | Err e => Err [List U8] [ParsedModules] e
-                            | Ok payload =>
-                                match payload [Result (List U8) ParsedModules] { | MkSourcePayload source afterSource =>
-                                  match (declaredModuleName source) [Result (List U8) ParsedModules] {
-                                    | Err e => Err [List U8] [ParsedModules] e
-                                    | Ok declared =>
-                                        if [Result (List U8) ParsedModules] (eqListU8 declared name)
-                                          (\u : U8 =>
-                                            let nextCount = predBin count in
-                                            let nextEntryFound = or entryFound (eqListU8 name entry) in
-                                            let nextAcc = cons [ModuleRecord] (MkModuleRecord name lengthDigits source) accRev in
-                                            if [Result (List U8) ParsedModules] (isZeroBin nextCount)
-                                              (\u : U8 => parseModules afterSource nextCount entry (Some [List U8] name) nextEntryFound nextAcc)
-                                              (\u : U8 =>
-                                                matchList [U8] [Result (List U8) ParsedModules] afterSource
-                                                  (Err [List U8] [ParsedModules] "missing module separator")
-                                                  (\sep : U8 => \afterSep : List U8 =>
-                                                    if [Result (List U8) ParsedModules] (eqU8 sep '\n')
-                                                      (\u : U8 => parseModules afterSep nextCount entry (Some [List U8] name) nextEntryFound nextAcc)
-                                                      (\u : U8 => Err [List U8] [ParsedModules] "missing module separator"))))
-                                          (\u : U8 => Err [List U8] [ParsedModules] "source module mismatch")
-                                  }
-                                }
-                          })
-                        (\u : U8 =>
-                          match previous [Result (List U8) ParsedModules] {
-                            | None => Err [List U8] [ParsedModules] "module order"
-                            | Some prev =>
-                                if [Result (List U8) ParsedModules] (eqListU8 prev name)
-                                  (\u : U8 => Err [List U8] [ParsedModules] "duplicate module")
-                                  (\u : U8 => Err [List U8] [ParsedModules] "module order")
-                          })
-                    }
-              }
             }
-      })
+        }
+    }
 
-poly parseBundleSummary = \input : List U8 =>
-  match (readLine input) [Result (List U8) BundleSummary] {
-    | Err e => Err [List U8] [BundleSummary] e
-    | Ok magicRes =>
-        match magicRes [Result (List U8) BundleSummary] { | MkLine magic afterMagic =>
-          if [Result (List U8) BundleSummary] (eqListU8 magic "TRIP-BUNDLE-V1")
-            (\u : U8 =>
-              match (readLine afterMagic) [Result (List U8) BundleSummary] {
-                | Err e => Err [List U8] [BundleSummary] e
-                | Ok entryLineRes =>
-                    match entryLineRes [Result (List U8) BundleSummary] { | MkLine entryLine afterEntry =>
-                      match (requireEntry entryLine) [Result (List U8) BundleSummary] {
-                        | Err e => Err [List U8] [BundleSummary] e
-                        | Ok entry =>
-                            if [Result (List U8) BundleSummary] (validateName entry)
-                              (\u : U8 =>
-                                match (readLine afterEntry) [Result (List U8) BundleSummary] {
-                                  | Err e => Err [List U8] [BundleSummary] e
-                                  | Ok targetLineRes =>
-                                      match targetLineRes [Result (List U8) BundleSummary] { | MkLine targetLine afterTarget =>
-                                        match (requireTarget targetLine) [Result (List U8) BundleSummary] {
-                                          | Err e => Err [List U8] [BundleSummary] e
-                                          | Ok targetValue =>
-                                              match (parseTarget targetValue) [Result (List U8) BundleSummary] {
-                                                | Err e => Err [List U8] [BundleSummary] e
-                                                | Ok target =>
+poly parseTarget =
+  \value : List U8 =>
+    if [Result (List U8) (List U8)] (eqListU8 value "generic")
+      (\u : U8 => Ok [List U8] [List U8] value)
+      (
+        \u : U8 =>
+          if [Result (List U8) (List U8)] (eqListU8 value "x86_64-unknown-linux-gnu")
+            (\u : U8 => Ok [List U8] [List U8] value)
+            (
+              \u : U8 =>
+                if [Result (List U8) (List U8)] (eqListU8 value "arm64-apple-darwin")
+                  (\u : U8 => Ok [List U8] [List U8] value)
+                  (
+                    \u : U8 =>
+                      if [Result (List U8) (List U8)] (eqListU8 value "x86_64-pc-windows-msvc")
+                        (\u : U8 => Ok [List U8] [List U8] value)
+                        (\u : U8 => Err [List U8] [List U8] "bad target")
+                  )
+            )
+      )
+
+poly parseWrapper =
+  \value : List U8 =>
+    if [Result (List U8) (List U8)] (eqListU8 value "none")
+      (\u : U8 => Ok [List U8] [List U8] value)
+      (
+        \u : U8 =>
+          if [Result (List U8) (List U8)] (eqListU8 value "enabled")
+            (\u : U8 => Ok [List U8] [List U8] value)
+            (\u : U8 => Err [List U8] [List U8] "bad wrapper")
+      )
+
+poly rec parseModules =
+  \remaining : List U8 =>
+    \count : Bin =>
+      \entry : List U8 =>
+        \previous : Maybe (List U8) =>
+          \entryFound : Bool =>
+            \accRev : List ModuleRecord =>
+              if [Result (List U8) ParsedModules] (isZeroBin count)
+                (
+                  \u : U8 =>
+                    if [Result (List U8) ParsedModules] (listIsEmpty [U8] remaining)
+                      (
+                        \u : U8 =>
+                          if [Result (List U8) ParsedModules] entryFound
+                            (
+                              \u : U8 =>
+                                Ok
+                                  [List U8]
+                                  [ParsedModules]
+                                  (
+                                    MkParsedModules
+                                      entryFound
+                                      (reverse [ModuleRecord] accRev)
+                                      remaining
+                                  )
+                            )
+                            (
+                              \u : U8 => Err [List U8] [ParsedModules] "missing entry"
+                            )
+                      )
+                      (
+                        \u : U8 => Err [List U8] [ParsedModules] "trailing bytes"
+                      )
+                )
+                (
+                  \u : U8 =>
+                    match (readLine remaining) [Result (List U8) ParsedModules] {
+                      | Err e => Err [List U8] [ParsedModules] e
+                      | Ok lineRes =>
+                        match lineRes [Result (List U8) ParsedModules] {
+                          | MkLine line afterHeader =>
+                            match (parseModuleHeader line) [Result (List U8) ParsedModules] {
+                              | Err e => Err [List U8] [ParsedModules] e
+                              | Ok header =>
+                                match header [Result (List U8) ParsedModules] {
+                                  | MkModuleHeader name lengthDigits length =>
+                                    let orderOk = match previous [Bool] {| None => true | Some prev => ltListU8 prev name} in
+                                    if [Result (List U8) ParsedModules] orderOk
+                                      (
+                                        \u : U8 =>
+                                          match (consumeSource length afterHeader) [Result (List U8) ParsedModules] {
+                                            | Err e => Err [List U8] [ParsedModules] e
+                                            | Ok payload =>
+                                              match payload [Result (List U8) ParsedModules] {
+                                                | MkSourcePayload source afterSource =>
+                                                  match (declaredModuleName source) [Result (List U8) ParsedModules] {
+                                                    | Err e => Err [List U8] [ParsedModules] e
+                                                    | Ok declared =>
+                                                      if [Result (List U8) ParsedModules] (eqListU8 declared name)
+                                                        (
+                                                          \u : U8 =>
+                                                            let nextCount = predBin count in
+                                                            let nextEntryFound = or entryFound (eqListU8 name entry) in
+                                                            let nextAcc = cons [ModuleRecord] (MkModuleRecord name lengthDigits source) accRev in
+                                                            if [Result (List U8) ParsedModules] (isZeroBin nextCount)
+                                                              (
+                                                                \u : U8 =>
+                                                                  parseModules
+                                                                    afterSource
+                                                                    nextCount
+                                                                    entry
+                                                                    (
+                                                                      Some
+                                                                        [List U8]
+                                                                        name
+                                                                    )
+                                                                    nextEntryFound
+                                                                    nextAcc
+                                                              )
+                                                              (
+                                                                \u : U8 =>
+                                                                  matchList
+                                                                    [U8]
+                                                                    [Result (List U8) ParsedModules]
+                                                                    afterSource
+                                                                    (
+                                                                      Err
+                                                                        [List U8]
+                                                                        [ParsedModules]
+                                                                        "missing module separator"
+                                                                    )
+                                                                    (
+                                                                      \sep : U8 =>
+                                                                        \afterSep : List U8 =>
+                                                                          if [Result (List U8) ParsedModules] (eqU8 sep '\n')
+                                                                            (
+                                                                              \u : U8 =>
+                                                                                parseModules
+                                                                                  afterSep
+                                                                                  nextCount
+                                                                                  entry
+                                                                                  (
+                                                                                    Some
+                                                                                      [List U8]
+                                                                                      name
+                                                                                  )
+                                                                                  nextEntryFound
+                                                                                  nextAcc
+                                                                            )
+                                                                            (
+                                                                              \u : U8 => Err [List U8] [ParsedModules] "missing module separator"
+                                                                            )
+                                                                    )
+                                                              )
+                                                        )
+                                                        (
+                                                          \u : U8 => Err [List U8] [ParsedModules] "source module mismatch"
+                                                        )
+                                                  }
+                                              }
+                                          }
+                                      )
+                                      (
+                                        \u : U8 =>
+                                          match previous [Result (List U8) ParsedModules] {
+                                            | None => Err [List U8] [ParsedModules] "module order"
+                                            | Some prev =>
+                                              if [Result (List U8) ParsedModules] (eqListU8 prev name)
+                                                (
+                                                  \u : U8 => Err [List U8] [ParsedModules] "duplicate module"
+                                                )
+                                                (
+                                                  \u : U8 => Err [List U8] [ParsedModules] "module order"
+                                                )
+                                          }
+                                      )
+                                }
+                            }
+                        }
+                    }
+                )
+
+poly parseBundleSummary =
+  \input : List U8 =>
+    match (readLine input) [Result (List U8) BundleSummary] {
+      | Err e => Err [List U8] [BundleSummary] e
+      | Ok magicRes =>
+        match magicRes [Result (List U8) BundleSummary] {
+          | MkLine magic afterMagic =>
+            if [Result (List U8) BundleSummary] (eqListU8 magic "TRIP-BUNDLE-V1")
+              (
+                \u : U8 =>
+                  match (readLine afterMagic) [Result (List U8) BundleSummary] {
+                    | Err e => Err [List U8] [BundleSummary] e
+                    | Ok entryLineRes =>
+                      match entryLineRes [Result (List U8) BundleSummary] {
+                        | MkLine entryLine afterEntry =>
+                          match (requireEntry entryLine) [Result (List U8) BundleSummary] {
+                            | Err e => Err [List U8] [BundleSummary] e
+                            | Ok entry =>
+                              if [Result (List U8) BundleSummary] (validateName entry)
+                                (
+                                  \u : U8 =>
+                                    match (readLine afterEntry) [Result (List U8) BundleSummary] {
+                                      | Err e => Err [List U8] [BundleSummary] e
+                                      | Ok targetLineRes =>
+                                        match targetLineRes [Result (List U8) BundleSummary] {
+                                          | MkLine targetLine afterTarget =>
+                                            match (requireTarget targetLine) [Result (List U8) BundleSummary] {
+                                              | Err e => Err [List U8] [BundleSummary] e
+                                              | Ok targetValue =>
+                                                match (parseTarget targetValue) [Result (List U8) BundleSummary] {
+                                                  | Err e => Err [List U8] [BundleSummary] e
+                                                  | Ok target =>
                                                     match (readLine afterTarget) [Result (List U8) BundleSummary] {
                                                       | Err e => Err [List U8] [BundleSummary] e
                                                       | Ok wrapperLineRes =>
-                                                          match wrapperLineRes [Result (List U8) BundleSummary] { | MkLine wrapperLine afterWrapper =>
+                                                        match wrapperLineRes [Result (List U8) BundleSummary] {
+                                                          | MkLine wrapperLine afterWrapper =>
                                                             match (requireWrapper wrapperLine) [Result (List U8) BundleSummary] {
                                                               | Err e => Err [List U8] [BundleSummary] e
                                                               | Ok wrapperValue =>
-                                                                  match (parseWrapper wrapperValue) [Result (List U8) BundleSummary] {
-                                                                    | Err e => Err [List U8] [BundleSummary] e
-                                                                    | Ok wrapper =>
-                                                                        match (readLine afterWrapper) [Result (List U8) BundleSummary] {
-                                                                          | Err e => Err [List U8] [BundleSummary] e
-                                                                          | Ok modulesLineRes =>
-                                                                              match modulesLineRes [Result (List U8) BundleSummary] { | MkLine modsLine afterModules =>
-                                                                                match (requireModules modsLine) [Result (List U8) BundleSummary] {
+                                                                match (parseWrapper wrapperValue) [Result (List U8) BundleSummary] {
+                                                                  | Err e => Err [List U8] [BundleSummary] e
+                                                                  | Ok wrapper =>
+                                                                    match (readLine afterWrapper) [Result (List U8) BundleSummary] {
+                                                                      | Err e => Err [List U8] [BundleSummary] e
+                                                                      | Ok modulesLineRes =>
+                                                                        match modulesLineRes [Result (List U8) BundleSummary] {
+                                                                          | MkLine modsLine afterModules =>
+                                                                            match (requireModules modsLine) [Result (List U8) BundleSummary] {
+                                                                              | Err e => Err [List U8] [BundleSummary] e
+                                                                              | Ok modsCountDigits =>
+                                                                                match (parseDecimal modsCountDigits) [Result (List U8) BundleSummary] {
                                                                                   | Err e => Err [List U8] [BundleSummary] e
-                                                                                  | Ok modsCountDigits =>
-                                                                                      match (parseDecimal modsCountDigits) [Result (List U8) BundleSummary] {
-                                                                                        | Err e => Err [List U8] [BundleSummary] e
-                                                                                        | Ok modsCount =>
-                                                                                            match (parseModules afterModules modsCount entry (None [List U8]) false (nil [ModuleRecord])) [Result (List U8) BundleSummary] {
-                                                                                              | Err e => Err [List U8] [BundleSummary] e
-                                                                                              | Ok parsed =>
-                                                                                                  match parsed [Result (List U8) BundleSummary] { | MkParsedModules found mods rest =>
-                                                                                                    Ok [List U8] [BundleSummary] (MkBundleSummary entry target wrapper modsCountDigits mods)
-                                                                                                  }
-                                                                                            }
-                                                                                      }
+                                                                                  | Ok modsCount =>
+                                                                                    match (parseModules afterModules modsCount entry (None [List U8]) false (nil [ModuleRecord])) [Result (List U8) BundleSummary] {
+                                                                                      | Err e => Err [List U8] [BundleSummary] e
+                                                                                      | Ok parsed =>
+                                                                                        match parsed [Result (List U8) BundleSummary] {
+                                                                                          | MkParsedModules found mods rest =>
+                                                                                            Ok
+                                                                                              [List U8]
+                                                                                              [BundleSummary]
+                                                                                              (
+                                                                                                MkBundleSummary
+                                                                                                  entry
+                                                                                                  target
+                                                                                                  wrapper
+                                                                                                  modsCountDigits
+                                                                                                  mods
+                                                                                              )
+                                                                                        }
+                                                                                    }
                                                                                 }
-                                                                              }
+                                                                            }
                                                                         }
-                                                                  }
+                                                                    }
+                                                                }
                                                             }
-                                                          }
+                                                        }
                                                     }
-                                              }
+                                                }
+                                            }
                                         }
-                                      }
-                                })
-                              (\u : U8 => Err [List U8] [BundleSummary] "bad entry name")
+                                    }
+                                )
+                                (
+                                  \u : U8 => Err [List U8] [BundleSummary] "bad entry name"
+                                )
+                          }
                       }
-                    }
-              })
-            (\u : U8 => Err [List U8] [BundleSummary] "bad magic")
+                  }
+              )
+              (\u : U8 => Err [List U8] [BundleSummary] "bad magic")
         }
-  }
+    }
 
-poly emitModuleSummary = \modRec : ModuleRecord =>
-  match modRec [List U8] { | MkModuleRecord name lengthDigits source =>
-    append [U8] "module " (append [U8] name (append [U8] " " (append [U8] lengthDigits "\n")))
-  }
+poly emitModuleSummary =
+  \modRec : ModuleRecord =>
+    match modRec [List U8] {
+      | MkModuleRecord name lengthDigits source =>
+        append
+          [U8]
+          "module "
+          (append [U8] name (append [U8] " " (append [U8] lengthDigits "\n")))
+    }
 
-poly rec emitModuleSummaries = \mods : List ModuleRecord =>
-  matchList [ModuleRecord] [List U8] mods
-    (nil [U8])
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-      append [U8] (emitModuleSummary h) (emitModuleSummaries t))
+poly rec emitModuleSummaries =
+  \mods : List ModuleRecord =>
+    matchList
+      [ModuleRecord]
+      [List U8]
+      mods
+      (nil [U8])
+      (
+        \h : ModuleRecord =>
+          \t : List ModuleRecord => append [U8] (emitModuleSummary h) (emitModuleSummaries t)
+      )
 
-poly emitBundleSummary = \bundle : BundleSummary =>
-  match bundle [List U8] { | MkBundleSummary entry target wrapper modsCountDigits mods =>
-    append [U8] "OK\n"
-      (append [U8] "version bundle-v1\n"
-        (append [U8] "entry "
-          (append [U8] entry
-            (append [U8] "\ntarget "
-              (append [U8] target
-                (append [U8] "\nwrapper "
-                  (append [U8] wrapper
-                    (append [U8] "\nmodules "
-                      (append [U8] modsCountDigits
-                        (append [U8] "\n" (emitModuleSummaries mods)))))))))))
-  }
+poly emitBundleSummary =
+  \bundle : BundleSummary =>
+    match bundle [List U8] {
+      | MkBundleSummary entry target wrapper modsCountDigits mods =>
+        append
+          [U8]
+          "OK\n"
+          (
+            append
+              [U8]
+              "version bundle-v1\n"
+              (
+                append
+                  [U8]
+                  "entry "
+                  (
+                    append
+                      [U8]
+                      entry
+                      (
+                        append
+                          [U8]
+                          "\ntarget "
+                          (
+                            append
+                              [U8]
+                              target
+                              (
+                                append
+                                  [U8]
+                                  "\nwrapper "
+                                  (
+                                    append
+                                      [U8]
+                                      wrapper
+                                      (
+                                        append
+                                          [U8]
+                                          "\nmodules "
+                                          (
+                                            append
+                                              [U8]
+                                              modsCountDigits
+                                              (
+                                                append
+                                                  [U8]
+                                                  "\n"
+                                                  (emitModuleSummaries mods)
+                                              )
+                                          )
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
+              )
+          )
+    }
 
-poly rec writeAll = \bytes : List U8 =>
-  matchList [U8] [U8] bytes
-    #u8(0)
-    (\h : U8 => \t : List U8 =>
-      writeOne h [U8] (\u : U8 => writeAll t))
+poly rec writeAll =
+  \bytes : List U8 =>
+    matchList [U8] [U8] bytes #u8(0) (\h : U8 => \t : List U8 => writeOne h [U8] (\u : U8 => writeAll t))
 
-poly main = \source : List U8 =>
-  match (parseBundleSummary source) [U8] {
-    | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
-    | Ok bundle => writeAll (emitBundleSummary bundle)
-  }
+poly main =
+  \source : List U8 =>
+    match (parseBundleSummary source) [U8] {
+      | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
+      | Ok bundle => writeAll (emitBundleSummary bundle)
+    }

--- a/bootstrap/src/core.trip
+++ b/bootstrap/src/core.trip
@@ -1,15 +1,23 @@
 module Core
 
 import Prelude List
+
 import Prelude U8
+
 import Unparse Terminal
 
 export Core
+
 export Cr_Var
+
 export Cr_App
+
 export Cr_Lam
+
 export Cr_Native
+
 export Cr_Ctor
+
 export Cr_Match
 
 data Core =

--- a/bootstrap/src/coreToLower.trip
+++ b/bootstrap/src/coreToLower.trip
@@ -1,166 +1,366 @@
 module CoreToLower
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude if
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude addU8
+
 import Prelude subU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude U8
+
 import Prelude and
+
 import Prelude or
+
 import Prelude not
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Avl Avl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl insert
+
 import Unparse Terminal
+
 import Unparse T_S
+
 import Unparse T_K
+
 import Unparse T_I
+
 import Unparse T_B
+
 import Unparse T_C
+
 import Unparse T_SPrime
+
 import Unparse T_BPrime
+
 import Unparse T_CPrime
+
 import Unparse T_WriteOne
+
 import Unparse T_ReadOne
+
 import Unparse T_EqU8
+
 import Unparse T_LtU8
+
 import Unparse T_DivU8
+
 import Unparse T_ModU8
+
 import Unparse T_AddU8
+
 import Unparse T_SubU8
+
 import Unparse T_Byte
+
 import Lowering Lower
+
 import Lowering L_Var
+
 import Lowering L_App
+
 import Lowering L_Lam
+
 import Lowering L_Native
+
 import Core Core
+
 import Core Cr_Var
+
 import Core Cr_App
+
 import Core Cr_Lam
+
 import Core Cr_Native
+
 import Core Cr_Ctor
+
 import Core Cr_Match
 
 export coreToLower
 
-poly rec eqListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    (matchList [U8] [Bool] b true (\hb : U8 => \tb : List U8 => false))
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => eqListU8 ta tb)
-            (\u : U8 => false)))
+poly rec eqListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
+        (matchList [U8] [Bool] b true (\hb : U8 => \tb : List U8 => false))
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => eqListU8 ta tb)
+                        (\u : U8 => false)
+                )
+        )
 
-poly rec lookupLocal = \name : List U8 => \locals : List (List U8) => \idx : U8 =>
-  matchList [List U8] [Maybe U8] locals
-    (None [U8])
-    (\h : List U8 => \t : List (List U8) =>
-      if [Maybe U8] (eqListU8 name h)
-        (\u : U8 => Some [U8] idx)
-        (\u : U8 => lookupLocal name t (addU8 idx #u8(1))))
+poly rec lookupLocal =
+  \name : List U8 =>
+    \locals : List (List U8) =>
+      \idx : U8 =>
+        matchList
+          [List U8]
+          [Maybe U8]
+          locals
+          (None [U8])
+          (
+            \h : List U8 =>
+              \t : List (List U8) =>
+                if [Maybe U8] (eqListU8 name h)
+                  (\u : U8 => Some [U8] idx)
+                  (\u : U8 => lookupLocal name t (addU8 idx #u8(1)))
+          )
 
-poly resolveNativeName = \name : List U8 =>
-  if [Maybe Lower] (eqListU8 name ".") (\u : U8 => Some [Lower] (L_Native T_WriteOne)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name ",") (\u : U8 => Some [Lower] (L_Native T_ReadOne)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "writeOne") (\u : U8 => Some [Lower] (L_Native T_WriteOne)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "readOne") (\u : U8 => Some [Lower] (L_Native T_ReadOne)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "addU8") (\u : U8 => Some [Lower] (L_Native T_AddU8)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "subU8") (\u : U8 => Some [Lower] (L_Native T_SubU8)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "divU8") (\u : U8 => Some [Lower] (L_Native T_DivU8)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "modU8") (\u : U8 => Some [Lower] (L_Native T_ModU8)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "eqU8") (\u : U8 => Some [Lower] (L_Native T_EqU8)) (\u : U8 =>
-  if [Maybe Lower] (eqListU8 name "ltU8") (\u : U8 => Some [Lower] (L_Native T_LtU8)) (\u : U8 =>
-  None [Lower]))))))))))
+poly resolveNativeName =
+  \name : List U8 =>
+    if [Maybe Lower] (eqListU8 name ".")
+      (\u : U8 => Some [Lower] (L_Native T_WriteOne))
+      (
+        \u : U8 =>
+          if [Maybe Lower] (eqListU8 name ",")
+            (\u : U8 => Some [Lower] (L_Native T_ReadOne))
+            (
+              \u : U8 =>
+                if [Maybe Lower] (eqListU8 name "writeOne")
+                  (\u : U8 => Some [Lower] (L_Native T_WriteOne))
+                  (
+                    \u : U8 =>
+                      if [Maybe Lower] (eqListU8 name "readOne")
+                        (\u : U8 => Some [Lower] (L_Native T_ReadOne))
+                        (
+                          \u : U8 =>
+                            if [Maybe Lower] (eqListU8 name "addU8")
+                              (\u : U8 => Some [Lower] (L_Native T_AddU8))
+                              (
+                                \u : U8 =>
+                                  if [Maybe Lower] (eqListU8 name "subU8")
+                                    (\u : U8 => Some [Lower] (L_Native T_SubU8))
+                                    (
+                                      \u : U8 =>
+                                        if [Maybe Lower] (eqListU8 name "divU8")
+                                          (
+                                            \u : U8 => Some [Lower] (L_Native T_DivU8)
+                                          )
+                                          (
+                                            \u : U8 =>
+                                              if [Maybe Lower] (eqListU8 name "modU8")
+                                                (
+                                                  \u : U8 => Some [Lower] (L_Native T_ModU8)
+                                                )
+                                                (
+                                                  \u : U8 =>
+                                                    if [Maybe Lower] (eqListU8 name "eqU8")
+                                                      (
+                                                        \u : U8 => Some [Lower] (L_Native T_EqU8)
+                                                      )
+                                                      (
+                                                        \u : U8 =>
+                                                          if [Maybe Lower] (eqListU8 name "ltU8")
+                                                            (
+                                                              \u : U8 => Some [Lower] (L_Native T_LtU8)
+                                                            )
+                                                            (
+                                                              \u : U8 => None [Lower]
+                                                            )
+                                                      )
+                                                )
+                                          )
+                                    )
+                              )
+                        )
+                  )
+            )
+      )
 
-poly rec applyScottArgs = \func : Lower => \nextArgIdx : U8 => \numArgs : U8 =>
-  if [Lower] (eqU8 numArgs #u8(0))
-    (\u : U8 => func)
-    (\u : U8 => applyScottArgs (L_App func (L_Var nextArgIdx)) (subU8 nextArgIdx #u8(1)) (subU8 numArgs #u8(1)))
+poly rec applyScottArgs =
+  \func : Lower =>
+    \nextArgIdx : U8 =>
+      \numArgs : U8 =>
+        if [Lower] (eqU8 numArgs #u8(0))
+          (\u : U8 => func)
+          (
+            \u : U8 =>
+              applyScottArgs
+                (L_App func (L_Var nextArgIdx))
+                (subU8 nextArgIdx #u8(1))
+                (subU8 numArgs #u8(1))
+          )
 
-poly rec wrapInLams = \n : U8 => \body : Lower =>
-  if [Lower] (eqU8 n #u8(0))
-    (\u : U8 => body)
-    (\u : U8 => L_Lam (wrapInLams (subU8 n #u8(1)) body))
+poly rec wrapInLams =
+  \n : U8 =>
+    \body : Lower =>
+      if [Lower] (eqU8 n #u8(0))
+        (\u : U8 => body)
+        (\u : U8 => L_Lam (wrapInLams (subU8 n #u8(1)) body))
 
-poly buildScottBody = \tag : U8 => \total : U8 => \arity : U8 =>
-  let c_idx = subU8 total (addU8 tag #u8(1)) in
-  if [Lower] (eqU8 arity #u8(0))
-    (\u : U8 => L_Var c_idx)
-    (\u : U8 =>
-      let a1_idx = addU8 total (subU8 arity #u8(1)) in
-      applyScottArgs (L_Var c_idx) a1_idx arity)
+poly buildScottBody =
+  \tag : U8 =>
+    \total : U8 =>
+      \arity : U8 =>
+        let c_idx = subU8 total (addU8 tag #u8(1)) in
+        if [Lower] (eqU8 arity #u8(0))
+          (\u : U8 => L_Var c_idx)
+          (
+            \u : U8 =>
+              let a1_idx = addU8 total (subU8 arity #u8(1)) in
+              applyScottArgs (L_Var c_idx) a1_idx arity
+          )
 
-poly buildScottCtor = \tag : U8 => \total : U8 => \arity : U8 =>
-  wrapInLams (addU8 arity total) (buildScottBody tag total arity)
+poly buildScottCtor =
+  \tag : U8 =>
+    \total : U8 =>
+      \arity : U8 =>
+        wrapInLams (addU8 arity total) (buildScottBody tag total arity)
 
-poly resolveGlobalOrNative = \globals : Avl (List U8) Lower => \name : List U8 =>
-  match (lookup [List U8] [Lower] lteListU8 name globals) [Lower] {
-    | Some l => l
-    | None =>
-        match (resolveNativeName name) [Lower] {
-          | Some intrinsic => intrinsic
-          | None => L_Native (T_Byte #u8(0))
-        }
-  }
+poly resolveGlobalOrNative =
+  \globals : Avl (List U8) Lower =>
+    \name : List U8 =>
+      match (lookup [List U8] [Lower] lteListU8 name globals) [Lower] {
+        | Some l => l
+        | None =>
+          match (resolveNativeName name) [Lower] {
+            | Some intrinsic => intrinsic
+            | None => L_Native (T_Byte #u8(0))
+          }
+      }
 
-poly rec applyArmsToScrut = \lower : Avl (List U8) Lower -> List (List U8) -> Maybe (List U8) -> Core -> Lower => \scrutLower : Lower => \arms : List Core => \globals : Avl (List U8) Lower => \locals : List (List U8) => \recName : Maybe (List U8) =>
-  matchList [Core] [Lower] arms
-    scrutLower
-    (\h : Core => \t : List Core =>
-      applyArmsToScrut lower (L_App scrutLower (lower globals locals recName h)) t globals locals recName)
+poly rec applyArmsToScrut =
+  \lower : Avl (List U8) Lower -> List (List U8) -> Maybe (List U8) -> Core -> Lower =>
+    \scrutLower : Lower =>
+      \arms : List Core =>
+        \globals : Avl (List U8) Lower =>
+          \locals : List (List U8) =>
+            \recName : Maybe (List U8) =>
+              matchList
+                [Core]
+                [Lower]
+                arms
+                scrutLower
+                (
+                  \h : Core =>
+                    \t : List Core =>
+                      applyArmsToScrut
+                        lower
+                        (L_App scrutLower (lower globals locals recName h))
+                        t
+                        globals
+                        locals
+                        recName
+                )
 
-poly rec lteListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    true
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b
-        false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => lteListU8 ta tb)
-            (\u : U8 => ltU8 ha hb)))
+poly rec lteListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
+        true
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => lteListU8 ta tb)
+                        (\u : U8 => ltU8 ha hb)
+                )
+        )
 
-poly rec coreToLower = \globals : Avl (List U8) Lower => \locals : List (List U8) => \recName : Maybe (List U8) => \expr : Core =>
-  match expr [Lower] {
-    | Cr_Var name =>
-        match (lookupLocal name locals #u8(0)) [Lower] {
-          | Some idx => L_Var idx
-          | None =>
-              match recName [Lower] {
-                | Some rn =>
-                    if [Lower] (eqListU8 name rn)
-                      (\u : U8 => L_Var #u8(0))
-                      (\u : U8 => resolveGlobalOrNative globals name)
-                | None => resolveGlobalOrNative globals name
+poly rec coreToLower =
+  \globals : Avl (List U8) Lower =>
+    \locals : List (List U8) =>
+      \recName : Maybe (List U8) =>
+        \expr : Core =>
+          match expr [Lower] {
+            | Cr_Var name =>
+              match (lookupLocal name locals #u8(0)) [Lower] {
+                | Some idx => L_Var idx
+                | None =>
+                  match recName [Lower] {
+                    | Some rn =>
+                      if [Lower] (eqListU8 name rn)
+                        (\u : U8 => L_Var #u8(0))
+                        (\u : U8 => resolveGlobalOrNative globals name)
+                    | None => resolveGlobalOrNative globals name
+                  }
               }
-        }
-    | Cr_App l r => L_App (coreToLower globals locals recName l) (coreToLower globals locals recName r)
-    | Cr_Lam name body => L_Lam (coreToLower globals (cons [List U8] name locals) recName body)
-    | Cr_Native t => L_Native t
-    | Cr_Ctor tag total arity => buildScottCtor tag total arity
-    | Cr_Match scrut arms =>
-        applyArmsToScrut coreToLower (coreToLower globals locals recName scrut) arms globals locals recName
-  }
+            | Cr_App l r =>
+              L_App
+                (coreToLower globals locals recName l)
+                (coreToLower globals locals recName r)
+            | Cr_Lam name body =>
+              L_Lam
+                (coreToLower globals (cons [List U8] name locals) recName body)
+            | Cr_Native t => L_Native t
+            | Cr_Ctor tag total arity => buildScottCtor tag total arity
+            | Cr_Match scrut arms =>
+              applyArmsToScrut
+                coreToLower
+                (coreToLower globals locals recName scrut)
+                arms
+                globals
+                locals
+                recName
+          }

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -1,31 +1,55 @@
 module CoreToMini
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude U8
+
 import Core Core
+
 import Core Cr_Var
+
 import Core Cr_App
+
 import Core Cr_Lam
+
 import Core Cr_Native
+
 import Core Cr_Ctor
+
 import Core Cr_Match
+
 import Unparse Terminal
 
 export MiniExpr
+
 export ME_Var
+
 export ME_Lam
+
 export ME_Call
+
 export ME_Con
+
 export ME_Let
+
 export ME_Native
+
 export ME_Match
+
 export coreToMini
 
 data MiniExpr =
@@ -37,58 +61,85 @@ data MiniExpr =
   | ME_Native Terminal
   | ME_Match MiniExpr (List MiniExpr)
 
-poly anonName = {U8 | '_'}
+poly anonName =
+  {U8 | '_'}
 
-poly rec collectSpine = \expr : Core => \acc : List Core =>
-  match expr [Pair Core (List Core)] {
-    | Cr_Var name => MkPair [Core] [List Core] expr acc
-    | Cr_App f x => collectSpine f (cons [Core] x acc)
-    | Cr_Lam n b => MkPair [Core] [List Core] expr acc
-    | Cr_Native t => MkPair [Core] [List Core] expr acc
-    | Cr_Ctor t n a => MkPair [Core] [List Core] expr acc
-    | Cr_Match s arms => MkPair [Core] [List Core] expr acc
-  }
+poly rec collectSpine =
+  \expr : Core =>
+    \acc : List Core =>
+      match expr [Pair Core (List Core)] {
+        | Cr_Var name => MkPair [Core] [List Core] expr acc
+        | Cr_App f x => collectSpine f (cons [Core] x acc)
+        | Cr_Lam n b => MkPair [Core] [List Core] expr acc
+        | Cr_Native t => MkPair [Core] [List Core] expr acc
+        | Cr_Ctor t n a => MkPair [Core] [List Core] expr acc
+        | Cr_Match s arms => MkPair [Core] [List Core] expr acc
+      }
 
-poly rec mapWith = \f : Core -> MiniExpr => \exprs : List Core =>
-  matchList [Core] [List MiniExpr] exprs
-    (nil [MiniExpr])
-    (\h : Core => \t : List Core =>
-      cons [MiniExpr] (f h) (mapWith f t))
+poly rec mapWith =
+  \f : Core -> MiniExpr =>
+    \exprs : List Core =>
+      matchList
+        [Core]
+        [List MiniExpr]
+        exprs
+        (nil [MiniExpr])
+        (\h : Core => \t : List Core => cons [MiniExpr] (f h) (mapWith f t))
 
-poly rec applyAnon = \head : MiniExpr => \args : List MiniExpr =>
-  matchList [MiniExpr] [MiniExpr] args
-    head
-    (\h : MiniExpr => \t : List MiniExpr =>
-      applyAnon
-        (ME_Call anonName {MiniExpr | head h})
-        t)
+poly rec applyAnon =
+  \head : MiniExpr =>
+    \args : List MiniExpr =>
+      matchList
+        [MiniExpr]
+        [MiniExpr]
+        args
+        head
+        (
+          \h : MiniExpr =>
+            \t : List MiniExpr => applyAnon (ME_Call anonName {MiniExpr | head h}) t
+        )
 
-poly rec coreToMini = \expr : Core =>
-  match expr [MiniExpr] {
-    | Cr_Var name => ME_Var name
-    | Cr_Lam name body => ME_Lam name (coreToMini body)
-    | Cr_Native t => ME_Native t
-    | Cr_Ctor tag total arity => ME_Con tag total arity (nil [MiniExpr])
-    | Cr_App lf rg =>
-        match (collectSpine (Cr_App lf rg) (nil [Core])) [MiniExpr] { | MkPair head args =>
-          let miniArgs = mapWith coreToMini args in
-          match head [MiniExpr] {
-            | Cr_Var name => ME_Call name miniArgs
-            | Cr_Ctor tag total arity => ME_Con tag total arity miniArgs
-            | Cr_Lam name body =>
-                matchList [MiniExpr] [MiniExpr] miniArgs
+poly rec coreToMini =
+  \expr : Core =>
+    match expr [MiniExpr] {
+      | Cr_Var name => ME_Var name
+      | Cr_Lam name body => ME_Lam name (coreToMini body)
+      | Cr_Native t => ME_Native t
+      | Cr_Ctor tag total arity => ME_Con tag total arity (nil [MiniExpr])
+      | Cr_App lf rg =>
+        match (collectSpine (Cr_App lf rg) (nil [Core])) [MiniExpr] {
+          | MkPair head args =>
+            let miniArgs = mapWith coreToMini args in
+            match head [MiniExpr] {
+              | Cr_Var name => ME_Call name miniArgs
+              | Cr_Ctor tag total arity => ME_Con tag total arity miniArgs
+              | Cr_Lam name body =>
+                matchList
+                  [MiniExpr]
+                  [MiniExpr]
+                  miniArgs
                   (ME_Lam name (coreToMini body))
-                  (\firstArg : MiniExpr => \rest : List MiniExpr =>
-                    matchList [MiniExpr] [MiniExpr] rest
-                      (ME_Let name firstArg (coreToMini body))
-                      (\rh : MiniExpr => \rt : List MiniExpr =>
-                        ME_Let name firstArg (applyAnon (coreToMini body) rest)))
-            | Cr_Native t => applyAnon (ME_Native t) miniArgs
-            | Cr_App _ _ => ME_Call anonName miniArgs
-            | Cr_Match s arms =>
-                applyAnon (ME_Match (coreToMini s) (mapWith coreToMini arms)) miniArgs
-          }
+                  (
+                    \firstArg : MiniExpr =>
+                      \rest : List MiniExpr =>
+                        matchList
+                          [MiniExpr]
+                          [MiniExpr]
+                          rest
+                          (ME_Let name firstArg (coreToMini body))
+                          (
+                            \rh : MiniExpr =>
+                              \rt : List MiniExpr => ME_Let name firstArg (applyAnon (coreToMini body) rest)
+                          )
+                  )
+              | Cr_Native t => applyAnon (ME_Native t) miniArgs
+              | Cr_App _ _ => ME_Call anonName miniArgs
+              | Cr_Match s arms =>
+                applyAnon
+                  (ME_Match (coreToMini s) (mapWith coreToMini arms))
+                  miniArgs
+            }
         }
-    | Cr_Match scrut arms =>
+      | Cr_Match scrut arms =>
         ME_Match (coreToMini scrut) (mapWith coreToMini arms)
-  }
+    }

--- a/bootstrap/src/dataEnv.trip
+++ b/bootstrap/src/dataEnv.trip
@@ -1,48 +1,110 @@
 module DataEnv
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude if
+
 import Prelude U8
+
 import Prelude and
+
 import Avl Avl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl insert
 
 export CtorInfo
+
 export MkCtorInfo
+
 export ctorTag
+
 export ctorTotal
+
 export ctorArity
+
 export ctorAdtName
+
 export ADTInfo
+
 export MkADTInfo
+
 export adtCtors
+
 export DataEnv
+
 export MkDataEnv
+
 export datEnvCtors
+
 export datEnvAdts
 
-data CtorInfo = MkCtorInfo U8 U8 U8 (List U8)
+data CtorInfo =
+  | MkCtorInfo U8 U8 U8 (List U8)
 
-poly ctorTag = \i : CtorInfo => match i [U8] { | MkCtorInfo t n a adt => t }
-poly ctorTotal = \i : CtorInfo => match i [U8] { | MkCtorInfo t n a adt => n }
-poly ctorArity = \i : CtorInfo => match i [U8] { | MkCtorInfo t n a adt => a }
-poly ctorAdtName = \i : CtorInfo => match i [List U8] { | MkCtorInfo t n a adt => adt }
+poly ctorTag =
+  \i : CtorInfo =>
+    match i [U8] {
+      | MkCtorInfo t n a adt => t
+    }
 
-data ADTInfo = MkADTInfo (List (List U8))
+poly ctorTotal =
+  \i : CtorInfo =>
+    match i [U8] {
+      | MkCtorInfo t n a adt => n
+    }
 
-poly adtCtors = \i : ADTInfo => match i [List (List U8)] { | MkADTInfo cs => cs }
+poly ctorArity =
+  \i : CtorInfo =>
+    match i [U8] {
+      | MkCtorInfo t n a adt => a
+    }
 
-data DataEnv = MkDataEnv (Avl (List U8) CtorInfo) (Avl (List U8) ADTInfo)
+poly ctorAdtName =
+  \i : CtorInfo =>
+    match i [List U8] {
+      | MkCtorInfo t n a adt => adt
+    }
 
-poly datEnvCtors = \e : DataEnv => match e [Avl (List U8) CtorInfo] { | MkDataEnv c a => c }
-poly datEnvAdts = \e : DataEnv => match e [Avl (List U8) ADTInfo] { | MkDataEnv c a => a }
+data ADTInfo =
+  | MkADTInfo (List (List U8))
+
+poly adtCtors =
+  \i : ADTInfo =>
+    match i [List (List U8)] {
+      | MkADTInfo cs => cs
+    }
+
+data DataEnv =
+  | MkDataEnv (Avl (List U8) CtorInfo) (Avl (List U8) ADTInfo)
+
+poly datEnvCtors =
+  \e : DataEnv =>
+    match e [Avl (List U8) CtorInfo] {
+      | MkDataEnv c a => c
+    }
+
+poly datEnvAdts =
+  \e : DataEnv =>
+    match e [Avl (List U8) ADTInfo] {
+      | MkDataEnv c a => a
+    }

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -1,84 +1,118 @@
 module Compiler
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Prelude append
+
 import Prelude writeOne
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude map
+
 import Prelude matchList
+
 import Lexer tokenize
+
 import Parser parseProgram
+
 import Parser D_Def
+
 import Parser Decl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl toListEntries
+
 import Bridge elaborateProgram
+
 import Lowering Lower
+
 import Lowering lowerToComb
+
 import Unparse Terminal
+
 import Unparse Comb
+
 import Unparse C_Term
+
 import Unparse C_App
+
 import Unparse T_I
+
 import Unparse unparseCombinator
+
 import Llvm compileSourceToLlvm
+
 import Llvm compileBundleSummaryToLlvm
+
 import BundleSummary parseBundleSummary
 
 export compileToComb
+
 export compileToLlvm
+
 export compileBundleToLlvm
+
 export main
 
-poly compileToComb = \source : List U8 =>
-  match (tokenize source) [Result (List U8) (List (Pair (List U8) Comb))] {
-    | Err e => Err [List U8] [List (Pair (List U8) Comb)] "Lex error"
-    | Ok toks =>
+poly compileToComb =
+  \source : List U8 =>
+    match (tokenize source) [Result (List U8) (List (Pair (List U8) Comb))] {
+      | Err e =>
+        Err [List U8] [List (Pair (List U8) Comb)] "Lex error"
+      | Ok toks =>
         match (parseProgram toks) [Result (List U8) (List (Pair (List U8) Comb))] {
-          | Err e => Err [List U8] [List (Pair (List U8) Comb)] "Parse error"
+          | Err e =>
+            Err [List U8] [List (Pair (List U8) Comb)] "Parse error"
           | Ok decls =>
-              match (elaborateProgram (empty [List U8] [Lower]) decls) [Result (List U8) (List (Pair (List U8) Comb))] {
-                | Err e => Err [List U8] [List (Pair (List U8) Comb)] e
-                | Ok globals =>
-                    let entries = toListEntries [List U8] [Lower] globals in
-                    let results = map [Pair (List U8) Lower] [Pair (List U8) Comb]
-                      (\entry : Pair (List U8) Lower =>
-                        MkPair [List U8] [Comb]
-                          (fst [List U8] [Lower] entry)
-                          (lowerToComb (snd [List U8] [Lower] entry)))
-                      entries in
-                    Ok [List U8] [List (Pair (List U8) Comb)] results
-              }
+            match (elaborateProgram (empty [List U8] [Lower]) decls) [Result (List U8) (List (Pair (List U8) Comb))] {
+              | Err e => Err [List U8] [List (Pair (List U8) Comb)] e
+              | Ok globals =>
+                let entries = toListEntries [List U8] [Lower] globals in
+                let results = map [Pair (List U8) Lower] [Pair (List U8) Comb] (\entry : Pair (List U8) Lower => MkPair [List U8] [Comb] (fst [List U8] [Lower] entry) (lowerToComb (snd [List U8] [Lower] entry))) entries in
+                Ok [List U8] [List (Pair (List U8) Comb)] results
+            }
         }
-  }
+    }
 
-poly compileToLlvm = \source : List U8 =>
-  compileSourceToLlvm source
+poly compileToLlvm =
+  compileSourceToLlvm
 
-poly compileBundleToLlvm = \source : List U8 =>
-  match (parseBundleSummary source) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [List U8] e
-    | Ok bundle => compileBundleSummaryToLlvm bundle
-  }
+poly compileBundleToLlvm =
+  \source : List U8 =>
+    match (parseBundleSummary source) [Result (List U8) (List U8)] {
+      | Err e => Err [List U8] [List U8] e
+      | Ok bundle => compileBundleSummaryToLlvm bundle
+    }
 
-poly rec writeAll = \bytes : List U8 =>
-  matchList [U8] [U8] bytes
-    #u8(0)
-    (\h : U8 => \t : List U8 =>
-      writeOne h [U8] (\u : U8 => writeAll t))
+poly rec writeAll =
+  \bytes : List U8 =>
+    matchList [U8] [U8] bytes #u8(0) (\h : U8 => \t : List U8 => writeOne h [U8] (\u : U8 => writeAll t))
 
-poly main = \source : List U8 =>
-  match (compileBundleToLlvm source) [U8] {
-    | Err e => writeAll (append [U8] "ERR:" e)
-    | Ok llvm => writeAll llvm
-  }
+poly main =
+  \source : List U8 =>
+    match (compileBundleToLlvm source) [U8] {
+      | Err e => writeAll (append [U8] "ERR:" e)
+      | Ok llvm => writeAll llvm
+    }

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -1,493 +1,843 @@
 module Lexer
 
 import Prelude Bool
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude tail
+
 import Prelude if
+
 import Prelude and
+
 import Prelude or
+
 import Prelude true
+
 import Prelude false
+
 import Prelude Result
+
 import Prelude Err
+
 import Prelude Ok
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude foldl
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude eqListU8
+
 import Prelude ltListU8
+
 import Prelude digitToAscii
+
 import Prelude singletonU8
+
 import Prelude u8ToDigits
 
 export ParseError
+
 export MkParseError
+
 export Token
+
 export T_LParen
+
 export T_RParen
+
 export T_LBrace
+
 export T_RBrace
+
 export T_LBracket
+
 export T_RBracket
+
 export T_Backslash
+
 export T_Arrow
+
 export T_FatArrow
+
 export T_Eq
+
 export T_Colon
+
 export T_Hash
+
 export T_Pipe
+
 export T_Dot
+
 export T_Comma
+
 export T_KwPoly
+
 export T_KwRec
+
 export T_KwLet
+
 export T_KwIn
+
 export T_KwMatch
+
 export T_KwModule
+
 export T_KwImport
+
 export T_KwExport
+
 export T_KwNative
+
 export T_KwOpaque
+
 export T_KwCombinator
+
 export T_KwType
+
 export T_KwData
+
 export T_Ident
+
 export T_Nat
+
 export T_EOF
+
 export tokenTag
+
 export tokenText
+
 export tokenNatValue
+
 export tokenize
+
 export kwPoly
+
 export isKeywordPoly
+
 export keywordWords
+
 export anyEqWord
+
 export isKeywordWord
+
 export keywordTokenFromWordData
+
 export keywordTokenFromWordType
+
 export keywordTokenFromWordCombinator
+
 export keywordTokenFromWordExport
+
 export keywordTokenFromWordNative
+
 export keywordTokenFromWordOpaque
+
 export keywordTokenFromWordImport
+
 export keywordTokenFromWordModule
+
 export keywordTokenFromWordMatch
+
 export keywordTokenFromWordIn
+
 export keywordTokenFromWordLet
+
 export keywordTokenFromWordRec
+
 export keywordTokenFromWord
+
 export mapResult
+
 export isSpaceU8
+
 export isDigitU8
+
 export isAlphaU8
+
 export isIdentCharU8
+
 export simpleTokensU8
+
 export lookupTokenU8
+
 export consumeIdent
+
 export consumeDigits
+
 export consumeString
 
-data ParseError = MkParseError (List U8)
+data ParseError =
+  | MkParseError (List U8)
 
 data Token =
   | T_Tagged U8
   | T_Ident (List U8)
   | T_Nat (List U8)
 
-poly T_LParen : Token = T_Tagged #u8(1)
-poly T_RParen : Token = T_Tagged #u8(2)
-poly T_LBrace : Token = T_Tagged #u8(3)
-poly T_RBrace : Token = T_Tagged #u8(4)
-poly T_LBracket : Token = T_Tagged #u8(5)
-poly T_RBracket : Token = T_Tagged #u8(6)
-poly T_Backslash : Token = T_Tagged #u8(7)
-poly T_Arrow : Token = T_Tagged #u8(8)
-poly T_FatArrow : Token = T_Tagged #u8(9)
-poly T_Eq : Token = T_Tagged #u8(10)
-poly T_Colon : Token = T_Tagged #u8(11)
-poly T_Hash : Token = T_Tagged #u8(12)
-poly T_Pipe : Token = T_Tagged #u8(13)
-poly T_Dot : Token = T_Tagged #u8(14)
-poly T_Comma : Token = T_Tagged #u8(15)
-poly T_KwPoly : Token = T_Tagged #u8(16)
-poly T_KwRec : Token = T_Tagged #u8(17)
-poly T_KwLet : Token = T_Tagged #u8(18)
-poly T_KwIn : Token = T_Tagged #u8(19)
-poly T_KwMatch : Token = T_Tagged #u8(20)
-poly T_KwModule : Token = T_Tagged #u8(21)
-poly T_KwImport : Token = T_Tagged #u8(22)
-poly T_KwExport : Token = T_Tagged #u8(23)
-poly T_KwNative : Token = T_Tagged #u8(24)
-poly T_KwOpaque : Token = T_Tagged #u8(25)
-poly T_KwCombinator : Token = T_Tagged #u8(26)
-poly T_KwType : Token = T_Tagged #u8(27)
-poly T_KwData : Token = T_Tagged #u8(28)
-poly T_EOF : Token = T_Tagged #u8(31)
+poly T_LParen : Token =
+  T_Tagged #u8(1)
 
-poly tokenTag = \tok : Token =>
-  match tok [U8] {
-    | T_Tagged tag => tag
-    | T_Ident str => #u8(29)
-    | T_Nat n => #u8(30)
-  }
+poly T_RParen : Token =
+  T_Tagged #u8(2)
 
-poly tokenTaggedTextData = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(28))
-    (\u : U8 => "data")
-    (\u : U8 => nil [U8])
+poly T_LBrace : Token =
+  T_Tagged #u8(3)
 
-poly tokenTaggedTextType = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(27))
-    (\u : U8 => "type")
-    (\u : U8 => tokenTaggedTextData tag)
+poly T_RBrace : Token =
+  T_Tagged #u8(4)
 
-poly tokenTaggedTextCombinator = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(26))
-    (\u : U8 => "combinator")
-    (\u : U8 => tokenTaggedTextType tag)
+poly T_LBracket : Token =
+  T_Tagged #u8(5)
 
-poly tokenTaggedTextOpaque = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(25))
-    (\u : U8 => "opaque")
-    (\u : U8 => tokenTaggedTextCombinator tag)
+poly T_RBracket : Token =
+  T_Tagged #u8(6)
 
-poly tokenTaggedTextNative = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(24))
-    (\u : U8 => "native")
-    (\u : U8 => tokenTaggedTextOpaque tag)
+poly T_Backslash : Token =
+  T_Tagged #u8(7)
 
-poly tokenTaggedTextExport = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(23))
-    (\u : U8 => "export")
-    (\u : U8 => tokenTaggedTextNative tag)
+poly T_Arrow : Token =
+  T_Tagged #u8(8)
 
-poly tokenTaggedTextImport = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(22))
-    (\u : U8 => "import")
-    (\u : U8 => tokenTaggedTextExport tag)
+poly T_FatArrow : Token =
+  T_Tagged #u8(9)
 
-poly tokenTaggedTextModule = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(21))
-    (\u : U8 => "module")
-    (\u : U8 => tokenTaggedTextImport tag)
+poly T_Eq : Token =
+  T_Tagged #u8(10)
 
-poly tokenTaggedTextMatch = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(20))
-    (\u : U8 => "match")
-    (\u : U8 => tokenTaggedTextModule tag)
+poly T_Colon : Token =
+  T_Tagged #u8(11)
 
-poly tokenTaggedTextIn = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(19))
-    (\u : U8 => "in")
-    (\u : U8 => tokenTaggedTextMatch tag)
+poly T_Hash : Token =
+  T_Tagged #u8(12)
 
-poly tokenTaggedTextLet = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(18))
-    (\u : U8 => "let")
-    (\u : U8 => tokenTaggedTextIn tag)
+poly T_Pipe : Token =
+  T_Tagged #u8(13)
 
-poly tokenTaggedTextRec = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(17))
-    (\u : U8 => "rec")
-    (\u : U8 => tokenTaggedTextLet tag)
+poly T_Dot : Token =
+  T_Tagged #u8(14)
 
-poly tokenTaggedText = \tag : U8 =>
-  if [List U8] (eqU8 tag #u8(16))
-    (\u : U8 => "poly")
-    (\u : U8 => tokenTaggedTextRec tag)
+poly T_Comma : Token =
+  T_Tagged #u8(15)
 
-poly tokenText = \tok : Token =>
-  match tok [List U8] {
-    | T_Tagged tag => tokenTaggedText tag
-    | T_Ident str => str
-    | T_Nat n => nil [U8]
-  }
+poly T_KwPoly : Token =
+  T_Tagged #u8(16)
 
-poly tokenNatValue = \tok : Token =>
-  match tok [List U8] {
-    | T_Tagged tag => nil [U8]
-    | T_Ident str => nil [U8]
-    | T_Nat digits => digits
-  }
+poly T_KwRec : Token =
+  T_Tagged #u8(17)
 
-poly u8_space    : U8 = ' '
-poly u8_newline  : U8 = '\n'
-poly u8_cr       : U8 = '\r'
-poly u8_tab      : U8 = '\t'
-poly u8_underscore : U8 = '_'
+poly T_KwLet : Token =
+  T_Tagged #u8(18)
 
-poly u8_quote : U8 = '\"'
-poly u8_squote : U8 = '\''
-poly u8_backslash : U8 = '\\'
-poly u8_gt : U8 = '>'
-poly u8_dash : U8 = '-'
-poly u8_eq : U8 = '='
-poly u8_n : U8 = 'n'
-poly u8_r : U8 = 'r'
-poly u8_lbrace : U8 = '{'
-poly u8_rbrace : U8 = '}'
+poly T_KwIn : Token =
+  T_Tagged #u8(19)
 
-poly isSpaceU8 = \c : U8 =>
-  if [Bool] (eqU8 c u8_space)   (\u : U8 => true)
-  (\u : U8 => if [Bool] (eqU8 c u8_newline) (\u : U8 => true)
-  (\u : U8 => if [Bool] (eqU8 c u8_cr)      (\u : U8 => true)
-  (\u : U8 => if [Bool] (eqU8 c u8_tab)     (\u : U8 => true)
-  (\u : U8 => false))))
+poly T_KwMatch : Token =
+  T_Tagged #u8(20)
 
-poly isDigitU8 = \c : U8 =>
-  if [Bool] (ltU8 c #u8(48)) (\u:U8 => false) (\u:U8 =>
-  if [Bool] (ltU8 c #u8(58)) (\u:U8 => true)  (\u:U8 => false))
+poly T_KwModule : Token =
+  T_Tagged #u8(21)
 
-poly isAlphaU8 = \c : U8 =>
-  if [Bool] (ltU8 c #u8(65)) (\u:U8 => false) (\u:U8 =>
-  if [Bool] (ltU8 c #u8(91)) (\u:U8 => true)  (\u:U8 =>
-  if [Bool] (ltU8 c #u8(97)) (\u:U8 => false) (\u:U8 =>
-  if [Bool] (ltU8 c #u8(123)) (\u:U8 => true) (\u:U8 => false))))
+poly T_KwImport : Token =
+  T_Tagged #u8(22)
 
-poly isIdentCharU8 = \c : U8 =>
-  or (isAlphaU8 c) (or (isDigitU8 c) (eqU8 c u8_underscore))
+poly T_KwExport : Token =
+  T_Tagged #u8(23)
 
-poly kwPoly : List U8 = "poly"
+poly T_KwNative : Token =
+  T_Tagged #u8(24)
 
-poly isKeywordPoly = \word : List U8 => eqListU8 word kwPoly
+poly T_KwOpaque : Token =
+  T_Tagged #u8(25)
+
+poly T_KwCombinator : Token =
+  T_Tagged #u8(26)
+
+poly T_KwType : Token =
+  T_Tagged #u8(27)
+
+poly T_KwData : Token =
+  T_Tagged #u8(28)
+
+poly T_EOF : Token =
+  T_Tagged #u8(31)
+
+poly tokenTag =
+  \tok : Token =>
+    match tok [U8] {
+      | T_Tagged tag => tag
+      | T_Ident str => #u8(29)
+      | T_Nat n => #u8(30)
+    }
+
+poly tokenTaggedTextData =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(28))
+      (\u : U8 => "data")
+      (\u : U8 => nil [U8])
+
+poly tokenTaggedTextType =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(27))
+      (\u : U8 => "type")
+      (\u : U8 => tokenTaggedTextData tag)
+
+poly tokenTaggedTextCombinator =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(26))
+      (\u : U8 => "combinator")
+      (\u : U8 => tokenTaggedTextType tag)
+
+poly tokenTaggedTextOpaque =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(25))
+      (\u : U8 => "opaque")
+      (\u : U8 => tokenTaggedTextCombinator tag)
+
+poly tokenTaggedTextNative =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(24))
+      (\u : U8 => "native")
+      (\u : U8 => tokenTaggedTextOpaque tag)
+
+poly tokenTaggedTextExport =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(23))
+      (\u : U8 => "export")
+      (\u : U8 => tokenTaggedTextNative tag)
+
+poly tokenTaggedTextImport =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(22))
+      (\u : U8 => "import")
+      (\u : U8 => tokenTaggedTextExport tag)
+
+poly tokenTaggedTextModule =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(21))
+      (\u : U8 => "module")
+      (\u : U8 => tokenTaggedTextImport tag)
+
+poly tokenTaggedTextMatch =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(20))
+      (\u : U8 => "match")
+      (\u : U8 => tokenTaggedTextModule tag)
+
+poly tokenTaggedTextIn =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(19))
+      (\u : U8 => "in")
+      (\u : U8 => tokenTaggedTextMatch tag)
+
+poly tokenTaggedTextLet =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(18))
+      (\u : U8 => "let")
+      (\u : U8 => tokenTaggedTextIn tag)
+
+poly tokenTaggedTextRec =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(17))
+      (\u : U8 => "rec")
+      (\u : U8 => tokenTaggedTextLet tag)
+
+poly tokenTaggedText =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(16))
+      (\u : U8 => "poly")
+      (\u : U8 => tokenTaggedTextRec tag)
+
+poly tokenText =
+  \tok : Token =>
+    match tok [List U8] {
+      | T_Tagged tag => tokenTaggedText tag
+      | T_Ident str => str
+      | T_Nat n => nil [U8]
+    }
+
+poly tokenNatValue =
+  \tok : Token =>
+    match tok [List U8] {
+      | T_Tagged tag => nil [U8]
+      | T_Ident str => nil [U8]
+      | T_Nat digits => digits
+    }
+
+poly u8_space : U8 =
+  ' '
+
+poly u8_newline : U8 =
+  '\n'
+
+poly u8_cr : U8 =
+  '\r'
+
+poly u8_tab : U8 =
+  '\t'
+
+poly u8_underscore : U8 =
+  '_'
+
+poly u8_quote : U8 =
+  '\"'
+
+poly u8_squote : U8 =
+  '\''
+
+poly u8_backslash : U8 =
+  '\\'
+
+poly u8_gt : U8 =
+  '>'
+
+poly u8_dash : U8 =
+  '-'
+
+poly u8_eq : U8 =
+  '='
+
+poly u8_n : U8 =
+  'n'
+
+poly u8_r : U8 =
+  'r'
+
+poly u8_lbrace : U8 =
+  '{'
+
+poly u8_rbrace : U8 =
+  '}'
+
+poly isSpaceU8 =
+  \c : U8 =>
+    if [Bool] (eqU8 c u8_space)
+      (\u : U8 => true)
+      (
+        \u : U8 =>
+          if [Bool] (eqU8 c u8_newline)
+            (\u : U8 => true)
+            (
+              \u : U8 =>
+                if [Bool] (eqU8 c u8_cr)
+                  (\u : U8 => true)
+                  (
+                    \u : U8 =>
+                      if [Bool] (eqU8 c u8_tab)
+                        (\u : U8 => true)
+                        (\u : U8 => false)
+                  )
+            )
+      )
+
+poly isDigitU8 =
+  \c : U8 =>
+    if [Bool] (ltU8 c #u8(48))
+      (\u : U8 => false)
+      (
+        \u : U8 =>
+          if [Bool] (ltU8 c #u8(58))
+            (\u : U8 => true)
+            (\u : U8 => false)
+      )
+
+poly isAlphaU8 =
+  \c : U8 =>
+    if [Bool] (ltU8 c #u8(65))
+      (\u : U8 => false)
+      (
+        \u : U8 =>
+          if [Bool] (ltU8 c #u8(91))
+            (\u : U8 => true)
+            (
+              \u : U8 =>
+                if [Bool] (ltU8 c #u8(97))
+                  (\u : U8 => false)
+                  (
+                    \u : U8 =>
+                      if [Bool] (ltU8 c #u8(123))
+                        (\u : U8 => true)
+                        (\u : U8 => false)
+                  )
+            )
+      )
+
+poly isIdentCharU8 =
+  \c : U8 => or (isAlphaU8 c) (or (isDigitU8 c) (eqU8 c u8_underscore))
+
+poly kwPoly : List U8 =
+  "poly"
+
+poly isKeywordPoly =
+  \word : List U8 => eqListU8 word kwPoly
 
 poly keywordWords =
-  {List U8 | "poly" "rec" "let" "in" "match" "module" "import" "export" "native" "opaque" "combinator" "type" "data"}
-
-
-poly rec anyEqWord = \word : List U8 => \words : List (List U8) =>
-  matchList [List U8] [Bool] words false
-    (\h : List U8 => \t : List (List U8) =>
-      if [Bool] (eqListU8 word h)
-        (\u : U8 => true)
-        (\u : U8 => anyEqWord word t))
-
-poly isKeywordWord = \word : List U8 =>
-  anyEqWord word keywordWords
-
-poly keywordTokenFromWordP = \word : List U8 =>
-  if [Token] (eqListU8 word "poly")
-    (\u : U8 => T_KwPoly)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordR = \word : List U8 =>
-  if [Token] (eqListU8 word "rec")
-    (\u : U8 => T_KwRec)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordL = \word : List U8 =>
-  if [Token] (eqListU8 word "let")
-    (\u : U8 => T_KwLet)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordI = \word : List U8 =>
-  if [Token] (eqListU8 word "in")
-    (\u : U8 => T_KwIn)
-    (\u : U8 =>
-      if [Token] (eqListU8 word "import")
-        (\u : U8 => T_KwImport)
-        (\u : U8 => T_Ident word))
-
-poly keywordTokenFromWordM = \word : List U8 =>
-  if [Token] (eqListU8 word "match")
-    (\u : U8 => T_KwMatch)
-    (\u : U8 =>
-      if [Token] (eqListU8 word "module")
-        (\u : U8 => T_KwModule)
-        (\u : U8 => T_Ident word))
-
-poly keywordTokenFromWordN = \word : List U8 =>
-  if [Token] (eqListU8 word "native")
-    (\u : U8 => T_KwNative)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordO = \word : List U8 =>
-  if [Token] (eqListU8 word "opaque")
-    (\u : U8 => T_KwOpaque)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordE = \word : List U8 =>
-  if [Token] (eqListU8 word "export")
-    (\u : U8 => T_KwExport)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordT = \word : List U8 =>
-  if [Token] (eqListU8 word "type")
-    (\u : U8 => T_KwType)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordC = \word : List U8 =>
-  if [Token] (eqListU8 word "combinator")
-    (\u : U8 => T_KwCombinator)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordData = \word : List U8 =>
-  if [Token] (eqListU8 word "data")
-    (\u : U8 => T_KwData)
-    (\u : U8 => T_Ident word)
-
-poly keywordTokenFromWordType = \word : List U8 =>
-  if [Token] (eqListU8 word "type")
-    (\u : U8 => T_KwType)
-    (\u : U8 => keywordTokenFromWordData word)
-
-poly keywordTokenFromWordCombinator = \word : List U8 =>
-  if [Token] (eqListU8 word "combinator")
-    (\u : U8 => T_KwCombinator)
-    (\u : U8 => keywordTokenFromWordType word)
-
-poly keywordTokenFromWordOpaque = \word : List U8 =>
-  if [Token] (eqListU8 word "opaque")
-    (\u : U8 => T_KwOpaque)
-    (\u : U8 => keywordTokenFromWordCombinator word)
-
-poly keywordTokenFromWordNative = \word : List U8 =>
-  if [Token] (eqListU8 word "native")
-    (\u : U8 => T_KwNative)
-    (\u : U8 => keywordTokenFromWordOpaque word)
-
-poly keywordTokenFromWordExport = \word : List U8 =>
-  if [Token] (eqListU8 word "export")
-    (\u : U8 => T_KwExport)
-    (\u : U8 => keywordTokenFromWordNative word)
-
-poly keywordTokenFromWordImport = \word : List U8 =>
-  if [Token] (eqListU8 word "import")
-    (\u : U8 => T_KwImport)
-    (\u : U8 => keywordTokenFromWordExport word)
-
-poly keywordTokenFromWordModule = \word : List U8 =>
-  if [Token] (eqListU8 word "module")
-    (\u : U8 => T_KwModule)
-    (\u : U8 => keywordTokenFromWordImport word)
-
-poly keywordTokenFromWordMatch = \word : List U8 =>
-  if [Token] (eqListU8 word "match")
-    (\u : U8 => T_KwMatch)
-    (\u : U8 => keywordTokenFromWordModule word)
-
-poly keywordTokenFromWordIn = \word : List U8 =>
-  if [Token] (eqListU8 word "in")
-    (\u : U8 => T_KwIn)
-    (\u : U8 => keywordTokenFromWordMatch word)
-
-poly keywordTokenFromWordLet = \word : List U8 =>
-  if [Token] (eqListU8 word "let")
-    (\u : U8 => T_KwLet)
-    (\u : U8 => keywordTokenFromWordIn word)
-
-poly keywordTokenFromWordRec = \word : List U8 =>
-  if [Token] (eqListU8 word "rec")
-    (\u : U8 => T_KwRec)
-    (\u : U8 => keywordTokenFromWordLet word)
-
-poly keywordTokenFromWord = \word : List U8 =>
-  matchList [U8] [Token] word
-    (T_Ident word)
-    (\h : U8 => \t : List U8 =>
-      if [Token] (eqU8 h 'p')
-        (\u : U8 => keywordTokenFromWordP word)
-        (\u : U8 =>
-          if [Token] (eqU8 h 'r')
-            (\u : U8 => keywordTokenFromWordR word)
-            (\u : U8 =>
-              if [Token] (eqU8 h 'l')
-                (\u : U8 => keywordTokenFromWordL word)
-                (\u : U8 =>
-                  if [Token] (eqU8 h 'i')
-                    (\u : U8 => keywordTokenFromWordI word)
-                    (\u : U8 =>
-                      if [Token] (eqU8 h 'm')
-                        (\u : U8 => keywordTokenFromWordM word)
-                        (\u : U8 =>
-                          if [Token] (eqU8 h 'n')
-                            (\u : U8 => keywordTokenFromWordN word)
-                            (\u : U8 =>
-                              if [Token] (eqU8 h 'o')
-                                (\u : U8 => keywordTokenFromWordO word)
-                                (\u : U8 =>
-                                  if [Token] (eqU8 h 'e')
-                                    (\u : U8 => keywordTokenFromWordE word)
-                                    (\u : U8 =>
-                                      if [Token] (eqU8 h 't')
-                                        (\u : U8 => keywordTokenFromWordT word)
-                                        (\u : U8 =>
-                                          if [Token] (eqU8 h 'c')
-                                            (\u : U8 => keywordTokenFromWordC word)
-                                            (\u : U8 =>
-                                              if [Token] (eqU8 h 'd')
-                                                (\u : U8 => keywordTokenFromWordData word)
-                                                (\u : U8 => T_Ident word))))))))))))
-
-poly simpleTokenFromU8Hash = \c : U8 =>
-  if [Maybe Token] (eqU8 c '#')
-    (\u : U8 => Some [Token] T_Hash)
-    (\u : U8 =>
-      if [Maybe Token] (eqU8 c '|')
-        (\u : U8 => Some [Token] T_Pipe)
-        (\u : U8 =>
-          if [Maybe Token] (eqU8 c '.')
-            (\u : U8 => Some [Token] T_Dot)
-            (\u : U8 =>
-              if [Maybe Token] (eqU8 c ',')
-                (\u : U8 => Some [Token] T_Comma)
-                (\u : U8 => None [Token]))))
-
-poly simpleTokenFromU8Colon = \c : U8 =>
-  if [Maybe Token] (eqU8 c ':')
-    (\u : U8 => Some [Token] T_Colon)
-    (\u : U8 => simpleTokenFromU8Hash c)
-
-poly simpleTokenFromU8Backslash = \c : U8 =>
-  if [Maybe Token] (eqU8 c '\\')
-    (\u : U8 => Some [Token] T_Backslash)
-    (\u : U8 => simpleTokenFromU8Colon c)
-
-poly simpleTokenFromU8Bracket = \c : U8 =>
-  if [Maybe Token] (eqU8 c '[')
-    (\u : U8 => Some [Token] T_LBracket)
-    (\u : U8 =>
-      if [Maybe Token] (eqU8 c ']')
-        (\u : U8 => Some [Token] T_RBracket)
-        (\u : U8 => simpleTokenFromU8Backslash c))
-
-poly simpleTokenFromU8Brace = \c : U8 =>
-  if [Maybe Token] (eqU8 c '{')
-    (\u : U8 => Some [Token] T_LBrace)
-    (\u : U8 =>
-      if [Maybe Token] (eqU8 c '}')
-        (\u : U8 => Some [Token] T_RBrace)
-        (\u : U8 => simpleTokenFromU8Bracket c))
-
-poly simpleTokenFromU8 = \c : U8 =>
-  if [Maybe Token] (eqU8 c '(')
-    (\u : U8 => Some [Token] T_LParen)
-    (\u : U8 =>
-      if [Maybe Token] (eqU8 c ')')
-        (\u : U8 => Some [Token] T_RParen)
-        (\u : U8 => simpleTokenFromU8Brace c))
-
-poly mapResult = #A => #B => \f : A -> B => \res : Result ParseError A =>
-  match res [Result ParseError B] {
-    | Err e => Err [ParseError] [B] e
-    | Ok val => Ok [ParseError] [B] (f val)
+  {List U8 |
+    "poly"
+    "rec"
+    "let"
+    "in"
+    "match"
+    "module"
+    "import"
+    "export"
+    "native"
+    "opaque"
+    "combinator"
+    "type"
+    "data"
   }
+
+poly rec anyEqWord =
+  \word : List U8 =>
+    \words : List (List U8) =>
+      matchList
+        [List U8]
+        [Bool]
+        words
+        false
+        (
+          \h : List U8 =>
+            \t : List (List U8) =>
+              if [Bool] (eqListU8 word h)
+                (\u : U8 => true)
+                (\u : U8 => anyEqWord word t)
+        )
+
+poly isKeywordWord =
+  \word : List U8 => anyEqWord word keywordWords
+
+poly keywordTokenFromWordP =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "poly")
+      (\u : U8 => T_KwPoly)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordR =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "rec")
+      (\u : U8 => T_KwRec)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordL =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "let")
+      (\u : U8 => T_KwLet)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordI =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "in")
+      (\u : U8 => T_KwIn)
+      (
+        \u : U8 =>
+          if [Token] (eqListU8 word "import")
+            (\u : U8 => T_KwImport)
+            (\u : U8 => T_Ident word)
+      )
+
+poly keywordTokenFromWordM =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "match")
+      (\u : U8 => T_KwMatch)
+      (
+        \u : U8 =>
+          if [Token] (eqListU8 word "module")
+            (\u : U8 => T_KwModule)
+            (\u : U8 => T_Ident word)
+      )
+
+poly keywordTokenFromWordN =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "native")
+      (\u : U8 => T_KwNative)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordO =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "opaque")
+      (\u : U8 => T_KwOpaque)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordE =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "export")
+      (\u : U8 => T_KwExport)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordT =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "type")
+      (\u : U8 => T_KwType)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordC =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "combinator")
+      (\u : U8 => T_KwCombinator)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordData =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "data")
+      (\u : U8 => T_KwData)
+      (\u : U8 => T_Ident word)
+
+poly keywordTokenFromWordType =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "type")
+      (\u : U8 => T_KwType)
+      (\u : U8 => keywordTokenFromWordData word)
+
+poly keywordTokenFromWordCombinator =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "combinator")
+      (\u : U8 => T_KwCombinator)
+      (\u : U8 => keywordTokenFromWordType word)
+
+poly keywordTokenFromWordOpaque =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "opaque")
+      (\u : U8 => T_KwOpaque)
+      (\u : U8 => keywordTokenFromWordCombinator word)
+
+poly keywordTokenFromWordNative =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "native")
+      (\u : U8 => T_KwNative)
+      (\u : U8 => keywordTokenFromWordOpaque word)
+
+poly keywordTokenFromWordExport =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "export")
+      (\u : U8 => T_KwExport)
+      (\u : U8 => keywordTokenFromWordNative word)
+
+poly keywordTokenFromWordImport =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "import")
+      (\u : U8 => T_KwImport)
+      (\u : U8 => keywordTokenFromWordExport word)
+
+poly keywordTokenFromWordModule =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "module")
+      (\u : U8 => T_KwModule)
+      (\u : U8 => keywordTokenFromWordImport word)
+
+poly keywordTokenFromWordMatch =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "match")
+      (\u : U8 => T_KwMatch)
+      (\u : U8 => keywordTokenFromWordModule word)
+
+poly keywordTokenFromWordIn =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "in")
+      (\u : U8 => T_KwIn)
+      (\u : U8 => keywordTokenFromWordMatch word)
+
+poly keywordTokenFromWordLet =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "let")
+      (\u : U8 => T_KwLet)
+      (\u : U8 => keywordTokenFromWordIn word)
+
+poly keywordTokenFromWordRec =
+  \word : List U8 =>
+    if [Token] (eqListU8 word "rec")
+      (\u : U8 => T_KwRec)
+      (\u : U8 => keywordTokenFromWordLet word)
+
+poly keywordTokenFromWord =
+  \word : List U8 =>
+    matchList
+      [U8]
+      [Token]
+      word
+      (T_Ident word)
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [Token] (eqU8 h 'p')
+              (\u : U8 => keywordTokenFromWordP word)
+              (
+                \u : U8 =>
+                  if [Token] (eqU8 h 'r')
+                    (\u : U8 => keywordTokenFromWordR word)
+                    (
+                      \u : U8 =>
+                        if [Token] (eqU8 h 'l')
+                          (\u : U8 => keywordTokenFromWordL word)
+                          (
+                            \u : U8 =>
+                              if [Token] (eqU8 h 'i')
+                                (\u : U8 => keywordTokenFromWordI word)
+                                (
+                                  \u : U8 =>
+                                    if [Token] (eqU8 h 'm')
+                                      (\u : U8 => keywordTokenFromWordM word)
+                                      (
+                                        \u : U8 =>
+                                          if [Token] (eqU8 h 'n')
+                                            (
+                                              \u : U8 => keywordTokenFromWordN word
+                                            )
+                                            (
+                                              \u : U8 =>
+                                                if [Token] (eqU8 h 'o')
+                                                  (
+                                                    \u : U8 => keywordTokenFromWordO word
+                                                  )
+                                                  (
+                                                    \u : U8 =>
+                                                      if [Token] (eqU8 h 'e')
+                                                        (
+                                                          \u : U8 => keywordTokenFromWordE word
+                                                        )
+                                                        (
+                                                          \u : U8 =>
+                                                            if [Token] (eqU8 h 't')
+                                                              (
+                                                                \u : U8 => keywordTokenFromWordT word
+                                                              )
+                                                              (
+                                                                \u : U8 =>
+                                                                  if [Token] (eqU8 h 'c')
+                                                                    (
+                                                                      \u : U8 => keywordTokenFromWordC word
+                                                                    )
+                                                                    (
+                                                                      \u : U8 =>
+                                                                        if [Token] (eqU8 h 'd')
+                                                                          (
+                                                                            \u : U8 => keywordTokenFromWordData word
+                                                                          )
+                                                                          (
+                                                                            \u : U8 => T_Ident word
+                                                                          )
+                                                                    )
+                                                              )
+                                                        )
+                                                  )
+                                            )
+                                      )
+                                )
+                          )
+                    )
+              )
+      )
+
+poly simpleTokenFromU8Hash =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c '#')
+      (\u : U8 => Some [Token] T_Hash)
+      (
+        \u : U8 =>
+          if [Maybe Token] (eqU8 c '|')
+            (\u : U8 => Some [Token] T_Pipe)
+            (
+              \u : U8 =>
+                if [Maybe Token] (eqU8 c '.')
+                  (\u : U8 => Some [Token] T_Dot)
+                  (
+                    \u : U8 =>
+                      if [Maybe Token] (eqU8 c ',')
+                        (\u : U8 => Some [Token] T_Comma)
+                        (\u : U8 => None [Token])
+                  )
+            )
+      )
+
+poly simpleTokenFromU8Colon =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c ':')
+      (\u : U8 => Some [Token] T_Colon)
+      (\u : U8 => simpleTokenFromU8Hash c)
+
+poly simpleTokenFromU8Backslash =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c '\\')
+      (\u : U8 => Some [Token] T_Backslash)
+      (\u : U8 => simpleTokenFromU8Colon c)
+
+poly simpleTokenFromU8Bracket =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c '[')
+      (\u : U8 => Some [Token] T_LBracket)
+      (
+        \u : U8 =>
+          if [Maybe Token] (eqU8 c ']')
+            (\u : U8 => Some [Token] T_RBracket)
+            (\u : U8 => simpleTokenFromU8Backslash c)
+      )
+
+poly simpleTokenFromU8Brace =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c '{')
+      (\u : U8 => Some [Token] T_LBrace)
+      (
+        \u : U8 =>
+          if [Maybe Token] (eqU8 c '}')
+            (\u : U8 => Some [Token] T_RBrace)
+            (\u : U8 => simpleTokenFromU8Bracket c)
+      )
+
+poly simpleTokenFromU8 =
+  \c : U8 =>
+    if [Maybe Token] (eqU8 c '(')
+      (\u : U8 => Some [Token] T_LParen)
+      (
+        \u : U8 =>
+          if [Maybe Token] (eqU8 c ')')
+            (\u : U8 => Some [Token] T_RParen)
+            (\u : U8 => simpleTokenFromU8Brace c)
+      )
+
+poly mapResult =
+  #A =>
+    #B =>
+      \f : A -> B =>
+        \res : Result ParseError A =>
+          match res [Result ParseError B] {
+            | Err e => Err [ParseError] [B] e
+            | Ok val => Ok [ParseError] [B] (f val)
+          }
 
 poly simpleTokensU8 =
   {Pair U8 Token |
@@ -505,213 +855,366 @@ poly simpleTokensU8 =
     (MkPair [U8] [Token] ',' T_Comma)
   }
 
+poly rec lookupTokenU8 =
+  \c : U8 =>
+    \list : List (Pair U8 Token) =>
+      matchList
+        [Pair U8 Token]
+        [Maybe Token]
+        list
+        (None [Token])
+        (
+          \h : Pair U8 Token =>
+            \t : List (Pair U8 Token) =>
+              if [Maybe Token] (eqU8 c (fst [U8] [Token] h))
+                (\u : U8 => Some [Token] (snd [U8] [Token] h))
+                (\u : U8 => lookupTokenU8 c t)
+        )
 
-poly rec lookupTokenU8 = \c : U8 => \list : List (Pair U8 Token) =>
-  matchList [Pair U8 Token] [Maybe Token] list
-    (None [Token])
-    (\h : Pair U8 Token => \t : List (Pair U8 Token) =>
-       if [Maybe Token]
-         (eqU8 c (fst [U8] [Token] h))
-         (\u : U8 => Some [Token] (snd [U8] [Token] h))
-         (\u : U8 => lookupTokenU8 c t)
-    )
+poly rec consumeIdent =
+  \acc : List U8 =>
+    \input : List U8 =>
+      matchList
+        [U8]
+        [Pair (List U8) (List U8)]
+        input
+        (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Pair (List U8) (List U8)] (isIdentCharU8 h)
+                (\u : U8 => consumeIdent (cons [U8] h acc) t)
+                (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
+        )
 
-poly rec consumeIdent = \acc : List U8 => \input : List U8 =>
-  matchList [U8] [Pair (List U8) (List U8)] input
-    (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
-    (\h : U8 => \t : List U8 =>
-       if [Pair (List U8) (List U8)] (isIdentCharU8 h)
-         (\u : U8 => consumeIdent (cons [U8] h acc) t)
-         (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
-    )
+poly rec consumeDigits =
+  \acc : List U8 =>
+    \input : List U8 =>
+      matchList
+        [U8]
+        [Pair (List U8) (List U8)]
+        input
+        (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Pair (List U8) (List U8)] (isDigitU8 h)
+                (\u : U8 => consumeDigits (cons [U8] h acc) t)
+                (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
+        )
 
-poly rec consumeDigits = \acc : List U8 => \input : List U8 =>
-  matchList [U8] [Pair (List U8) (List U8)] input
-    (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
-    (\h : U8 => \t : List U8 =>
-       if [Pair (List U8) (List U8)] (isDigitU8 h)
-         (\u : U8 => consumeDigits (cons [U8] h acc) t)
-         (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
-    )
+poly rec consumeString =
+  \acc : List U8 =>
+    \input : List U8 =>
+      matchList
+        [U8]
+        [Result ParseError (Pair (List U8) (List U8))]
+        input
+        (Err [ParseError] [Pair (List U8) (List U8)] (MkParseError (nil [U8])))
+        (
+          \h : U8 =>
+            \t : List U8 =>
+              if [Result ParseError (Pair (List U8) (List U8))] (eqU8 h u8_quote)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair (List U8) (List U8)]
+                      (MkPair [List U8] [List U8] (reverse [U8] acc) t)
+                )
+                (\u : U8 => consumeString (cons [U8] h acc) t)
+        )
 
-poly rec consumeString = \acc : List U8 => \input : List U8 =>
-  matchList [U8] [Result ParseError (Pair (List U8) (List U8))] input
-    (Err [ParseError] [Pair (List U8) (List U8)] (MkParseError (nil [U8])))
-    (\h : U8 => \t : List U8 =>
-      if [Result ParseError (Pair (List U8) (List U8))] (eqU8 h u8_quote)
-        (\u : U8 =>
-          Ok [ParseError] [Pair (List U8) (List U8)]
-            (MkPair [List U8] [List U8] (reverse [U8] acc) t))
-        (\u : U8 => consumeString (cons [U8] h acc) t)
-    )
-
-poly escapedCharValue = \c : U8 =>
-  if [U8] (eqU8 c u8_n)
-    (\u : U8 => u8_newline)
-    (\u : U8 =>
-      if [U8] (eqU8 c u8_r)
-        (\u : U8 => u8_cr)
-        (\u : U8 =>
-          if [U8] (eqU8 c 't')
-            (\u : U8 => u8_tab)
-            (\u : U8 =>
-              if [U8] (eqU8 c u8_quote)
-                (\u : U8 => u8_quote)
-                (\u : U8 =>
-                  if [U8] (eqU8 c u8_squote)
-                    (\u : U8 => u8_squote)
-                    (\u : U8 => c)))))
+poly escapedCharValue =
+  \c : U8 =>
+    if [U8] (eqU8 c u8_n)
+      (\u : U8 => u8_newline)
+      (
+        \u : U8 =>
+          if [U8] (eqU8 c u8_r)
+            (\u : U8 => u8_cr)
+            (
+              \u : U8 =>
+                if [U8] (eqU8 c 't')
+                  (\u : U8 => u8_tab)
+                  (
+                    \u : U8 =>
+                      if [U8] (eqU8 c u8_quote)
+                        (\u : U8 => u8_quote)
+                        (
+                          \u : U8 =>
+                            if [U8] (eqU8 c u8_squote)
+                              (\u : U8 => u8_squote)
+                              (\u : U8 => c)
+                        )
+                  )
+            )
+      )
 
 poly charLiteralError =
   Err [ParseError] [Pair U8 (List U8)] (MkParseError (nil [U8]))
 
-poly finishCharLiteral = \value : U8 => \input : List U8 =>
-  matchList [U8] [Result ParseError (Pair U8 (List U8))] input
-    charLiteralError
-    (\close : U8 => \rest : List U8 =>
-      if [Result ParseError (Pair U8 (List U8))] (eqU8 close u8_squote)
-        (\u : U8 =>
-          Ok [ParseError] [Pair U8 (List U8)]
-            (MkPair [U8] [List U8] value rest))
-        (\u : U8 => charLiteralError))
+poly finishCharLiteral =
+  \value : U8 =>
+    \input : List U8 =>
+      matchList
+        [U8]
+        [Result ParseError (Pair U8 (List U8))]
+        input
+        charLiteralError
+        (
+          \close : U8 =>
+            \rest : List U8 =>
+              if [Result ParseError (Pair U8 (List U8))] (eqU8 close u8_squote)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair U8 (List U8)]
+                      (MkPair [U8] [List U8] value rest)
+                )
+                (\u : U8 => charLiteralError)
+        )
 
-poly consumeCharLiteral = \input : List U8 =>
-  matchList [U8] [Result ParseError (Pair U8 (List U8))] input
-    charLiteralError
-    (\h : U8 => \t : List U8 =>
-      if [Result ParseError (Pair U8 (List U8))] (eqU8 h u8_backslash)
-        (\u : U8 =>
-          matchList [U8] [Result ParseError (Pair U8 (List U8))] t
-            charLiteralError
-            (\escaped : U8 => \afterEscaped : List U8 =>
-              finishCharLiteral (escapedCharValue escaped) afterEscaped))
-        (\u : U8 => finishCharLiteral h t))
+poly consumeCharLiteral =
+  \input : List U8 =>
+    matchList
+      [U8]
+      [Result ParseError (Pair U8 (List U8))]
+      input
+      charLiteralError
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [Result ParseError (Pair U8 (List U8))] (eqU8 h u8_backslash)
+              (
+                \u : U8 =>
+                  matchList
+                    [U8]
+                    [Result ParseError (Pair U8 (List U8))]
+                    t
+                    charLiteralError
+                    (
+                      \escaped : U8 =>
+                        \afterEscaped : List U8 => finishCharLiteral (escapedCharValue escaped) afterEscaped
+                    )
+              )
+              (\u : U8 => finishCharLiteral h t)
+      )
 
 -- Drops a "--" line comment body: returns the input after the next newline
 -- (or nil at end of input). The leading "--" is already detected by the caller.
-poly rec dropLineComment = \input : List U8 =>
-  matchList [U8] [List U8] input
-    (nil [U8])
-    (\h : U8 => \t : List U8 =>
-      if [List U8] (eqU8 h u8_newline)
-        (\u : U8 => t)
-        (\u : U8 => dropLineComment t))
+poly rec dropLineComment =
+  \input : List U8 =>
+    matchList
+      [U8]
+      [List U8]
+      input
+      (nil [U8])
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [List U8] (eqU8 h u8_newline)
+              (\u : U8 => t)
+              (\u : U8 => dropLineComment t)
+      )
 
 -- Skips a "{- ... -}" block comment body, with `input` positioned just after
 -- the opening "{-". Nesting is handled via the call stack: an inner "{-"
 -- recurses, and the value it returns (the text after the inner "-}") is then
 -- scanned for this level's "-}". Returns the input after the matching close,
 -- or Err on an unterminated comment (mirroring the host parser's error).
-poly rec skipBlockComment = \input : List U8 =>
-  matchList [U8] [Result ParseError (List U8)] input
-    (Err [ParseError] [List U8] (MkParseError (nil [U8])))
-    (\h : U8 => \t : List U8 =>
-      if [Result ParseError (List U8)]
-        (and (eqU8 h u8_lbrace)
-          (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_dash h2)))
-        (\u : U8 =>
-          match (skipBlockComment (tail [U8] t)) [Result ParseError (List U8)] {
-            | Err e => Err [ParseError] [List U8] e
-            | Ok afterInner => skipBlockComment afterInner
-          })
-        (\u : U8 =>
-          if [Result ParseError (List U8)]
-            (and (eqU8 h u8_dash)
-              (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_rbrace h2)))
-            (\u : U8 => Ok [ParseError] [List U8] (tail [U8] t))
-            (\u : U8 => skipBlockComment t)))
+poly rec skipBlockComment =
+  \input : List U8 =>
+    matchList
+      [U8]
+      [Result ParseError (List U8)]
+      input
+      (Err [ParseError] [List U8] (MkParseError (nil [U8])))
+      (
+        \h : U8 =>
+          \t : List U8 =>
+            if [Result ParseError (List U8)] (and (eqU8 h u8_lbrace) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_dash h2)))
+              (
+                \u : U8 =>
+                  match (skipBlockComment (tail [U8] t)) [Result ParseError (List U8)] {
+                    | Err e => Err [ParseError] [List U8] e
+                    | Ok afterInner => skipBlockComment afterInner
+                  }
+              )
+              (
+                \u : U8 =>
+                  if [Result ParseError (List U8)] (and (eqU8 h u8_dash) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_rbrace h2)))
+                    (\u : U8 => Ok [ParseError] [List U8] (tail [U8] t))
+                    (\u : U8 => skipBlockComment t)
+              )
+      )
 
-poly rec tokenizeAcc = \input : List U8 => \accRev : List Token =>
-  matchList [U8] [Result ParseError (List Token)] input
-    (Ok [ParseError] [List Token] accRev)
-    (\c : U8 => \cs : List U8 =>
-      if [Result ParseError (List Token)] (isSpaceU8 c)
-        (\u : U8 => tokenizeAcc cs accRev)
-        (\u : U8 =>
-
-      if [Result ParseError (List Token)]
-        (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
-        (\u : U8 => tokenizeAcc (dropLineComment cs) accRev)
-        (\u : U8 =>
-
-      if [Result ParseError (List Token)]
-        (and (eqU8 c u8_lbrace) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
-        (\u : U8 =>
-          match (skipBlockComment (tail [U8] cs)) [Result ParseError (List Token)] {
-            | Err e => Err [ParseError] [List Token] e
-            | Ok rest => tokenizeAcc rest accRev
-          })
-        (\u : U8 =>
-
-      if [Result ParseError (List Token)]
-        (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
-        (\u : U8 =>
-          let rest = tail [U8] cs in
-          tokenizeAcc rest (cons [Token] T_Arrow accRev))
-        (\u : U8 =>
-
-      if [Result ParseError (List Token)]
-        (and (eqU8 c u8_eq) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
-        (\u : U8 =>
-          let rest = tail [U8] cs in
-          tokenizeAcc rest (cons [Token] T_FatArrow accRev))
-        (\u : U8 =>
-
-      match (simpleTokenFromU8 c) [Result ParseError (List Token)] {
-        | None =>
-            if [Result ParseError (List Token)] (or (isAlphaU8 c) (eqU8 c u8_underscore))
-              (\u : U8 =>
-                match (consumeIdent (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
-                  | MkPair taken remaining =>
-                      let tok = keywordTokenFromWord taken in
-                      tokenizeAcc remaining (cons [Token] tok accRev)
-                })
-
-              (\u : U8 =>
-                if [Result ParseError (List Token)] (isDigitU8 c)
-                  (\u : U8 =>
-                    match (consumeDigits (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
-                      | MkPair taken remaining =>
-                          tokenizeAcc remaining (cons [Token] (T_Nat taken) accRev)
-                    })
-
-                  (\u : U8 =>
-                    if [Result ParseError (List Token)] (eqU8 c u8_quote)
-                      (\u : U8 =>
-                        match (consumeString (nil [U8]) cs) [Result ParseError (List Token)] {
-                          | Err e => Err [ParseError] [List Token] e
-                          | Ok strRes =>
-                              let str = fst [List U8] [List U8] strRes in
-                              let remaining = snd [List U8] [List U8] strRes in
-                              tokenizeAcc remaining (cons [Token] (T_Ident str) accRev)
-                        })
-                      (\u : U8 =>
-                        if [Result ParseError (List Token)] (eqU8 c u8_squote)
-                          (\u : U8 =>
-                            match (consumeCharLiteral cs) [Result ParseError (List Token)] {
-                              | Err e => Err [ParseError] [List Token] e
-                              | Ok charRes =>
-                                  let value = fst [U8] [List U8] charRes in
-                                  let remaining = snd [U8] [List U8] charRes in
-                                  tokenizeAcc remaining (cons [Token] (T_Nat (u8ToDigits value)) accRev)
-                            })
-                          (\u : U8 =>
-                            if [Result ParseError (List Token)] (eqU8 c u8_eq)
-                              (\u : U8 => tokenizeAcc cs (cons [Token] T_Eq accRev))
-                              (\u : U8 => Err [ParseError] [List Token] (MkParseError (nil [U8]))))
+poly rec tokenizeAcc =
+  \input : List U8 =>
+    \accRev : List Token =>
+      matchList
+        [U8]
+        [Result ParseError (List Token)]
+        input
+        (Ok [ParseError] [List Token] accRev)
+        (
+          \c : U8 =>
+            \cs : List U8 =>
+              if [Result ParseError (List Token)] (isSpaceU8 c)
+                (\u : U8 => tokenizeAcc cs accRev)
+                (
+                  \u : U8 =>
+                    if [Result ParseError (List Token)] (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
+                      (\u : U8 => tokenizeAcc (dropLineComment cs) accRev)
+                      (
+                        \u : U8 =>
+                          if [Result ParseError (List Token)] (and (eqU8 c u8_lbrace) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
+                            (
+                              \u : U8 =>
+                                match (skipBlockComment (tail [U8] cs)) [Result ParseError (List Token)] {
+                                  | Err e => Err [ParseError] [List Token] e
+                                  | Ok rest => tokenizeAcc rest accRev
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                if [Result ParseError (List Token)] (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
+                                  (
+                                    \u : U8 =>
+                                      let rest = tail [U8] cs in
+                                      tokenizeAcc
+                                        rest
+                                        (cons [Token] T_Arrow accRev)
+                                  )
+                                  (
+                                    \u : U8 =>
+                                      if [Result ParseError (List Token)] (and (eqU8 c u8_eq) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
+                                        (
+                                          \u : U8 =>
+                                            let rest = tail [U8] cs in
+                                            tokenizeAcc
+                                              rest
+                                              (cons [Token] T_FatArrow accRev)
+                                        )
+                                        (
+                                          \u : U8 =>
+                                            match (simpleTokenFromU8 c) [Result ParseError (List Token)] {
+                                              | None =>
+                                                if [Result ParseError (List Token)] (or (isAlphaU8 c) (eqU8 c u8_underscore))
+                                                  (
+                                                    \u : U8 =>
+                                                      match (consumeIdent (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
+                                                        | MkPair taken remaining =>
+                                                          let tok = keywordTokenFromWord taken in
+                                                          tokenizeAcc
+                                                            remaining
+                                                            (
+                                                              cons
+                                                                [Token]
+                                                                tok
+                                                                accRev
+                                                            )
+                                                      }
+                                                  )
+                                                  (
+                                                    \u : U8 =>
+                                                      if [Result ParseError (List Token)] (isDigitU8 c)
+                                                        (
+                                                          \u : U8 =>
+                                                            match (consumeDigits (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
+                                                              | MkPair taken remaining =>
+                                                                tokenizeAcc
+                                                                  remaining
+                                                                  (
+                                                                    cons
+                                                                      [Token]
+                                                                      (
+                                                                        T_Nat
+                                                                          taken
+                                                                      )
+                                                                      accRev
+                                                                  )
+                                                            }
+                                                        )
+                                                        (
+                                                          \u : U8 =>
+                                                            if [Result ParseError (List Token)] (eqU8 c u8_quote)
+                                                              (
+                                                                \u : U8 =>
+                                                                  match (consumeString (nil [U8]) cs) [Result ParseError (List Token)] {
+                                                                    | Err e => Err [ParseError] [List Token] e
+                                                                    | Ok strRes =>
+                                                                      let str = fst [List U8] [List U8] strRes in
+                                                                      let remaining = snd [List U8] [List U8] strRes in
+                                                                      tokenizeAcc
+                                                                        remaining
+                                                                        (
+                                                                          cons
+                                                                            [Token]
+                                                                            (
+                                                                              T_Ident
+                                                                                str
+                                                                            )
+                                                                            accRev
+                                                                        )
+                                                                  }
+                                                              )
+                                                              (
+                                                                \u : U8 =>
+                                                                  if [Result ParseError (List Token)] (eqU8 c u8_squote)
+                                                                    (
+                                                                      \u : U8 =>
+                                                                        match (consumeCharLiteral cs) [Result ParseError (List Token)] {
+                                                                          | Err e => Err [ParseError] [List Token] e
+                                                                          | Ok charRes =>
+                                                                            let value = fst [U8] [List U8] charRes in
+                                                                            let remaining = snd [U8] [List U8] charRes in
+                                                                            tokenizeAcc
+                                                                              remaining
+                                                                              (
+                                                                                cons
+                                                                                  [Token]
+                                                                                  (
+                                                                                    T_Nat
+                                                                                      (
+                                                                                        u8ToDigits
+                                                                                          value
+                                                                                      )
+                                                                                  )
+                                                                                  accRev
+                                                                              )
+                                                                        }
+                                                                    )
+                                                                    (
+                                                                      \u : U8 =>
+                                                                        if [Result ParseError (List Token)] (eqU8 c u8_eq)
+                                                                          (
+                                                                            \u : U8 => tokenizeAcc cs (cons [Token] T_Eq accRev)
+                                                                          )
+                                                                          (
+                                                                            \u : U8 => Err [ParseError] [List Token] (MkParseError (nil [U8]))
+                                                                          )
+                                                                    )
+                                                              )
+                                                        )
+                                                  )
+                                              | Some tok => tokenizeAcc cs (cons [Token] tok accRev)
+                                            }
+                                        )
+                                  )
+                            )
                       )
-                  ))
+                )
+        )
 
-        | Some tok =>
-            tokenizeAcc cs (cons [Token] tok accRev)
-      }
-
-      ))))))
-
-poly tokenize = \input : List U8 =>
-  match (tokenizeAcc input (nil [Token])) [Result ParseError (List Token)] {
-    | Err e => Err [ParseError] [List Token] e
-    | Ok revWithEnd =>
-        Ok [ParseError] [List Token]
+poly tokenize =
+  \input : List U8 =>
+    match (tokenizeAcc input (nil [Token])) [Result ParseError (List Token)] {
+      | Err e => Err [ParseError] [List Token] e
+      | Ok revWithEnd =>
+        Ok
+          [ParseError]
+          [List Token]
           (reverse [Token] (cons [Token] T_EOF revWithEnd))
-  }
+    }

--- a/bootstrap/src/llvm.trip
+++ b/bootstrap/src/llvm.trip
@@ -1,396 +1,708 @@
 module Llvm
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude and
+
 import Prelude or
+
 import Prelude U8
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude ltU8
+
 import Prelude eqListU8
+
 import Lexer tokenize
+
 import Parser parseProgram
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Type
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Data
+
 import Parser D_Def
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
+
 import BundleSummary BundleSummary
+
 import BundleSummary MkBundleSummary
+
 import BundleSummary ModuleRecord
+
 import BundleSummary MkModuleRecord
 
 export compileSourceToLlvm
+
 export compileBundleSummaryToLlvm
+
 export emitLlvmForWriteBytes
+
 export collectWriteBytes
+
 export findMainBody
 
-data ParsedModule = MkParsedModule (List U8) (List Decl)
-data QualifiedName = MkQualifiedName (List U8) (List U8)
-data EmitState = MkEmitState (List QualifiedName) (List U8)
+data ParsedModule =
+  | MkParsedModule (List U8) (List Decl)
 
-poly digitToAscii = \d : U8 =>
-  addU8 d #u8(48)
+data QualifiedName =
+  | MkQualifiedName (List U8) (List U8)
 
-poly singletonU8 = \b : U8 =>
-  cons [U8] b (nil [U8])
+data EmitState =
+  | MkEmitState (List QualifiedName) (List U8)
 
-poly u8ToDigits = \n : U8 =>
-  if [List U8] (ltU8 n #u8(10))
-    (\u : U8 => singletonU8 (digitToAscii n))
-    (\u : U8 =>
-      if [List U8] (ltU8 n #u8(100))
-        (\u : U8 =>
-          cons [U8]
-            (digitToAscii (divU8 n #u8(10)))
-            (singletonU8 (digitToAscii (modU8 n #u8(10)))))
-        (\u : U8 =>
-          let hundreds = divU8 n #u8(100) in
-          let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-          let ones = modU8 n #u8(10) in
-          cons [U8]
-            (digitToAscii hundreds)
-            (cons [U8]
-              (digitToAscii tens)
-              (singletonU8 (digitToAscii ones))))
-    )
+poly digitToAscii =
+  \d : U8 => addU8 d #u8(48)
 
-poly digitValue = \c : U8 =>
-  modU8 c #u8(16)
+poly singletonU8 =
+  \b : U8 => {U8 | b}
 
-poly mul10U8 = \n : U8 =>
-  let two = addU8 n n in
-  let four = addU8 two two in
-  let eight = addU8 four four in
-  addU8 eight two
+poly u8ToDigits =
+  \n : U8 =>
+    if [List U8] (ltU8 n #u8(10))
+      (\u : U8 => singletonU8 (digitToAscii n))
+      (
+        \u : U8 =>
+          if [List U8] (ltU8 n #u8(100))
+            (
+              \u : U8 =>
+                cons
+                  [U8]
+                  (digitToAscii (divU8 n #u8(10)))
+                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
+            )
+            (
+              \u : U8 =>
+                let hundreds = divU8 n #u8(100) in
+                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
+                let ones = modU8 n #u8(10) in
+                cons
+                  [U8]
+                  (digitToAscii hundreds)
+                  (
+                    cons
+                      [U8]
+                      (digitToAscii tens)
+                      (singletonU8 (digitToAscii ones))
+                  )
+            )
+      )
 
-poly rec parseByteDigitsAcc = \digits : List U8 => \acc : U8 =>
-  matchList [U8] [U8] digits acc
-    (\h : U8 => \t : List U8 =>
-      parseByteDigitsAcc t (addU8 (mul10U8 acc) (digitValue h)))
+poly digitValue =
+  \c : U8 => modU8 c #u8(16)
 
-poly parseByteDigits = \digits : List U8 =>
-  parseByteDigitsAcc digits #u8(0)
+poly mul10U8 =
+  \n : U8 =>
+    let two = addU8 n n in
+    let four = addU8 two two in
+    let eight = addU8 four four in
+    addU8 eight two
 
-poly isWriteOneName = \name : List U8 =>
-  or (eqListU8 name "writeOne") (eqListU8 name ".")
+poly rec parseByteDigitsAcc =
+  \digits : List U8 =>
+    \acc : U8 =>
+      matchList
+        [U8]
+        [U8]
+        digits
+        acc
+        (
+          \h : U8 =>
+            \t : List U8 => parseByteDigitsAcc t (addU8 (mul10U8 acc) (digitValue h))
+        )
 
-poly rec collectWriteBytes = \expr : Expr =>
-  match expr [Result (List U8) (List U8)] {
-    | E_Var name => Ok [List U8] [List U8] (nil [U8])
-    | E_Nat digits => Err [List U8] [List U8] "Unsupported LLVM expression"
-    | E_Lam name body => collectWriteBytes body
-    | E_Let name value body => collectWriteBytes body
-    | E_Match scrutinee arms => Err [List U8] [List U8] "Unsupported LLVM expression"
-    | E_App fn cont =>
+poly parseByteDigits =
+  \digits : List U8 => parseByteDigitsAcc digits #u8(0)
+
+poly isWriteOneName =
+  \name : List U8 => or (eqListU8 name "writeOne") (eqListU8 name ".")
+
+poly rec collectWriteBytes =
+  \expr : Expr =>
+    match expr [Result (List U8) (List U8)] {
+      | E_Var name => Ok [List U8] [List U8] ""
+      | E_Nat digits =>
+        Err [List U8] [List U8] "Unsupported LLVM expression"
+      | E_Lam name body => collectWriteBytes body
+      | E_Let name value body => collectWriteBytes body
+      | E_Match scrutinee arms =>
+        Err [List U8] [List U8] "Unsupported LLVM expression"
+      | E_App fn cont =>
         match fn [Result (List U8) (List U8)] {
           | E_App head byteExpr =>
-              match head [Result (List U8) (List U8)] {
-                | E_Var callee =>
-                    if [Result (List U8) (List U8)] (isWriteOneName callee)
-                      (\u : U8 =>
-                        match byteExpr [Result (List U8) (List U8)] {
-                          | E_Nat digits =>
-                              match cont [Result (List U8) (List U8)] {
-                                | E_Lam name body =>
-                                    match (collectWriteBytes body) [Result (List U8) (List U8)] {
-                                      | Err e => Err [List U8] [List U8] e
-                                      | Ok rest =>
-                                          Ok [List U8] [List U8]
-                                            (cons [U8] (parseByteDigits digits) rest)
-                                    }
-                                | E_Var name => Ok [List U8] [List U8] (singletonU8 (parseByteDigits digits))
-                                | E_App a b => Err [List U8] [List U8] "Expected writeOne continuation"
-                                | E_Let name value body => Err [List U8] [List U8] "Expected writeOne continuation"
-                                | E_Nat digits => Err [List U8] [List U8] "Expected writeOne continuation"
-                                | E_Match scrutinee arms => Err [List U8] [List U8] "Expected writeOne continuation"
+            match head [Result (List U8) (List U8)] {
+              | E_Var callee =>
+                if [Result (List U8) (List U8)] (isWriteOneName callee)
+                  (
+                    \u : U8 =>
+                      match byteExpr [Result (List U8) (List U8)] {
+                        | E_Nat digits =>
+                          match cont [Result (List U8) (List U8)] {
+                            | E_Lam name body =>
+                              match (collectWriteBytes body) [Result (List U8) (List U8)] {
+                                | Err e => Err [List U8] [List U8] e
+                                | Ok rest =>
+                                  Ok
+                                    [List U8]
+                                    [List U8]
+                                    (cons [U8] (parseByteDigits digits) rest)
                               }
-                          | E_Var name => Err [List U8] [List U8] "Expected literal byte"
-                          | E_App a b => Err [List U8] [List U8] "Expected literal byte"
-                          | E_Lam name body => Err [List U8] [List U8] "Expected literal byte"
-                          | E_Let name value body => Err [List U8] [List U8] "Expected literal byte"
-                          | E_Match scrutinee arms => Err [List U8] [List U8] "Expected literal byte"
-                        })
-                      (\u : U8 => Err [List U8] [List U8] "Unsupported LLVM expression")
-                | E_App a b => Err [List U8] [List U8] "Unsupported LLVM expression"
-                | E_Lam name body => Err [List U8] [List U8] "Unsupported LLVM expression"
-                | E_Let name value body => Err [List U8] [List U8] "Unsupported LLVM expression"
-                | E_Nat digits => Err [List U8] [List U8] "Unsupported LLVM expression"
-                | E_Match scrutinee arms => Err [List U8] [List U8] "Unsupported LLVM expression"
-              }
-          | E_Var name => Err [List U8] [List U8] "Unsupported LLVM expression"
-          | E_Lam name body => Err [List U8] [List U8] "Unsupported LLVM expression"
-          | E_Let name value body => Err [List U8] [List U8] "Unsupported LLVM expression"
-          | E_Nat digits => Err [List U8] [List U8] "Unsupported LLVM expression"
-          | E_Match scrutinee arms => Err [List U8] [List U8] "Unsupported LLVM expression"
+                            | E_Var name =>
+                              Ok
+                                [List U8]
+                                [List U8]
+                                (singletonU8 (parseByteDigits digits))
+                            | E_App a b =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
+                            | E_Let name value body =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
+                            | E_Nat digits =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
+                            | E_Match scrutinee arms =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
+                          }
+                        | E_Var name => Err [List U8] [List U8] "Expected literal byte"
+                        | E_App a b => Err [List U8] [List U8] "Expected literal byte"
+                        | E_Lam name body => Err [List U8] [List U8] "Expected literal byte"
+                        | E_Let name value body => Err [List U8] [List U8] "Expected literal byte"
+                        | E_Match scrutinee arms => Err [List U8] [List U8] "Expected literal byte"
+                      }
+                  )
+                  (
+                    \u : U8 => Err [List U8] [List U8] "Unsupported LLVM expression"
+                  )
+              | E_App a b =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Lam name body =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Let name value body =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Nat digits =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Match scrutinee arms =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+            }
+          | E_Var name =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Lam name body =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Let name value body =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Nat digits =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Match scrutinee arms =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
         }
-  }
-
-poly rec findDefBody = \wanted : List U8 => \decls : List Decl =>
-  matchList [Decl] [Maybe Expr] decls
-    (None [Expr])
-    (\h : Decl => \t : List Decl =>
-      match h [Maybe Expr] {
-        | D_Def kind isRec name body =>
-            if [Maybe Expr] (eqListU8 name wanted)
-              (\u : U8 => Some [Expr] body)
-              (\u : U8 => findDefBody wanted t)
-        | D_Module name => findDefBody wanted t
-        | D_Import moduleName symbolName => findDefBody wanted t
-        | D_Export name => findDefBody wanted t
-        | D_Opaque name => findDefBody wanted t
-        | D_Native name => findDefBody wanted t
-        | D_Type name => findDefBody wanted t
-        | D_Data name ctors => findDefBody wanted t
-      })
-
-poly findMainBody = \decls : List Decl =>
-  findDefBody "main" decls
-
-poly rec findImportModule = \wanted : List U8 => \decls : List Decl =>
-  matchList [Decl] [Maybe (List U8)] decls
-    (None [List U8])
-    (\h : Decl => \t : List Decl =>
-      match h [Maybe (List U8)] {
-        | D_Import moduleName symbolName =>
-            if [Maybe (List U8)] (eqListU8 symbolName wanted)
-              (\u : U8 => Some [List U8] moduleName)
-              (\u : U8 => findImportModule wanted t)
-        | D_Def kind isRec name body => findImportModule wanted t
-        | D_Module name => findImportModule wanted t
-        | D_Export name => findImportModule wanted t
-        | D_Opaque name => findImportModule wanted t
-        | D_Native name => findImportModule wanted t
-        | D_Type name => findImportModule wanted t
-        | D_Data name ctors => findImportModule wanted t
-      })
-
-poly rec parseModuleSource = \name : List U8 => \source : List U8 =>
-  match (tokenize source) [Result (List U8) ParsedModule] {
-    | Err e => Err [List U8] [ParsedModule] "Lex error"
-    | Ok toks =>
-        match (parseProgram toks) [Result (List U8) ParsedModule] {
-          | Err e => Err [List U8] [ParsedModule] "Parse error"
-          | Ok decls => Ok [List U8] [ParsedModule] (MkParsedModule name decls)
-        }
-  }
-
-poly rec parseModuleRecords = \records : List ModuleRecord =>
-  matchList [ModuleRecord] [Result (List U8) (List ParsedModule)] records
-    (Ok [List U8] [List ParsedModule] (nil [ParsedModule]))
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-      match h [Result (List U8) (List ParsedModule)] { | MkModuleRecord name lengthDigits source =>
-        match (parseModuleSource name source) [Result (List U8) (List ParsedModule)] {
-          | Err e => Err [List U8] [List ParsedModule] e
-          | Ok parsed =>
-              match (parseModuleRecords t) [Result (List U8) (List ParsedModule)] {
-                | Err e => Err [List U8] [List ParsedModule] e
-                | Ok rest => Ok [List U8] [List ParsedModule] (cons [ParsedModule] parsed rest)
-              }
-        }
-      })
-
-poly rec findParsedModule = \wanted : List U8 => \mods : List ParsedModule =>
-  matchList [ParsedModule] [Maybe ParsedModule] mods
-    (None [ParsedModule])
-    (\h : ParsedModule => \t : List ParsedModule =>
-      match h [Maybe ParsedModule] { | MkParsedModule name decls =>
-        if [Maybe ParsedModule] (eqListU8 name wanted)
-          (\u : U8 => Some [ParsedModule] h)
-          (\u : U8 => findParsedModule wanted t)
-      })
-
-poly resolveCallee = \moduleName : List U8 => \decls : List Decl => \callee : List U8 =>
-  match (findImportModule callee decls) [Result (List U8) QualifiedName] {
-    | Some importedModule =>
-        Ok [List U8] [QualifiedName] (MkQualifiedName importedModule callee)
-    | None =>
-        match (findDefBody callee decls) [Result (List U8) QualifiedName] {
-          | Some localBody => Ok [List U8] [QualifiedName] (MkQualifiedName moduleName callee)
-          | None => Err [List U8] [QualifiedName] "Unknown callee"
-        }
-  }
-
-poly sameQualified = \moduleName : List U8 => \name : List U8 => \qualified : QualifiedName =>
-  match qualified [Bool] { | MkQualifiedName qModule qName =>
-    and (eqListU8 moduleName qModule) (eqListU8 name qName)
-  }
-
-poly rec hasEmitted = \moduleName : List U8 => \name : List U8 => \seen : List QualifiedName =>
-  matchList [QualifiedName] [Bool] seen
-    false
-    (\h : QualifiedName => \t : List QualifiedName =>
-      if [Bool] (sameQualified moduleName name h)
-        (\u : U8 => true)
-        (\u : U8 => hasEmitted moduleName name t))
-
-poly markEmitted = \moduleName : List U8 => \name : List U8 => \state : EmitState =>
-  match state [EmitState] { | MkEmitState seen text =>
-    MkEmitState (cons [QualifiedName] (MkQualifiedName moduleName name) seen) text
-  }
-
-poly appendStateText = \state : EmitState => \text : List U8 =>
-  match state [EmitState] { | MkEmitState seen current =>
-    MkEmitState seen (append [U8] current text)
-  }
-
-poly functionSymbol = \moduleName : List U8 => \name : List U8 =>
-  append [U8] "trip_fn_" (append [U8] moduleName (append [U8] "_" name))
-
-poly emitFunctionHeader = \moduleName : List U8 => \name : List U8 =>
-  append [U8] "define i8 @" (append [U8] (functionSymbol moduleName name) "() {\nentry:\n")
-
-poly emitLiteralFunction = \moduleName : List U8 => \name : List U8 => \digits : List U8 =>
-  append [U8] (emitFunctionHeader moduleName name)
-    (append [U8] "  ret i8 " (append [U8] digits "\n}\n\n"))
-
-poly emitCallFunction = \moduleName : List U8 => \name : List U8 => \calleeModule : List U8 => \calleeName : List U8 =>
-  append [U8] (emitFunctionHeader moduleName name)
-    (append [U8] "  %call = call i8 @"
-      (append [U8] (functionSymbol calleeModule calleeName)
-        "()\n  ret i8 %call\n}\n\n"))
-
-poly emitWriteCall = \byte : U8 =>
-  append [U8]
-    "  call void @trip_write_one(i8 "
-    (append [U8] (u8ToDigits byte) ")\n")
-
-poly rec emitWriteCalls = \bytes : List U8 =>
-  matchList [U8] [List U8] bytes
-    (nil [U8])
-    (\h : U8 => \t : List U8 =>
-      append [U8] (emitWriteCall h) (emitWriteCalls t))
-
-poly rec lastByteOrZero = \bytes : List U8 => \last : U8 =>
-  matchList [U8] [U8] bytes
-    last
-    (\h : U8 => \t : List U8 => lastByteOrZero t h)
-
-poly emitWriteFunction = \moduleName : List U8 => \name : List U8 => \bytes : List U8 =>
-  append [U8]
-    (emitFunctionHeader moduleName name)
-    (append [U8]
-      (emitWriteCalls bytes)
-      (append [U8]
-        "  ret i8 "
-        (append [U8] (u8ToDigits (lastByteOrZero bytes #u8(0))) "\n}\n\n")))
-
-poly emitMainWrapper = \moduleName : List U8 =>
-  append [U8] "define i32 @main() {\nentry:\n  %trip_result = call i8 @"
-    (append [U8] (functionSymbol moduleName "main") "()\n  ret i32 0\n}\n")
-
-poly emitLlvmForWriteBytes = \bytes : List U8 =>
-  append [U8]
-    "declare void @trip_write_one(i8)\n\n"
-    (append [U8] (emitWriteFunction "Main" "main" bytes) (emitMainWrapper "Main"))
-
-poly rec emitRequiredFunction = \mods : List ParsedModule => \moduleName : List U8 => \name : List U8 => \state : EmitState =>
-  match state [Result (List U8) EmitState] { | MkEmitState seen text =>
-    if [Result (List U8) EmitState] (hasEmitted moduleName name seen)
-      (\u : U8 => Ok [List U8] [EmitState] state)
-      (\u : U8 =>
-        match (findParsedModule moduleName mods) [Result (List U8) EmitState] {
-          | None => Err [List U8] [EmitState] "Module not found"
-          | Some parsed =>
-              match parsed [Result (List U8) EmitState] { | MkParsedModule parsedName decls =>
-                match (findDefBody name decls) [Result (List U8) EmitState] {
-                  | None => Err [List U8] [EmitState] "Definition not found"
-                  | Some body =>
-                      emitFunctionBody mods moduleName decls name body (markEmitted moduleName name state)
-                }
-              }
-        })
-  }
-
-poly emitWriteBody = \moduleName : List U8 => \name : List U8 => \body : Expr => \state : EmitState =>
-  match (collectWriteBytes body) [Result (List U8) EmitState] {
-    | Err e => Err [List U8] [EmitState] e
-    | Ok bytes => Ok [List U8] [EmitState] (appendStateText state (emitWriteFunction moduleName name bytes))
-  }
-
-poly emitFunctionBody = \mods : List ParsedModule => \moduleName : List U8 => \decls : List Decl => \name : List U8 => \body : Expr => \state : EmitState =>
-  match body [Result (List U8) EmitState] {
-    | E_Nat digits =>
-        Ok [List U8] [EmitState] (appendStateText state (emitLiteralFunction moduleName name digits))
-    | E_Var callee =>
-        match (resolveCallee moduleName decls callee) [Result (List U8) EmitState] {
-          | Err e => Err [List U8] [EmitState] e
-          | Ok qualified =>
-              match qualified [Result (List U8) EmitState] { | MkQualifiedName calleeModule calleeName =>
-                match (emitRequiredFunction mods calleeModule calleeName state) [Result (List U8) EmitState] {
-                  | Err e => Err [List U8] [EmitState] e
-                  | Ok depState =>
-                      Ok [List U8] [EmitState] (appendStateText depState (emitCallFunction moduleName name calleeModule calleeName))
-                }
-              }
-        }
-    | E_App f x => emitWriteBody moduleName name body state
-    | E_Lam arg inner => Err [List U8] [EmitState] "Unsupported LLVM expression"
-    | E_Let letName value inner => Err [List U8] [EmitState] "Unsupported LLVM expression"
-    | E_Match scrutinee arms => Err [List U8] [EmitState] "Unsupported LLVM expression"
-  }
-
-poly compileParsedModulesToLlvm = \entry : List U8 => \wrapper : List U8 => \mods : List ParsedModule =>
-  match (emitRequiredFunction mods entry "main" (MkEmitState (nil [QualifiedName]) (nil [U8]))) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [List U8] e
-    | Ok state =>
-        match state [Result (List U8) (List U8)] { | MkEmitState seen body =>
-          let withDecl = append [U8] "declare void @trip_write_one(i8)\n\n" body in
-          if [Result (List U8) (List U8)] (eqListU8 wrapper "enabled")
-            (\u : U8 => Ok [List U8] [List U8] (append [U8] withDecl (emitMainWrapper entry)))
-            (\u : U8 => Ok [List U8] [List U8] withDecl)
-        }
-  }
-
-poly compileBundleSummaryToLlvm = \bundle : BundleSummary =>
-  match bundle [Result (List U8) (List U8)] { | MkBundleSummary entry target wrapper modsCountDigits mods =>
-    match (parseModuleRecords mods) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok parsedMods => compileParsedModulesToLlvm entry wrapper parsedMods
     }
-  }
 
-poly compileSourceToLlvm = \source : List U8 =>
-  match (tokenize source) [Result (List U8) (List U8)] {
-    | Err e => Err [List U8] [List U8] "Lex error"
-    | Ok toks =>
+poly rec findDefBody =
+  \wanted : List U8 =>
+    \decls : List Decl =>
+      matchList
+        [Decl]
+        [Maybe Expr]
+        decls
+        (None [Expr])
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Maybe Expr] {
+                | D_Def kind isRec name body =>
+                  if [Maybe Expr] (eqListU8 name wanted)
+                    (\u : U8 => Some [Expr] body)
+                    (\u : U8 => findDefBody wanted t)
+                | D_Module name => findDefBody wanted t
+                | D_Import moduleName symbolName => findDefBody wanted t
+                | D_Export name => findDefBody wanted t
+                | D_Opaque name => findDefBody wanted t
+                | D_Native name => findDefBody wanted t
+                | D_Type name => findDefBody wanted t
+                | D_Data name ctors => findDefBody wanted t
+              }
+        )
+
+poly findMainBody =
+  \decls : List Decl => findDefBody "main" decls
+
+poly rec findImportModule =
+  \wanted : List U8 =>
+    \decls : List Decl =>
+      matchList
+        [Decl]
+        [Maybe (List U8)]
+        decls
+        (None [List U8])
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Maybe (List U8)] {
+                | D_Import moduleName symbolName =>
+                  if [Maybe (List U8)] (eqListU8 symbolName wanted)
+                    (\u : U8 => Some [List U8] moduleName)
+                    (\u : U8 => findImportModule wanted t)
+                | D_Def kind isRec name body => findImportModule wanted t
+                | D_Module name => findImportModule wanted t
+                | D_Export name => findImportModule wanted t
+                | D_Opaque name => findImportModule wanted t
+                | D_Native name => findImportModule wanted t
+                | D_Type name => findImportModule wanted t
+                | D_Data name ctors => findImportModule wanted t
+              }
+        )
+
+poly rec parseModuleSource =
+  \name : List U8 =>
+    \source : List U8 =>
+      match (tokenize source) [Result (List U8) ParsedModule] {
+        | Err e => Err [List U8] [ParsedModule] "Lex error"
+        | Ok toks =>
+          match (parseProgram toks) [Result (List U8) ParsedModule] {
+            | Err e => Err [List U8] [ParsedModule] "Parse error"
+            | Ok decls =>
+              Ok [List U8] [ParsedModule] (MkParsedModule name decls)
+          }
+      }
+
+poly rec parseModuleRecords =
+  \records : List ModuleRecord =>
+    matchList
+      [ModuleRecord]
+      [Result (List U8) (List ParsedModule)]
+      records
+      (Ok [List U8] [List ParsedModule] ({ParsedModule |}))
+      (
+        \h : ModuleRecord =>
+          \t : List ModuleRecord =>
+            match h [Result (List U8) (List ParsedModule)] {
+              | MkModuleRecord name lengthDigits source =>
+                match (parseModuleSource name source) [Result (List U8) (List ParsedModule)] {
+                  | Err e => Err [List U8] [List ParsedModule] e
+                  | Ok parsed =>
+                    match (parseModuleRecords t) [Result (List U8) (List ParsedModule)] {
+                      | Err e => Err [List U8] [List ParsedModule] e
+                      | Ok rest =>
+                        Ok
+                          [List U8]
+                          [List ParsedModule]
+                          (cons [ParsedModule] parsed rest)
+                    }
+                }
+            }
+      )
+
+poly rec findParsedModule =
+  \wanted : List U8 =>
+    \mods : List ParsedModule =>
+      matchList
+        [ParsedModule]
+        [Maybe ParsedModule]
+        mods
+        (None [ParsedModule])
+        (
+          \h : ParsedModule =>
+            \t : List ParsedModule =>
+              match h [Maybe ParsedModule] {
+                | MkParsedModule name decls =>
+                  if [Maybe ParsedModule] (eqListU8 name wanted)
+                    (\u : U8 => Some [ParsedModule] h)
+                    (\u : U8 => findParsedModule wanted t)
+              }
+        )
+
+poly resolveCallee =
+  \moduleName : List U8 =>
+    \decls : List Decl =>
+      \callee : List U8 =>
+        match (findImportModule callee decls) [Result (List U8) QualifiedName] {
+          | Some importedModule =>
+            Ok [List U8] [QualifiedName] (MkQualifiedName importedModule callee)
+          | None =>
+            match (findDefBody callee decls) [Result (List U8) QualifiedName] {
+              | Some localBody =>
+                Ok [List U8] [QualifiedName] (MkQualifiedName moduleName callee)
+              | None => Err [List U8] [QualifiedName] "Unknown callee"
+            }
+        }
+
+poly sameQualified =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \qualified : QualifiedName =>
+        match qualified [Bool] {
+          | MkQualifiedName qModule qName =>
+            and (eqListU8 moduleName qModule) (eqListU8 name qName)
+        }
+
+poly rec hasEmitted =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \seen : List QualifiedName =>
+        matchList
+          [QualifiedName]
+          [Bool]
+          seen
+          false
+          (
+            \h : QualifiedName =>
+              \t : List QualifiedName =>
+                if [Bool] (sameQualified moduleName name h)
+                  (\u : U8 => true)
+                  (\u : U8 => hasEmitted moduleName name t)
+          )
+
+poly markEmitted =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \state : EmitState =>
+        match state [EmitState] {
+          | MkEmitState seen text =>
+            MkEmitState
+              (cons [QualifiedName] (MkQualifiedName moduleName name) seen)
+              text
+        }
+
+poly appendStateText =
+  \state : EmitState =>
+    \text : List U8 =>
+      match state [EmitState] {
+        | MkEmitState seen current => MkEmitState seen (append [U8] current text)
+      }
+
+poly functionSymbol =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      append [U8] "trip_fn_" (append [U8] moduleName (append [U8] "_" name))
+
+poly emitFunctionHeader =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      append
+        [U8]
+        "define i8 @"
+        (append [U8] (functionSymbol moduleName name) "() {\nentry:\n")
+
+poly emitLiteralFunction =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \digits : List U8 =>
+        append
+          [U8]
+          (emitFunctionHeader moduleName name)
+          (append [U8] "  ret i8 " (append [U8] digits "\n}\n\n"))
+
+poly emitCallFunction =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \calleeModule : List U8 =>
+        \calleeName : List U8 =>
+          append
+            [U8]
+            (emitFunctionHeader moduleName name)
+            (
+              append
+                [U8]
+                "  %call = call i8 @"
+                (
+                  append
+                    [U8]
+                    (functionSymbol calleeModule calleeName)
+                    "()\n  ret i8 %call\n}\n\n"
+                )
+            )
+
+poly emitWriteCall =
+  \byte : U8 =>
+    append
+      [U8]
+      "  call void @trip_write_one(i8 "
+      (append [U8] (u8ToDigits byte) ")\n")
+
+poly rec emitWriteCalls =
+  \bytes : List U8 =>
+    matchList
+      [U8]
+      [List U8]
+      bytes
+      ""
+      (
+        \h : U8 =>
+          \t : List U8 => append [U8] (emitWriteCall h) (emitWriteCalls t)
+      )
+
+poly rec lastByteOrZero =
+  \bytes : List U8 =>
+    \last : U8 =>
+      matchList
+        [U8]
+        [U8]
+        bytes
+        last
+        (\h : U8 => \t : List U8 => lastByteOrZero t h)
+
+poly emitWriteFunction =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \bytes : List U8 =>
+        append
+          [U8]
+          (emitFunctionHeader moduleName name)
+          (
+            append
+              [U8]
+              (emitWriteCalls bytes)
+              (
+                append
+                  [U8]
+                  "  ret i8 "
+                  (
+                    append
+                      [U8]
+                      (u8ToDigits (lastByteOrZero bytes #u8(0)))
+                      "\n}\n\n"
+                  )
+              )
+          )
+
+poly emitMainWrapper =
+  \moduleName : List U8 =>
+    append
+      [U8]
+      "define i32 @main() {\nentry:\n  %trip_result = call i8 @"
+      (append [U8] (functionSymbol moduleName "main") "()\n  ret i32 0\n}\n")
+
+poly emitLlvmForWriteBytes =
+  \bytes : List U8 =>
+    append
+      [U8]
+      "declare void @trip_write_one(i8)\n\n"
+      (
+        append
+          [U8]
+          (emitWriteFunction "Main" "main" bytes)
+          (emitMainWrapper "Main")
+      )
+
+poly rec emitRequiredFunction =
+  \mods : List ParsedModule =>
+    \moduleName : List U8 =>
+      \name : List U8 =>
+        \state : EmitState =>
+          match state [Result (List U8) EmitState] {
+            | MkEmitState seen text =>
+              if [Result (List U8) EmitState] (hasEmitted moduleName name seen)
+                (\u : U8 => Ok [List U8] [EmitState] state)
+                (
+                  \u : U8 =>
+                    match (findParsedModule moduleName mods) [Result (List U8) EmitState] {
+                      | None => Err [List U8] [EmitState] "Module not found"
+                      | Some parsed =>
+                        match parsed [Result (List U8) EmitState] {
+                          | MkParsedModule parsedName decls =>
+                            match (findDefBody name decls) [Result (List U8) EmitState] {
+                              | None => Err [List U8] [EmitState] "Definition not found"
+                              | Some body =>
+                                emitFunctionBody
+                                  mods
+                                  moduleName
+                                  decls
+                                  name
+                                  body
+                                  (markEmitted moduleName name state)
+                            }
+                        }
+                    }
+                )
+          }
+
+poly emitWriteBody =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \body : Expr =>
+        \state : EmitState =>
+          match (collectWriteBytes body) [Result (List U8) EmitState] {
+            | Err e => Err [List U8] [EmitState] e
+            | Ok bytes =>
+              Ok
+                [List U8]
+                [EmitState]
+                (
+                  appendStateText
+                    state
+                    (emitWriteFunction moduleName name bytes)
+                )
+          }
+
+poly emitFunctionBody =
+  \mods : List ParsedModule =>
+    \moduleName : List U8 =>
+      \decls : List Decl =>
+        \name : List U8 =>
+          \body : Expr =>
+            \state : EmitState =>
+              match body [Result (List U8) EmitState] {
+                | E_Nat digits =>
+                  Ok
+                    [List U8]
+                    [EmitState]
+                    (
+                      appendStateText
+                        state
+                        (emitLiteralFunction moduleName name digits)
+                    )
+                | E_Var callee =>
+                  match (resolveCallee moduleName decls callee) [Result (List U8) EmitState] {
+                    | Err e => Err [List U8] [EmitState] e
+                    | Ok qualified =>
+                      match qualified [Result (List U8) EmitState] {
+                        | MkQualifiedName calleeModule calleeName =>
+                          match (emitRequiredFunction mods calleeModule calleeName state) [Result (List U8) EmitState] {
+                            | Err e => Err [List U8] [EmitState] e
+                            | Ok depState =>
+                              Ok
+                                [List U8]
+                                [EmitState]
+                                (
+                                  appendStateText
+                                    depState
+                                    (
+                                      emitCallFunction
+                                        moduleName
+                                        name
+                                        calleeModule
+                                        calleeName
+                                    )
+                                )
+                          }
+                      }
+                  }
+                | E_App f x => emitWriteBody moduleName name body state
+                | E_Lam arg inner =>
+                  Err [List U8] [EmitState] "Unsupported LLVM expression"
+                | E_Let letName value inner =>
+                  Err [List U8] [EmitState] "Unsupported LLVM expression"
+                | E_Match scrutinee arms =>
+                  Err [List U8] [EmitState] "Unsupported LLVM expression"
+              }
+
+poly compileParsedModulesToLlvm =
+  \entry : List U8 =>
+    \wrapper : List U8 =>
+      \mods : List ParsedModule =>
+        match (emitRequiredFunction mods entry "main" (MkEmitState ({QualifiedName |}) "")) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok state =>
+            match state [Result (List U8) (List U8)] {
+              | MkEmitState seen body =>
+                let withDecl = append [U8] "declare void @trip_write_one(i8)\n\n" body in
+                if [Result (List U8) (List U8)] (eqListU8 wrapper "enabled")
+                  (
+                    \u : U8 =>
+                      Ok
+                        [List U8]
+                        [List U8]
+                        (append [U8] withDecl (emitMainWrapper entry))
+                  )
+                  (\u : U8 => Ok [List U8] [List U8] withDecl)
+            }
+        }
+
+poly compileBundleSummaryToLlvm =
+  \bundle : BundleSummary =>
+    match bundle [Result (List U8) (List U8)] {
+      | MkBundleSummary entry target wrapper modsCountDigits mods =>
+        match (parseModuleRecords mods) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok parsedMods =>
+            compileParsedModulesToLlvm entry wrapper parsedMods
+        }
+    }
+
+poly compileSourceToLlvm =
+  \source : List U8 =>
+    match (tokenize source) [Result (List U8) (List U8)] {
+      | Err e => Err [List U8] [List U8] "Lex error"
+      | Ok toks =>
         match (parseProgram toks) [Result (List U8) (List U8)] {
           | Err e => Err [List U8] [List U8] "Parse error"
           | Ok decls =>
-              match (findMainBody decls) [Result (List U8) (List U8)] {
-                | None => Err [List U8] [List U8] "Missing main"
-                | Some body =>
-                    match (collectWriteBytes body) [Result (List U8) (List U8)] {
-                      | Err e => Err [List U8] [List U8] e
-                      | Ok bytes => Ok [List U8] [List U8] (emitLlvmForWriteBytes bytes)
-                    }
-              }
+            match (findMainBody decls) [Result (List U8) (List U8)] {
+              | None => Err [List U8] [List U8] "Missing main"
+              | Some body =>
+                match (collectWriteBytes body) [Result (List U8) (List U8)] {
+                  | Err e => Err [List U8] [List U8] e
+                  | Ok bytes =>
+                    Ok [List U8] [List U8] (emitLlvmForWriteBytes bytes)
+                }
+            }
         }
-  }
+    }

--- a/bootstrap/src/lowering.trip
+++ b/bootstrap/src/lowering.trip
@@ -1,79 +1,149 @@
 module Lowering
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude if
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude U8
+
 import Prelude and
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude or
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Nat Nat
 
 import Nat zero
+
 import Nat succ
+
 import Nat isZero
+
 import Nat pred
+
 import Nat add
+
 import Nat sub
+
 import Nat eq
+
 import Nat lte
+
 import Avl Avl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl insert
+
 import Unparse Terminal
+
 import Unparse Comb
+
 import Unparse C_Term
+
 import Unparse C_App
+
 import Unparse T_S
+
 import Unparse T_K
+
 import Unparse T_I
+
 import Unparse T_B
+
 import Unparse T_C
+
 import Unparse T_SPrime
+
 import Unparse T_BPrime
+
 import Unparse T_CPrime
+
 import Unparse T_WriteOne
+
 import Unparse T_ReadOne
+
 import Unparse T_EqU8
+
 import Unparse T_LtU8
+
 import Unparse T_DivU8
+
 import Unparse T_ModU8
+
 import Unparse T_AddU8
+
 import Unparse T_SubU8
+
 import Unparse T_Byte
+
 import Unparse terminalTag
+
 import Unparse terminalByteValue
 
 export Lower
+
 export L_Var
+
 export L_App
+
 export L_Lam
+
 export L_Native
+
 export Res
+
 export MkRes
+
 export lowerToComb
+
 export compile
+
 export zip
+
 export liftArity
+
 export emitBulk
+
 export selectOuter
+
 export sbi
+
 export yComb
+
 export lteLower
 
 data Lower =
@@ -82,212 +152,322 @@ data Lower =
   | L_Lam Lower
   | L_Native Terminal
 
-poly rec lteTerminal = \a : Terminal => \b : Terminal =>
-  let tagA = terminalTag a in
-  let tagB = terminalTag b in
-  if [Bool] (eqU8 tagA tagB)
-    (\u : U8 =>
-      if [Bool] (eqU8 tagA #u8(15))
-        (\u : U8 => lteU8 (terminalByteValue a) (terminalByteValue b))
-        (\u : U8 => true))
-    (\u : U8 => ltU8 tagA tagB)
+poly rec lteTerminal =
+  \a : Terminal =>
+    \b : Terminal =>
+      let tagA = terminalTag a in
+      let tagB = terminalTag b in
+      if [Bool] (eqU8 tagA tagB)
+        (
+          \u : U8 =>
+            if [Bool] (eqU8 tagA #u8(15))
+              (\u : U8 => lteU8 (terminalByteValue a) (terminalByteValue b))
+              (\u : U8 => true)
+        )
+        (\u : U8 => ltU8 tagA tagB)
 
-poly rec lteLower = \a : Lower => \b : Lower =>
-  match a [Bool] {
-    | L_Var i =>
-        match b [Bool] {
-          | L_Var j => lteU8 i j
-          | L_App _ _ => true
-          | L_Lam _ => true
-          | L_Native _ => true
-        }
-    | L_App l1 r1 =>
-        match b [Bool] {
-          | L_Var _ => false
-          | L_App l2 r2 =>
+poly rec lteLower =
+  \a : Lower =>
+    \b : Lower =>
+      match a [Bool] {
+        | L_Var i =>
+          match b [Bool] {
+            | L_Var j => lteU8 i j
+            | L_App _ _ => true
+            | L_Lam _ => true
+            | L_Native _ => true
+          }
+        | L_App l1 r1 =>
+          match b [Bool] {
+            | L_Var _ => false
+            | L_App l2 r2 =>
               if [Bool] (and (lteLower l1 l2) (lteLower l2 l1))
                 (\u : U8 => lteLower r1 r2)
                 (\u : U8 => lteLower l1 l2)
-          | L_Lam _ => true
-          | L_Native _ => true
-        }
-    | L_Lam b1 =>
-        match b [Bool] {
-          | L_Var _ => false
-          | L_App _ _ => false
-          | L_Lam b2 => lteLower b1 b2
-          | L_Native _ => true
-        }
-    | L_Native t1 =>
-        match b [Bool] {
-          | L_Var _ => false
-          | L_App _ _ => false
-          | L_Lam _ => false
-          | L_Native t2 => lteTerminal t1 t2
-        }
-  }
+            | L_Lam _ => true
+            | L_Native _ => true
+          }
+        | L_Lam b1 =>
+          match b [Bool] {
+            | L_Var _ => false
+            | L_App _ _ => false
+            | L_Lam b2 => lteLower b1 b2
+            | L_Native _ => true
+          }
+        | L_Native t1 =>
+          match b [Bool] {
+            | L_Var _ => false
+            | L_App _ _ => false
+            | L_Lam _ => false
+            | L_Native t2 => lteTerminal t1 t2
+          }
+      }
 
-data Res = MkRes U8 Comb
+data Res =
+  | MkRes U8 Comb
 
-poly sbi = C_App (C_App (C_Term T_S) (C_Term T_B)) (C_Term T_I)
+poly sbi =
+  C_App (C_App (C_Term T_S) (C_Term T_B)) (C_Term T_I)
 
-poly combS = C_Term T_S
-poly combK = C_Term T_K
-poly combI = C_Term T_I
-poly combB = C_Term T_B
-poly combC = C_Term T_C
-poly combSPrime = C_Term T_SPrime
-poly combCPrime = C_Term T_CPrime
-poly combBB = C_App combB combB
-poly combBK = C_App combB combK
-poly bbSbi = C_App (C_App combB combBB) sbi
-poly bbSPrimeSbi = C_App (C_App combB (C_App combB combSPrime)) sbi
-poly bbCPrimeSbi = C_App (C_App combB (C_App combB combCPrime)) sbi
+poly combS =
+  C_Term T_S
 
-poly selectOuter2 = C_App (C_App combB combI) combK
-poly selectOuter3 = C_App (C_App combB selectOuter2) combK
-poly selectOuter4 = C_App (C_App combB selectOuter3) combK
-poly selectOuter5 = C_App (C_App combB selectOuter4) combK
-poly selectOuter6 = C_App (C_App combB selectOuter5) combK
+poly combK =
+  C_Term T_K
 
-poly rec selectOuter = \arity : U8 =>
-  if [Comb] (eqU8 arity #u8(0))
-    (\u : U8 => combI)
-    (\u : U8 =>
-      if [Comb] (eqU8 arity #u8(1))
-        (\u : U8 => combI)
-        (\u : U8 =>
-          if [Comb] (eqU8 arity #u8(2))
-            (\u : U8 => selectOuter2)
-            (\u : U8 =>
-              if [Comb] (eqU8 arity #u8(3))
-                (\u : U8 => selectOuter3)
-                (\u : U8 =>
-                  if [Comb] (eqU8 arity #u8(4))
-                    (\u : U8 => selectOuter4)
-                    (\u : U8 =>
-                      if [Comb] (eqU8 arity #u8(5))
-                        (\u : U8 => selectOuter5)
-                        (\u : U8 =>
-                          if [Comb] (eqU8 arity #u8(6))
-                            (\u : U8 => selectOuter6)
-                            (\u : U8 => C_App (C_App combB (selectOuter (subU8 arity #u8(1)))) combK)
+poly combI =
+  C_Term T_I
+
+poly combB =
+  C_Term T_B
+
+poly combC =
+  C_Term T_C
+
+poly combSPrime =
+  C_Term T_SPrime
+
+poly combCPrime =
+  C_Term T_CPrime
+
+poly combBB =
+  C_App combB combB
+
+poly combBK =
+  C_App combB combK
+
+poly bbSbi =
+  C_App (C_App combB combBB) sbi
+
+poly bbSPrimeSbi =
+  C_App (C_App combB (C_App combB combSPrime)) sbi
+
+poly bbCPrimeSbi =
+  C_App (C_App combB (C_App combB combCPrime)) sbi
+
+poly selectOuter2 =
+  C_App (C_App combB combI) combK
+
+poly selectOuter3 =
+  C_App (C_App combB selectOuter2) combK
+
+poly selectOuter4 =
+  C_App (C_App combB selectOuter3) combK
+
+poly selectOuter5 =
+  C_App (C_App combB selectOuter4) combK
+
+poly selectOuter6 =
+  C_App (C_App combB selectOuter5) combK
+
+poly rec selectOuter =
+  \arity : U8 =>
+    if [Comb] (eqU8 arity #u8(0))
+      (\u : U8 => combI)
+      (
+        \u : U8 =>
+          if [Comb] (eqU8 arity #u8(1))
+            (\u : U8 => combI)
+            (
+              \u : U8 =>
+                if [Comb] (eqU8 arity #u8(2))
+                  (\u : U8 => selectOuter2)
+                  (
+                    \u : U8 =>
+                      if [Comb] (eqU8 arity #u8(3))
+                        (\u : U8 => selectOuter3)
+                        (
+                          \u : U8 =>
+                            if [Comb] (eqU8 arity #u8(4))
+                              (\u : U8 => selectOuter4)
+                              (
+                                \u : U8 =>
+                                  if [Comb] (eqU8 arity #u8(5))
+                                    (\u : U8 => selectOuter5)
+                                    (
+                                      \u : U8 =>
+                                        if [Comb] (eqU8 arity #u8(6))
+                                          (\u : U8 => selectOuter6)
+                                          (
+                                            \u : U8 => C_App (C_App combB (selectOuter (subU8 arity #u8(1)))) combK
+                                          )
+                                    )
+                              )
                         )
-                    )
-                )
+                  )
             )
+      )
+
+poly rec emitBulkB =
+  \depth : U8 =>
+    if [Comb] (eqU8 depth #u8(1))
+      (\u : U8 => combB)
+      (
+        \u : U8 =>
+          let smaller = emitBulkB (divU8 depth #u8(2)) in
+          if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
+            (\u : U8 => C_App sbi smaller)
+            (\u : U8 => C_App bbSbi smaller)
+      )
+
+poly rec emitBulkSCore =
+  \depth : U8 =>
+    if [Comb] (eqU8 depth #u8(1))
+      (\u : U8 => combSPrime)
+      (
+        \u : U8 =>
+          let smaller = emitBulkSCore (divU8 depth #u8(2)) in
+          if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
+            (\u : U8 => C_App sbi smaller)
+            (\u : U8 => C_App bbSPrimeSbi smaller)
+      )
+
+poly emitBulkS =
+  \depth : U8 =>
+    if [Comb] (eqU8 depth #u8(1))
+      (\u : U8 => combS)
+      (\u : U8 => C_App (emitBulkSCore depth) combI)
+
+poly rec emitBulkCCore =
+  \depth : U8 =>
+    if [Comb] (eqU8 depth #u8(1))
+      (\u : U8 => combCPrime)
+      (
+        \u : U8 =>
+          let smaller = emitBulkCCore (divU8 depth #u8(2)) in
+          if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
+            (\u : U8 => C_App sbi smaller)
+            (\u : U8 => C_App bbCPrimeSbi smaller)
+      )
+
+poly emitBulkC =
+  \depth : U8 =>
+    if [Comb] (eqU8 depth #u8(1))
+      (\u : U8 => combC)
+      (\u : U8 => C_App (emitBulkCCore depth) combI)
+
+poly emitBulk =
+  \kind : U8 =>
+    \depth : U8 =>
+      if [Comb] (eqU8 kind #u8(0))
+        (\u : U8 => emitBulkS depth)
+        (
+          \u : U8 =>
+            if [Comb] (eqU8 kind #u8(1))
+              (\u : U8 => emitBulkB depth)
+              (\u : U8 => emitBulkC depth)
         )
-    )
 
-poly rec emitBulkB = \depth : U8 =>
-  if [Comb] (eqU8 depth #u8(1))
-    (\u : U8 => combB)
-    (\u : U8 =>
-      let smaller = emitBulkB (divU8 depth #u8(2)) in
-      if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
-        (\u : U8 => C_App sbi smaller)
-        (\u : U8 => C_App bbSbi smaller)
-    )
+poly rec dropArity =
+  \count : U8 =>
+    if [Comb] (eqU8 count #u8(0))
+      (\u : U8 => combI)
+      (
+        \u : U8 =>
+          if [Comb] (eqU8 count #u8(1))
+            (\u : U8 => combK)
+            (
+              \u : U8 =>
+                let half = dropArity (divU8 count #u8(2)) in
+                let doubled = C_App (C_App combB half) half in
+                if [Comb] (eqU8 (modU8 count #u8(2)) #u8(0))
+                  (\u : U8 => doubled)
+                  (\u : U8 => C_App combBK doubled)
+            )
+      )
 
-poly rec emitBulkSCore = \depth : U8 =>
-  if [Comb] (eqU8 depth #u8(1))
-    (\u : U8 => combSPrime)
-    (\u : U8 =>
-      let smaller = emitBulkSCore (divU8 depth #u8(2)) in
-      if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
-        (\u : U8 => C_App sbi smaller)
-        (\u : U8 => C_App bbSPrimeSbi smaller)
-    )
+poly liftArity =
+  \expr : Comb =>
+    \from : U8 =>
+      \to : U8 =>
+        if [Comb] (ltU8 from to)
+          (\u : U8 => C_App (dropArity (subU8 to from)) expr)
+          (\u : U8 => expr)
 
-poly emitBulkS = \depth : U8 =>
-  if [Comb] (eqU8 depth #u8(1))
-    (\u : U8 => combS)
-    (\u : U8 => C_App (emitBulkSCore depth) combI)
+poly zip =
+  \l : Res =>
+    \r : Res =>
+      match l [Res] {
+        | MkRes n exprA =>
+          match r [Res] {
+            | MkRes m exprB =>
+              if [Res] (and (eqU8 n #u8(0)) (eqU8 m #u8(0)))
+                (\u : U8 => MkRes #u8(0) (C_App exprA exprB))
+                (
+                  \u : U8 =>
+                    if [Res] (eqU8 n #u8(0))
+                      (
+                        \u : U8 => MkRes m (C_App (C_App (emitBulk #u8(1) m) exprA) exprB)
+                      )
+                      (
+                        \u : U8 =>
+                          if [Res] (eqU8 m #u8(0))
+                            (
+                              \u : U8 => MkRes n (C_App (C_App (emitBulk #u8(2) n) exprA) exprB)
+                            )
+                            (
+                              \u : U8 =>
+                                if [Res] (eqU8 n m)
+                                  (
+                                    \u : U8 => MkRes n (C_App (C_App (emitBulk #u8(0) n) exprA) exprB)
+                                  )
+                                  (
+                                    \u : U8 =>
+                                      if [Res] (ltU8 n m)
+                                        (
+                                          \u : U8 =>
+                                            let liftedA = liftArity exprA n m in
+                                            MkRes
+                                              m
+                                              (
+                                                C_App
+                                                  (
+                                                    C_App
+                                                      (emitBulk #u8(0) m)
+                                                      liftedA
+                                                  )
+                                                  exprB
+                                              )
+                                        )
+                                        (
+                                          \u : U8 =>
+                                            let liftedB = liftArity exprB m n in
+                                            MkRes
+                                              n
+                                              (
+                                                C_App
+                                                  (
+                                                    C_App
+                                                      (emitBulk #u8(0) n)
+                                                      exprA
+                                                  )
+                                                  liftedB
+                                              )
+                                        )
+                                  )
+                            )
+                      )
+                )
+          }
+      }
 
-poly rec emitBulkCCore = \depth : U8 =>
-  if [Comb] (eqU8 depth #u8(1))
-    (\u : U8 => combCPrime)
-    (\u : U8 =>
-      let smaller = emitBulkCCore (divU8 depth #u8(2)) in
-      if [Comb] (eqU8 (modU8 depth #u8(2)) #u8(0))
-        (\u : U8 => C_App sbi smaller)
-        (\u : U8 => C_App bbCPrimeSbi smaller)
-    )
-
-poly emitBulkC = \depth : U8 =>
-  if [Comb] (eqU8 depth #u8(1))
-    (\u : U8 => combC)
-    (\u : U8 => C_App (emitBulkCCore depth) combI)
-
-poly emitBulk = \kind : U8 => \depth : U8 =>
-  if [Comb] (eqU8 kind #u8(0))
-    (\u : U8 => emitBulkS depth)
-    (\u : U8 =>
-      if [Comb] (eqU8 kind #u8(1))
-        (\u : U8 => emitBulkB depth)
-        (\u : U8 => emitBulkC depth)
-    )
-
-poly rec dropArity = \count : U8 =>
-  if [Comb] (eqU8 count #u8(0))
-    (\u : U8 => combI)
-    (\u : U8 =>
-      if [Comb] (eqU8 count #u8(1))
-        (\u : U8 => combK)
-        (\u : U8 =>
-          let half = dropArity (divU8 count #u8(2)) in
-          let doubled = C_App (C_App combB half) half in
-          if [Comb] (eqU8 (modU8 count #u8(2)) #u8(0))
-            (\u : U8 => doubled)
-            (\u : U8 => C_App combBK doubled)
-        )
-    )
-
-poly liftArity = \expr : Comb => \from : U8 => \to : U8 =>
-  if [Comb] (ltU8 from to)
-    (\u : U8 => C_App (dropArity (subU8 to from)) expr)
-    (\u : U8 => expr)
-
-poly zip = \l : Res => \r : Res =>
-  match l [Res] { | MkRes n exprA =>
-  match r [Res] { | MkRes m exprB =>
-    if [Res] (and (eqU8 n #u8(0)) (eqU8 m #u8(0)))
-      (\u : U8 => MkRes #u8(0) (C_App exprA exprB))
-      (\u : U8 =>
-    if [Res] (eqU8 n #u8(0))
-      (\u : U8 => MkRes m (C_App (C_App (emitBulk #u8(1) m) exprA) exprB))
-      (\u : U8 =>
-    if [Res] (eqU8 m #u8(0))
-      (\u : U8 => MkRes n (C_App (C_App (emitBulk #u8(2) n) exprA) exprB))
-      (\u : U8 =>
-    if [Res] (eqU8 n m)
-      (\u : U8 => MkRes n (C_App (C_App (emitBulk #u8(0) n) exprA) exprB))
-      (\u : U8 =>
-    if [Res] (ltU8 n m)
-      (\u : U8 =>
-        let liftedA = liftArity exprA n m in
-        MkRes m (C_App (C_App (emitBulk #u8(0) m) liftedA) exprB))
-      (\u : U8 =>
-        let liftedB = liftArity exprB m n in
-        MkRes n (C_App (C_App (emitBulk #u8(0) n) exprA) liftedB))
-    ))))
-  }}
-
-poly rec compile = \term : Lower =>
-  match term [Res] {
-    | L_Var i =>
+poly rec compile =
+  \term : Lower =>
+    match term [Res] {
+      | L_Var i =>
         let iPlus1 = addU8 i #u8(1) in
         MkRes iPlus1 (selectOuter iPlus1)
-    | L_App l r => zip (compile l) (compile r)
-    | L_Lam body =>
+      | L_App l r => zip (compile l) (compile r)
+      | L_Lam body =>
         let res = compile body in
-        match res [Res] { | MkRes n expr =>
-          if [Res] (eqU8 n #u8(0))
-            (\u : U8 => MkRes #u8(0) (C_App (C_Term T_K) expr))
-            (\u : U8 => MkRes (subU8 n #u8(1)) expr)
+        match res [Res] {
+          | MkRes n expr =>
+            if [Res] (eqU8 n #u8(0))
+              (\u : U8 => MkRes #u8(0) (C_App (C_Term T_K) expr))
+              (\u : U8 => MkRes (subU8 n #u8(1)) expr)
         }
-    | L_Native t => MkRes #u8(0) (C_Term t)
-  }
+      | L_Native t => MkRes #u8(0) (C_Term t)
+    }
 
 poly yComb =
   let sii = C_App (C_App (C_Term T_S) (C_Term T_I)) (C_Term T_I) in
@@ -295,7 +475,8 @@ poly yComb =
   let sks = C_App (C_App (C_Term T_S) (C_App (C_Term T_K) (C_Term T_S))) (C_Term T_K) in
   C_App (C_App (C_Term T_S) ksii) (C_App sks ksii)
 
-poly lowerToComb = \term : Lower =>
-  match (compile term) [Comb] {
-    | MkRes n expr => expr
-  }
+poly lowerToComb =
+  \term : Lower =>
+    match (compile term) [Comb] {
+      | MkRes n expr => expr
+    }

--- a/bootstrap/src/miniCore.trip
+++ b/bootstrap/src/miniCore.trip
@@ -1,104 +1,173 @@
 module MiniCore
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude U8
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude or
+
 import Prelude if
+
 import Prelude append
+
 import Core Core
+
 import Core Cr_Var
+
 import Core Cr_App
+
 import Core Cr_Lam
+
 import Core Cr_Native
+
 import Core Cr_Ctor
+
 import Core Cr_Match
+
 import CoreToMini MiniExpr
+
 import CoreToMini ME_Var
+
 import CoreToMini ME_Lam
+
 import CoreToMini ME_Call
+
 import CoreToMini ME_Con
+
 import CoreToMini ME_Let
+
 import CoreToMini ME_Native
+
 import CoreToMini ME_Match
+
 import CoreToMini coreToMini
 
 export MiniFunc
+
 export MkMiniFunc
+
 export MiniProgram
+
 export MkMiniProgram
+
 export buildMiniProgram
 
-data MiniFunc = MkMiniFunc (List U8) (List (List U8)) MiniExpr
+data MiniFunc =
+  | MkMiniFunc (List U8) (List (List U8)) MiniExpr
 
-data MiniProgram = MkMiniProgram (List MiniFunc) (List U8)
+data MiniProgram =
+  | MkMiniProgram (List MiniFunc) (List U8)
 
-poly rec peelLams = \expr : Core =>
-  match expr [Pair (List (List U8)) Core] {
-    | Cr_Var n => MkPair [List (List U8)] [Core] (nil [List U8]) expr
-    | Cr_App a b => MkPair [List (List U8)] [Core] (nil [List U8]) expr
-    | Cr_Lam name body =>
+poly rec peelLams =
+  \expr : Core =>
+    match expr [Pair (List (List U8)) Core] {
+      | Cr_Var n =>
+        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+      | Cr_App a b =>
+        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+      | Cr_Lam name body =>
         match (peelLams body) [Pair (List (List U8)) Core] {
           | MkPair ps inner =>
-              MkPair [List (List U8)] [Core] (cons [List U8] name ps) inner
+            MkPair [List (List U8)] [Core] (cons [List U8] name ps) inner
         }
-    | Cr_Native t => MkPair [List (List U8)] [Core] (nil [List U8]) expr
-    | Cr_Ctor t n a => MkPair [List (List U8)] [Core] (nil [List U8]) expr
-    | Cr_Match s arms => MkPair [List (List U8)] [Core] (nil [List U8]) expr
-  }
+      | Cr_Native t =>
+        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+      | Cr_Ctor t n a =>
+        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+      | Cr_Match s arms =>
+        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+    }
 
-poly rec listAnyLam = \f : MiniExpr -> Bool => \es : List MiniExpr =>
-  matchList [MiniExpr] [Bool] es
-    false
-    (\h : MiniExpr => \t : List MiniExpr => or (f h) (listAnyLam f t))
+poly rec listAnyLam =
+  \f : MiniExpr -> Bool =>
+    \es : List MiniExpr =>
+      matchList
+        [MiniExpr]
+        [Bool]
+        es
+        false
+        (\h : MiniExpr => \t : List MiniExpr => or (f h) (listAnyLam f t))
 
-poly rec exprHasLam = \e : MiniExpr =>
-  match e [Bool] {
-    | ME_Var n => false
-    | ME_Lam n b => true
-    | ME_Call fn args => listAnyLam exprHasLam args
-    | ME_Con tag total arity fields => listAnyLam exprHasLam fields
-    | ME_Let n v b => or (exprHasLam v) (exprHasLam b)
-    | ME_Native t => false
-    | ME_Match s arms => or (exprHasLam s) (listAnyLam exprHasLam arms)
-  }
+poly rec exprHasLam =
+  \e : MiniExpr =>
+    match e [Bool] {
+      | ME_Var n => false
+      | ME_Lam n b => true
+      | ME_Call fn args => listAnyLam exprHasLam args
+      | ME_Con tag total arity fields => listAnyLam exprHasLam fields
+      | ME_Let n v b => or (exprHasLam v) (exprHasLam b)
+      | ME_Native t => false
+      | ME_Match s arms => or (exprHasLam s) (listAnyLam exprHasLam arms)
+    }
 
-poly rec buildFuncs = \defs : List (Pair (List U8) Core) =>
-  matchList [Pair (List U8) Core] [Result (List U8) (List MiniFunc)] defs
-    (Ok [List U8] [List MiniFunc] (nil [MiniFunc]))
-    (\h : Pair (List U8) Core => \t : List (Pair (List U8) Core) =>
-      let name = fst [List U8] [Core] h in
-      let core = snd [List U8] [Core] h in
-      match (peelLams core) [Result (List U8) (List MiniFunc)] {
-        | MkPair params inner =>
-            let body = coreToMini inner in
-            if [Result (List U8) (List MiniFunc)] (exprHasLam body)
-              (\u : U8 =>
-                Err [List U8] [List MiniFunc]
-                  (append [U8] "escaping lambda in function " name))
-              (\u : U8 =>
-                match (buildFuncs t) [Result (List U8) (List MiniFunc)] {
-                  | Err e => Err [List U8] [List MiniFunc] e
-                  | Ok rest =>
-                      Ok [List U8] [List MiniFunc]
-                        (cons [MiniFunc] (MkMiniFunc name params body) rest)
-                })
-      })
+poly rec buildFuncs =
+  \defs : List (Pair (List U8) Core) =>
+    matchList
+      [Pair (List U8) Core]
+      [Result (List U8) (List MiniFunc)]
+      defs
+      (Ok [List U8] [List MiniFunc] (nil [MiniFunc]))
+      (
+        \h : Pair (List U8) Core =>
+          \t : List (Pair (List U8) Core) =>
+            let name = fst [List U8] [Core] h in
+            let core = snd [List U8] [Core] h in
+            match (peelLams core) [Result (List U8) (List MiniFunc)] {
+              | MkPair params inner =>
+                let body = coreToMini inner in
+                if [Result (List U8) (List MiniFunc)] (exprHasLam body)
+                  (
+                    \u : U8 =>
+                      Err
+                        [List U8]
+                        [List MiniFunc]
+                        (append [U8] "escaping lambda in function " name)
+                  )
+                  (
+                    \u : U8 =>
+                      match (buildFuncs t) [Result (List U8) (List MiniFunc)] {
+                        | Err e => Err [List U8] [List MiniFunc] e
+                        | Ok rest =>
+                          Ok
+                            [List U8]
+                            [List MiniFunc]
+                            (cons [MiniFunc] (MkMiniFunc name params body) rest)
+                      }
+                  )
+            }
+      )
 
-poly buildMiniProgram = \defs : List (Pair (List U8) Core) => \entry : List U8 =>
-  match (buildFuncs defs) [Result (List U8) MiniProgram] {
-    | Err e => Err [List U8] [MiniProgram] e
-    | Ok funcs => Ok [List U8] [MiniProgram] (MkMiniProgram funcs entry)
-  }
+poly buildMiniProgram =
+  \defs : List (Pair (List U8) Core) =>
+    \entry : List U8 =>
+      match (buildFuncs defs) [Result (List U8) MiniProgram] {
+        | Err e => Err [List U8] [MiniProgram] e
+        | Ok funcs =>
+          Ok [List U8] [MiniProgram] (MkMiniProgram funcs entry)
+      }

--- a/bootstrap/src/miniVerify.trip
+++ b/bootstrap/src/miniVerify.trip
@@ -1,149 +1,275 @@
 module MiniVerify
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude U8
+
 import Prelude append
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude ltU8
+
 import Prelude if
+
 import Core Core
+
 import Lexer tokenize
+
 import Parser parseProgram
+
 import Parser Decl
+
 import Bridge elaborateProgramToCore
+
 import MiniCore buildMiniProgram
+
 import MiniCore MiniProgram
+
 import Anf normalizeProgram
+
 import Anf AnfProgram
+
 import Anf MkAnfProgram
+
 import Anf AnfFunc
+
 import Anf MkAnfFunc
+
 import Anf AnfExpr
+
 import Anf AE_Var
+
 import Anf AE_Native
+
 import Anf AE_Lam
+
 import Anf AE_Call
+
 import Anf AE_Con
+
 import Anf AE_Case
+
 import Anf AE_Let
+
 import Unparse Terminal
+
 import Unparse terminalBytes
 
 export unparseAnfProgram
+
 export verifyToAnfText
 
-poly digitToAscii = \d : U8 =>
-  addU8 d #u8(48)
+poly digitToAscii =
+  \d : U8 => addU8 d #u8(48)
 
-poly singletonU8 = \b : U8 =>
-  cons [U8] b (nil [U8])
+poly singletonU8 =
+  \b : U8 => cons [U8] b (nil [U8])
 
-poly u8ToDigits = \n : U8 =>
-  if [List U8] (ltU8 n #u8(10))
-    (\u : U8 => singletonU8 (digitToAscii n))
-    (\u : U8 =>
-      if [List U8] (ltU8 n #u8(100))
-        (\u : U8 =>
-          cons [U8]
-            (digitToAscii (divU8 n #u8(10)))
-            (singletonU8 (digitToAscii (modU8 n #u8(10)))))
-        (\u : U8 =>
-          let hundreds = divU8 n #u8(100) in
-          let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-          let ones = modU8 n #u8(10) in
-          cons [U8]
-            (digitToAscii hundreds)
-            (cons [U8]
-              (digitToAscii tens)
-              (singletonU8 (digitToAscii ones))))
-    )
+poly u8ToDigits =
+  \n : U8 =>
+    if [List U8] (ltU8 n #u8(10))
+      (\u : U8 => singletonU8 (digitToAscii n))
+      (
+        \u : U8 =>
+          if [List U8] (ltU8 n #u8(100))
+            (
+              \u : U8 =>
+                cons
+                  [U8]
+                  (digitToAscii (divU8 n #u8(10)))
+                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
+            )
+            (
+              \u : U8 =>
+                let hundreds = divU8 n #u8(100) in
+                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
+                let ones = modU8 n #u8(10) in
+                cons
+                  [U8]
+                  (digitToAscii hundreds)
+                  (
+                    cons
+                      [U8]
+                      (digitToAscii tens)
+                      (singletonU8 (digitToAscii ones))
+                  )
+            )
+      )
 
-poly rec renderList = \f : AnfExpr -> List U8 => \es : List AnfExpr =>
-  matchList [AnfExpr] [List U8] es
-    (nil [U8])
-    (\h : AnfExpr => \t : List AnfExpr =>
-      append [U8] (cons [U8] ' ' (f h)) (renderList f t))
+poly rec renderList =
+  \f : AnfExpr -> List U8 =>
+    \es : List AnfExpr =>
+      matchList
+        [AnfExpr]
+        [List U8]
+        es
+        (nil [U8])
+        (
+          \h : AnfExpr =>
+            \t : List AnfExpr => append [U8] (cons [U8] ' ' (f h)) (renderList f t)
+        )
 
-poly rec renderParams = \ps : List (List U8) =>
-  matchList [List U8] [List U8] ps
-    (nil [U8])
-    (\h : List U8 => \t : List (List U8) =>
-      append [U8] (cons [U8] ' ' h) (renderParams t))
+poly rec renderParams =
+  \ps : List (List U8) =>
+    matchList
+      [List U8]
+      [List U8]
+      ps
+      (nil [U8])
+      (
+        \h : List U8 =>
+          \t : List (List U8) => append [U8] (cons [U8] ' ' h) (renderParams t)
+      )
 
-poly rec unparseAnfExpr = \e : AnfExpr =>
-  match e [List U8] {
-    | AE_Var n => n
-    | AE_Native t => terminalBytes t
-    | AE_Lam n b =>
-        append [U8] "(lam "
-          (append [U8] n
-            (append [U8] " " (append [U8] (unparseAnfExpr b) ")")))
-    | AE_Call f args =>
-        append [U8] "(call "
+poly rec unparseAnfExpr =
+  \e : AnfExpr =>
+    match e [List U8] {
+      | AE_Var n => n
+      | AE_Native t => terminalBytes t
+      | AE_Lam n b =>
+        append
+          [U8]
+          "(lam "
+          (append [U8] n (append [U8] " " (append [U8] (unparseAnfExpr b) ")")))
+      | AE_Call f args =>
+        append
+          [U8]
+          "(call "
           (append [U8] f (append [U8] (renderList unparseAnfExpr args) ")"))
-    | AE_Con tag total arity args =>
-        append [U8] "(con "
-          (append [U8] (u8ToDigits tag)
-            (append [U8] "/"
-              (append [U8] (u8ToDigits total)
-                (append [U8] "/"
-                  (append [U8] (u8ToDigits arity)
-                    (append [U8] (renderList unparseAnfExpr args) ")"))))))
-    | AE_Case scrut arms =>
-        append [U8] "(case "
-          (append [U8] (unparseAnfExpr scrut)
-            (append [U8] (renderList unparseAnfExpr arms) ")"))
-    | AE_Let n v b =>
-        append [U8] "(let "
-          (append [U8] n
-            (append [U8] " "
-              (append [U8] (unparseAnfExpr v)
-                (append [U8] " " (append [U8] (unparseAnfExpr b) ")")))))
-  }
+      | AE_Con tag total arity args =>
+        append
+          [U8]
+          "(con "
+          (
+            append
+              [U8]
+              (u8ToDigits tag)
+              (
+                append
+                  [U8]
+                  "/"
+                  (
+                    append
+                      [U8]
+                      (u8ToDigits total)
+                      (
+                        append
+                          [U8]
+                          "/"
+                          (
+                            append
+                              [U8]
+                              (u8ToDigits arity)
+                              (append [U8] (renderList unparseAnfExpr args) ")")
+                          )
+                      )
+                  )
+              )
+          )
+      | AE_Case scrut arms =>
+        append
+          [U8]
+          "(case "
+          (
+            append
+              [U8]
+              (unparseAnfExpr scrut)
+              (append [U8] (renderList unparseAnfExpr arms) ")")
+          )
+      | AE_Let n v b =>
+        append
+          [U8]
+          "(let "
+          (
+            append
+              [U8]
+              n
+              (
+                append
+                  [U8]
+                  " "
+                  (
+                    append
+                      [U8]
+                      (unparseAnfExpr v)
+                      (append [U8] " " (append [U8] (unparseAnfExpr b) ")"))
+                  )
+              )
+          )
+    }
 
-poly unparseAnfFunc = \fn : AnfFunc =>
-  match fn [List U8] {
-    | MkAnfFunc name params body =>
-        append [U8] name
-          (append [U8] (renderParams params)
-            (append [U8] " = "
-              (append [U8] (unparseAnfExpr body) (singletonU8 #u8(10)))))
-  }
+poly unparseAnfFunc =
+  \fn : AnfFunc =>
+    match fn [List U8] {
+      | MkAnfFunc name params body =>
+        append
+          [U8]
+          name
+          (
+            append
+              [U8]
+              (renderParams params)
+              (
+                append
+                  [U8]
+                  " = "
+                  (append [U8] (unparseAnfExpr body) (singletonU8 #u8(10)))
+              )
+          )
+    }
 
-poly rec unparseAnfFuncs = \fns : List AnfFunc =>
-  matchList [AnfFunc] [List U8] fns
-    (nil [U8])
-    (\h : AnfFunc => \t : List AnfFunc =>
-      append [U8] (unparseAnfFunc h) (unparseAnfFuncs t))
+poly rec unparseAnfFuncs =
+  \fns : List AnfFunc =>
+    matchList
+      [AnfFunc]
+      [List U8]
+      fns
+      (nil [U8])
+      (
+        \h : AnfFunc =>
+          \t : List AnfFunc => append [U8] (unparseAnfFunc h) (unparseAnfFuncs t)
+      )
 
-poly unparseAnfProgram = \prog : AnfProgram =>
-  match prog [List U8] {
-    | MkAnfProgram funcs entry => unparseAnfFuncs funcs
-  }
+poly unparseAnfProgram =
+  \prog : AnfProgram =>
+    match prog [List U8] {
+      | MkAnfProgram funcs entry => unparseAnfFuncs funcs
+    }
 
-poly verifyToAnfText = \source : List U8 =>
-  match (tokenize source) [List U8] {
-    | Err e => append [U8] "ERR:" "Lex error"
-    | Ok toks =>
+poly verifyToAnfText =
+  \source : List U8 =>
+    match (tokenize source) [List U8] {
+      | Err e => append [U8] "ERR:" "Lex error"
+      | Ok toks =>
         match (parseProgram toks) [List U8] {
           | Err e => append [U8] "ERR:" "Parse error"
           | Ok decls =>
-              match (elaborateProgramToCore decls) [List U8] {
-                | Err e => append [U8] "ERR:" e
-                | Ok coreDefs =>
-                    match (buildMiniProgram coreDefs "main") [List U8] {
-                      | Err e => append [U8] "ERR:" e
-                      | Ok prog => unparseAnfProgram (normalizeProgram prog)
-                    }
-              }
+            match (elaborateProgramToCore decls) [List U8] {
+              | Err e => append [U8] "ERR:" e
+              | Ok coreDefs =>
+                match (buildMiniProgram coreDefs "main") [List U8] {
+                  | Err e => append [U8] "ERR:" e
+                  | Ok prog => unparseAnfProgram (normalizeProgram prog)
+                }
+            }
         }
-  }
+    }

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -1,877 +1,2065 @@
 module ModuleEnv
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude append
+
 import Prelude reverse
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude or
+
 import Prelude not
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude addU8
+
 import Prelude eqListU8
+
 import Prelude lteListU8
+
 import Prelude digitToAscii
+
 import Prelude singletonU8
+
 import Prelude u8ToDigits
+
 import Prelude writeOne
+
 import Avl empty
+
 import Avl insert
+
 import BundleSummary parseBundleSummary
+
 import BundleSummary BundleSummary
+
 import BundleSummary MkBundleSummary
+
 import BundleSummary ModuleRecord
+
 import BundleSummary MkModuleRecord
+
 import Lexer tokenize
+
 import Lexer ParseError
+
 import Lexer MkParseError
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
+
 import Parser DefKind
+
 import Parser K_Poly
+
 import Parser K_Combinator
+
 import Parser parseProgram
+
 import DataEnv DataEnv
+
 import DataEnv MkDataEnv
+
 import DataEnv CtorInfo
+
 import DataEnv MkCtorInfo
+
 import DataEnv ADTInfo
+
 import DataEnv MkADTInfo
 
 export ModuleInfo
+
 export MkModuleInfo
+
 export ImportInfo
+
 export MkImportInfo
+
 export ExportInfo
+
 export MkExportInfo
+
 export DefinitionInfo
+
 export MkDefinitionInfo
+
 export DataTypeInfo
+
 export MkDataTypeInfo
+
 export ConstructorMeta
+
 export MkConstructorMeta
+
 export ConstructorAliasInfo
+
 export MkConstructorAliasInfo
+
 export OpaqueInfo
+
 export MkOpaqueInfo
+
 export NativeInfo
+
 export MkNativeInfo
+
 export PrimitiveInfo
+
 export MkPrimitiveInfo
+
 export ModuleEnv
+
 export MkModuleEnv
+
 export buildModuleEnv
+
 export lookupModule
+
 export lookupImport
+
 export lookupExport
+
 export lookupDefinition
+
 export lookupADT
+
 export lookupConstructor
+
 export lookupConstructorAlias
+
 export lookupPrimitive
+
 export lookupOpaque
+
 export lookupNative
+
 export dataEnvFromModuleEnv
+
 export emitModuleEnvSummary
+
 export emitBundleModuleEnvSummary
+
 export main
 
-data ModuleInfo = MkModuleInfo (List U8) (List Decl)
-data ImportInfo = MkImportInfo (List U8) (List U8) (List U8)
-data ExportInfo = MkExportInfo (List U8) (List U8)
-data DefinitionInfo = MkDefinitionInfo (List U8) (List U8) (List U8)
-data DataTypeInfo = MkDataTypeInfo (List U8) (List U8) U8
-data ConstructorMeta = MkConstructorMeta (List U8) (List U8) (List U8) (List U8) U8 U8 U8 U8 U8
-data ConstructorAliasInfo = MkConstructorAliasInfo (List U8) (Maybe (List U8))
-data OpaqueInfo = MkOpaqueInfo (List U8) (List U8)
-data NativeInfo = MkNativeInfo (List U8) (List U8)
-data PrimitiveInfo = MkPrimitiveInfo (List U8) U8 U8
+data ModuleInfo =
+  | MkModuleInfo (List U8) (List Decl)
 
-data ModuleEnv = MkModuleEnv
-  (List ModuleInfo)
-  (List ImportInfo)
-  (List ExportInfo)
-  (List DefinitionInfo)
-  (List DataTypeInfo)
-  (List ConstructorMeta)
-  (List ConstructorAliasInfo)
-  (List OpaqueInfo)
-  (List NativeInfo)
-  (List PrimitiveInfo)
+data ImportInfo =
+  | MkImportInfo (List U8) (List U8) (List U8)
 
-data BuildState = MkBuildState
-  (List ModuleInfo)
-  (List ImportInfo)
-  (List ExportInfo)
-  (List DefinitionInfo)
-  (List DataTypeInfo)
-  (List OpaqueInfo)
-  (List NativeInfo)
-  U8
+data ExportInfo =
+  | MkExportInfo (List U8) (List U8)
 
-poly newline : List U8 = "\n"
-poly space : List U8 = " "
-poly dot : List U8 = "."
-poly ambiguousText : List U8 = "AMBIGUOUS"
+data DefinitionInfo =
+  | MkDefinitionInfo (List U8) (List U8) (List U8)
 
-poly inc = \n : U8 =>
-  addU8 n #u8(1)
+data DataTypeInfo =
+  | MkDataTypeInfo (List U8) (List U8) U8
 
-poly qualify = \moduleName : List U8 => \name : List U8 =>
-  append [U8] moduleName (append [U8] dot name)
+data ConstructorMeta =
+  | MkConstructorMeta (List U8) (List U8) (List U8) (List U8) U8 U8 U8 U8 U8
 
-poly qualifyCtor = \moduleName : List U8 => \typeName : List U8 => \ctorName : List U8 =>
-  append [U8] moduleName (append [U8] dot (append [U8] typeName (append [U8] dot ctorName)))
+data ConstructorAliasInfo =
+  | MkConstructorAliasInfo (List U8) (Maybe (List U8))
 
-poly emitLine1 = \prefix : List U8 => \a : List U8 =>
-  append [U8] prefix (append [U8] a newline)
+data OpaqueInfo =
+  | MkOpaqueInfo (List U8) (List U8)
 
-poly emitLine2 = \prefix : List U8 => \a : List U8 => \b : List U8 =>
-  append [U8] prefix (append [U8] a (append [U8] space (append [U8] b newline)))
+data NativeInfo =
+  | MkNativeInfo (List U8) (List U8)
 
-poly emitLine3 = \prefix : List U8 => \a : List U8 => \b : List U8 => \c : List U8 =>
-  append [U8] prefix (append [U8] a (append [U8] space (append [U8] b (append [U8] space (append [U8] c newline)))))
+data PrimitiveInfo =
+  | MkPrimitiveInfo (List U8) U8 U8
 
-poly emitU8Line = \prefix : List U8 => \n : U8 =>
-  append [U8] prefix (append [U8] (u8ToDigits n) newline)
+data ModuleEnv =
+  | MkModuleEnv (List ModuleInfo) (List ImportInfo) (List ExportInfo) (List DefinitionInfo) (List DataTypeInfo) (List ConstructorMeta) (List ConstructorAliasInfo) (List OpaqueInfo) (List NativeInfo) (List PrimitiveInfo)
 
-poly rec countList = #A => \xs : List A => \acc : U8 =>
-  matchList [A] [U8] xs acc
-    (\h : A => \t : List A => countList [A] t (inc acc))
+data BuildState =
+  | MkBuildState (List ModuleInfo) (List ImportInfo) (List ExportInfo) (List DefinitionInfo) (List DataTypeInfo) (List OpaqueInfo) (List NativeInfo) U8
 
-poly count = #A => \xs : List A =>
-  countList [A] xs #u8(0)
+poly newline : List U8 =
+  "\n"
 
-poly defKindName = \kind : DefKind =>
-  match kind [List U8] {
-    | K_Poly => "poly"
-    | K_Combinator => "combinator"
-  }
+poly space : List U8 =
+  " "
 
-poly definitionKind = \decl : Decl =>
-  match decl [List U8] {
-    | D_Def kind isRec name body => defKindName kind
-    | D_Data name ctors => "data"
-    | D_Type name => "type"
-    | D_Opaque name => "opaque"
-    | D_Native name => "native"
-    | D_Module name => "module"
-    | D_Import fromName symbolName => "import"
-    | D_Export name => "export"
-  }
+poly dot : List U8 =
+  "."
 
-poly definitionName = \decl : Decl =>
-  match decl [List U8] {
-    | D_Def kind isRec name body => name
-    | D_Data name ctors => name
-    | D_Type name => name
-    | D_Opaque name => name
-    | D_Native name => name
-    | D_Module name => name
-    | D_Import fromName symbolName => symbolName
-    | D_Export name => name
-  }
+poly ambiguousText : List U8 =
+  "AMBIGUOUS"
 
-poly rec declaredModuleAcc = \decls : List Decl => \seen : Maybe (List U8) =>
-  matchList [Decl] [Result (List U8) (List U8)] decls
-    (match seen [Result (List U8) (List U8)] {
-      | None => Err [List U8] [List U8] "missing module declaration"
-      | Some name => Ok [List U8] [List U8] name
-    })
-    (\h : Decl => \t : List Decl =>
-      match h [Result (List U8) (List U8)] {
-        | D_Module name =>
-            match seen [Result (List U8) (List U8)] {
-              | None => declaredModuleAcc t (Some [List U8] name)
-              | Some prev => Err [List U8] [List U8] "multiple module declarations"
-            }
-        | D_Import fromName symbolName => declaredModuleAcc t seen
-        | D_Export name => declaredModuleAcc t seen
-        | D_Opaque name => declaredModuleAcc t seen
-        | D_Native name => declaredModuleAcc t seen
-        | D_Type name => declaredModuleAcc t seen
-        | D_Data name ctors => declaredModuleAcc t seen
-        | D_Def kind isRec name body => declaredModuleAcc t seen
-      })
+poly inc =
+  \n : U8 => addU8 n #u8(1)
 
-poly declaredModule = \decls : List Decl =>
-  declaredModuleAcc decls (None [List U8])
+poly qualify =
+  \moduleName : List U8 =>
+    \name : List U8 => append [U8] moduleName (append [U8] dot name)
 
-poly parseModuleSource = \bundleName : List U8 => \source : List U8 =>
-  match (tokenize source) [Result (List U8) ModuleInfo] {
-    | Err e => Err [List U8] [ModuleInfo] "Lex error"
-    | Ok toks =>
-        match (parseProgram toks) [Result (List U8) ModuleInfo] {
-          | Err e =>
-              match e [Result (List U8) ModuleInfo] { | MkParseError msg =>
-                Err [List U8] [ModuleInfo] msg
+poly qualifyCtor =
+  \moduleName : List U8 =>
+    \typeName : List U8 =>
+      \ctorName : List U8 =>
+        append
+          [U8]
+          moduleName
+          (append [U8] dot (append [U8] typeName (append [U8] dot ctorName)))
+
+poly emitLine1 =
+  \prefix : List U8 => \a : List U8 => append [U8] prefix (append [U8] a newline)
+
+poly emitLine2 =
+  \prefix : List U8 =>
+    \a : List U8 =>
+      \b : List U8 =>
+        append
+          [U8]
+          prefix
+          (append [U8] a (append [U8] space (append [U8] b newline)))
+
+poly emitLine3 =
+  \prefix : List U8 =>
+    \a : List U8 =>
+      \b : List U8 =>
+        \c : List U8 =>
+          append
+            [U8]
+            prefix
+            (
+              append
+                [U8]
+                a
+                (
+                  append
+                    [U8]
+                    space
+                    (append [U8] b (append [U8] space (append [U8] c newline)))
+                )
+            )
+
+poly emitU8Line =
+  \prefix : List U8 =>
+    \n : U8 => append [U8] prefix (append [U8] (u8ToDigits n) newline)
+
+poly rec countList =
+  #A =>
+    \xs : List A =>
+      \acc : U8 =>
+        matchList
+          [A]
+          [U8]
+          xs
+          acc
+          (\h : A => \t : List A => countList [A] t (inc acc))
+
+poly count =
+  #A => \xs : List A => countList [A] xs #u8(0)
+
+poly defKindName =
+  \kind : DefKind =>
+    match kind [List U8] {
+      | K_Poly => "poly"
+      | K_Combinator => "combinator"
+    }
+
+poly definitionKind =
+  \decl : Decl =>
+    match decl [List U8] {
+      | D_Def kind isRec name body => defKindName kind
+      | D_Data name ctors => "data"
+      | D_Type name => "type"
+      | D_Opaque name => "opaque"
+      | D_Native name => "native"
+      | D_Module name => "module"
+      | D_Import fromName symbolName => "import"
+      | D_Export name => "export"
+    }
+
+poly definitionName =
+  \decl : Decl =>
+    match decl [List U8] {
+      | D_Def kind isRec name body => name
+      | D_Data name ctors => name
+      | D_Type name => name
+      | D_Opaque name => name
+      | D_Native name => name
+      | D_Module name => name
+      | D_Import fromName symbolName => symbolName
+      | D_Export name => name
+    }
+
+poly rec declaredModuleAcc =
+  \decls : List Decl =>
+    \seen : Maybe (List U8) =>
+      matchList
+        [Decl]
+        [Result (List U8) (List U8)]
+        decls
+        (
+          match seen [Result (List U8) (List U8)] {
+            | None =>
+              Err [List U8] [List U8] "missing module declaration"
+            | Some name => Ok [List U8] [List U8] name
+          }
+        )
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Result (List U8) (List U8)] {
+                | D_Module name =>
+                  match seen [Result (List U8) (List U8)] {
+                    | None => declaredModuleAcc t (Some [List U8] name)
+                    | Some prev =>
+                      Err [List U8] [List U8] "multiple module declarations"
+                  }
+                | D_Import fromName symbolName => declaredModuleAcc t seen
+                | D_Export name => declaredModuleAcc t seen
+                | D_Opaque name => declaredModuleAcc t seen
+                | D_Native name => declaredModuleAcc t seen
+                | D_Type name => declaredModuleAcc t seen
+                | D_Data name ctors => declaredModuleAcc t seen
+                | D_Def kind isRec name body => declaredModuleAcc t seen
               }
-          | Ok decls =>
+        )
+
+poly declaredModule =
+  \decls : List Decl => declaredModuleAcc decls (None [List U8])
+
+poly parseModuleSource =
+  \bundleName : List U8 =>
+    \source : List U8 =>
+      match (tokenize source) [Result (List U8) ModuleInfo] {
+        | Err e => Err [List U8] [ModuleInfo] "Lex error"
+        | Ok toks =>
+          match (parseProgram toks) [Result (List U8) ModuleInfo] {
+            | Err e =>
+              match e [Result (List U8) ModuleInfo] {
+                | MkParseError msg => Err [List U8] [ModuleInfo] msg
+              }
+            | Ok decls =>
               match (declaredModule decls) [Result (List U8) ModuleInfo] {
                 | Err e => Err [List U8] [ModuleInfo] e
                 | Ok declared =>
-                    if [Result (List U8) ModuleInfo] (eqListU8 declared bundleName)
-                      (\u : U8 => Ok [List U8] [ModuleInfo] (MkModuleInfo bundleName decls))
-                      (\u : U8 => Err [List U8] [ModuleInfo] "source module mismatch")
+                  if [Result (List U8) ModuleInfo] (eqListU8 declared bundleName)
+                    (
+                      \u : U8 => Ok [List U8] [ModuleInfo] (MkModuleInfo bundleName decls)
+                    )
+                    (
+                      \u : U8 => Err [List U8] [ModuleInfo] "source module mismatch"
+                    )
               }
-        }
-  }
+          }
+      }
 
-poly rec collectDecls = \moduleName : List U8 => \decls : List Decl => \state : BuildState =>
-  matchList [Decl] [BuildState] decls
-    state
-    (\h : Decl => \t : List Decl =>
-      match state [BuildState] { | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
-        match h [BuildState] {
-          | D_Import fromName symbolName =>
-              collectDecls moduleName t
-                (MkBuildState mods (append [ImportInfo] imps (cons [ImportInfo] (MkImportInfo moduleName fromName symbolName) (nil [ImportInfo]))) exps defs dataTypes opaques natives nextTypeId)
-          | D_Export name =>
-              collectDecls moduleName t
-                (MkBuildState mods imps (append [ExportInfo] exps (cons [ExportInfo] (MkExportInfo moduleName name) (nil [ExportInfo]))) defs dataTypes opaques natives nextTypeId)
-          | D_Data name ctors =>
-              let qName = qualify moduleName name in
-              collectDecls moduleName t
-                (MkBuildState mods imps exps
-                  (append [DefinitionInfo] defs (cons [DefinitionInfo] (MkDefinitionInfo moduleName name "data") (nil [DefinitionInfo])))
-                  (append [DataTypeInfo] dataTypes (cons [DataTypeInfo] (MkDataTypeInfo qName name nextTypeId) (nil [DataTypeInfo])))
-                  opaques natives (inc nextTypeId))
-          | D_Type name =>
-              collectDecls moduleName t
-                (MkBuildState mods imps exps (append [DefinitionInfo] defs (cons [DefinitionInfo] (MkDefinitionInfo moduleName name "type") (nil [DefinitionInfo]))) dataTypes opaques natives nextTypeId)
-          | D_Opaque name =>
-              collectDecls moduleName t
-                (MkBuildState mods imps exps
-                  (append [DefinitionInfo] defs (cons [DefinitionInfo] (MkDefinitionInfo moduleName name "opaque") (nil [DefinitionInfo])))
-                  dataTypes (append [OpaqueInfo] opaques (cons [OpaqueInfo] (MkOpaqueInfo moduleName name) (nil [OpaqueInfo]))) natives nextTypeId)
-          | D_Native name =>
-              collectDecls moduleName t
-                (MkBuildState mods imps exps
-                  (append [DefinitionInfo] defs (cons [DefinitionInfo] (MkDefinitionInfo moduleName name "native") (nil [DefinitionInfo])))
-                  dataTypes opaques (append [NativeInfo] natives (cons [NativeInfo] (MkNativeInfo moduleName name) (nil [NativeInfo]))) nextTypeId)
-          | D_Def kind isRec name body =>
-              collectDecls moduleName t
-                (MkBuildState mods imps exps
-                  (append [DefinitionInfo] defs (cons [DefinitionInfo] (MkDefinitionInfo moduleName name (defKindName kind)) (nil [DefinitionInfo])))
-                  dataTypes opaques natives nextTypeId)
-          | D_Module name => collectDecls moduleName t state
-        }
-      })
-
-poly rec parseModulesAcc = \records : List ModuleRecord => \state : BuildState =>
-  matchList [ModuleRecord] [Result (List U8) BuildState] records
-    (Ok [List U8] [BuildState] state)
-    (\h : ModuleRecord => \t : List ModuleRecord =>
-      match h [Result (List U8) BuildState] { | MkModuleRecord name lengthDigits source =>
-        match (parseModuleSource name source) [Result (List U8) BuildState] {
-          | Err e => Err [List U8] [BuildState] e
-          | Ok modInfo =>
-              match modInfo [Result (List U8) BuildState] { | MkModuleInfo modName decls =>
-                match state [Result (List U8) BuildState] { | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
-                  let withMod = MkBuildState
-                    (append [ModuleInfo] mods (cons [ModuleInfo] modInfo (nil [ModuleInfo])))
-                    imps exps defs dataTypes opaques natives nextTypeId in
-                  parseModulesAcc t (collectDecls modName decls withMod)
+poly rec collectDecls =
+  \moduleName : List U8 =>
+    \decls : List Decl =>
+      \state : BuildState =>
+        matchList
+          [Decl]
+          [BuildState]
+          decls
+          state
+          (
+            \h : Decl =>
+              \t : List Decl =>
+                match state [BuildState] {
+                  | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
+                    match h [BuildState] {
+                      | D_Import fromName symbolName =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              (
+                                append
+                                  [ImportInfo]
+                                  imps
+                                  (
+                                    cons
+                                      [ImportInfo]
+                                      (
+                                        MkImportInfo
+                                          moduleName
+                                          fromName
+                                          symbolName
+                                      )
+                                      (nil [ImportInfo])
+                                  )
+                              )
+                              exps
+                              defs
+                              dataTypes
+                              opaques
+                              natives
+                              nextTypeId
+                          )
+                      | D_Export name =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              (
+                                append
+                                  [ExportInfo]
+                                  exps
+                                  (
+                                    cons
+                                      [ExportInfo]
+                                      (MkExportInfo moduleName name)
+                                      (nil [ExportInfo])
+                                  )
+                              )
+                              defs
+                              dataTypes
+                              opaques
+                              natives
+                              nextTypeId
+                          )
+                      | D_Data name ctors =>
+                        let qName = qualify moduleName name in
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              exps
+                              (
+                                append
+                                  [DefinitionInfo]
+                                  defs
+                                  (
+                                    cons
+                                      [DefinitionInfo]
+                                      (MkDefinitionInfo moduleName name "data")
+                                      (nil [DefinitionInfo])
+                                  )
+                              )
+                              (
+                                append
+                                  [DataTypeInfo]
+                                  dataTypes
+                                  (
+                                    cons
+                                      [DataTypeInfo]
+                                      (MkDataTypeInfo qName name nextTypeId)
+                                      (nil [DataTypeInfo])
+                                  )
+                              )
+                              opaques
+                              natives
+                              (inc nextTypeId)
+                          )
+                      | D_Type name =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              exps
+                              (
+                                append
+                                  [DefinitionInfo]
+                                  defs
+                                  (
+                                    cons
+                                      [DefinitionInfo]
+                                      (MkDefinitionInfo moduleName name "type")
+                                      (nil [DefinitionInfo])
+                                  )
+                              )
+                              dataTypes
+                              opaques
+                              natives
+                              nextTypeId
+                          )
+                      | D_Opaque name =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              exps
+                              (
+                                append
+                                  [DefinitionInfo]
+                                  defs
+                                  (
+                                    cons
+                                      [DefinitionInfo]
+                                      (
+                                        MkDefinitionInfo
+                                          moduleName
+                                          name
+                                          "opaque"
+                                      )
+                                      (nil [DefinitionInfo])
+                                  )
+                              )
+                              dataTypes
+                              (
+                                append
+                                  [OpaqueInfo]
+                                  opaques
+                                  (
+                                    cons
+                                      [OpaqueInfo]
+                                      (MkOpaqueInfo moduleName name)
+                                      (nil [OpaqueInfo])
+                                  )
+                              )
+                              natives
+                              nextTypeId
+                          )
+                      | D_Native name =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              exps
+                              (
+                                append
+                                  [DefinitionInfo]
+                                  defs
+                                  (
+                                    cons
+                                      [DefinitionInfo]
+                                      (
+                                        MkDefinitionInfo
+                                          moduleName
+                                          name
+                                          "native"
+                                      )
+                                      (nil [DefinitionInfo])
+                                  )
+                              )
+                              dataTypes
+                              opaques
+                              (
+                                append
+                                  [NativeInfo]
+                                  natives
+                                  (
+                                    cons
+                                      [NativeInfo]
+                                      (MkNativeInfo moduleName name)
+                                      (nil [NativeInfo])
+                                  )
+                              )
+                              nextTypeId
+                          )
+                      | D_Def kind isRec name body =>
+                        collectDecls
+                          moduleName
+                          t
+                          (
+                            MkBuildState
+                              mods
+                              imps
+                              exps
+                              (
+                                append
+                                  [DefinitionInfo]
+                                  defs
+                                  (
+                                    cons
+                                      [DefinitionInfo]
+                                      (
+                                        MkDefinitionInfo
+                                          moduleName
+                                          name
+                                          (defKindName kind)
+                                      )
+                                      (nil [DefinitionInfo])
+                                  )
+                              )
+                              dataTypes
+                              opaques
+                              natives
+                              nextTypeId
+                          )
+                      | D_Module name => collectDecls moduleName t state
+                    }
                 }
+          )
+
+poly rec parseModulesAcc =
+  \records : List ModuleRecord =>
+    \state : BuildState =>
+      matchList
+        [ModuleRecord]
+        [Result (List U8) BuildState]
+        records
+        (Ok [List U8] [BuildState] state)
+        (
+          \h : ModuleRecord =>
+            \t : List ModuleRecord =>
+              match h [Result (List U8) BuildState] {
+                | MkModuleRecord name lengthDigits source =>
+                  match (parseModuleSource name source) [Result (List U8) BuildState] {
+                    | Err e => Err [List U8] [BuildState] e
+                    | Ok modInfo =>
+                      match modInfo [Result (List U8) BuildState] {
+                        | MkModuleInfo modName decls =>
+                          match state [Result (List U8) BuildState] {
+                            | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
+                              let withMod = MkBuildState (append [ModuleInfo] mods (cons [ModuleInfo] modInfo (nil [ModuleInfo]))) imps exps defs dataTypes opaques natives nextTypeId in
+                              parseModulesAcc
+                                t
+                                (collectDecls modName decls withMod)
+                          }
+                      }
+                  }
               }
-        }
-      })
+        )
 
 poly initialBuildState =
-  MkBuildState (nil [ModuleInfo]) (nil [ImportInfo]) (nil [ExportInfo]) (nil [DefinitionInfo])
-    (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0))
-      (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.List" "List" #u8(1)) (nil [DataTypeInfo])))
-    (nil [OpaqueInfo]) (nil [NativeInfo]) #u8(2)
+  MkBuildState (nil [ModuleInfo]) (nil [ImportInfo]) (nil [ExportInfo]) (nil [DefinitionInfo]) (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0)) (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.List" "List" #u8(1)) (nil [DataTypeInfo]))) (nil [OpaqueInfo]) (nil [NativeInfo]) #u8(2)
 
-poly rec findDataTypeId = \qName : List U8 => \dataTypes : List DataTypeInfo =>
-  matchList [DataTypeInfo] [Maybe U8] dataTypes
-    (None [U8])
-    (\h : DataTypeInfo => \t : List DataTypeInfo =>
-      match h [Maybe U8] { | MkDataTypeInfo hQName hLocal hId =>
-        if [Maybe U8] (eqListU8 hQName qName)
-          (\u : U8 => Some [U8] hId)
-          (\u : U8 => findDataTypeId qName t)
-      })
+poly rec findDataTypeId =
+  \qName : List U8 =>
+    \dataTypes : List DataTypeInfo =>
+      matchList
+        [DataTypeInfo]
+        [Maybe U8]
+        dataTypes
+        (None [U8])
+        (
+          \h : DataTypeInfo =>
+            \t : List DataTypeInfo =>
+              match h [Maybe U8] {
+                | MkDataTypeInfo hQName hLocal hId =>
+                  if [Maybe U8] (eqListU8 hQName qName)
+                    (\u : U8 => Some [U8] hId)
+                    (\u : U8 => findDataTypeId qName t)
+              }
+        )
 
-poly rec countCtors = \ctors : List (Pair (List U8) U8) => \acc : U8 =>
-  matchList [Pair (List U8) U8] [U8] ctors acc
-    (\h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) => countCtors t (inc acc))
+poly rec countCtors =
+  \ctors : List (Pair (List U8) U8) =>
+    \acc : U8 =>
+      matchList
+        [Pair (List U8) U8]
+        [U8]
+        ctors
+        acc
+        (
+          \h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) => countCtors t (inc acc)
+        )
 
-poly rec addCtorMetas = \moduleName : List U8 => \typeName : List U8 => \dataId : U8 => \ctors : List (Pair (List U8) U8) => \total : U8 => \tag : U8 => \symbolId : U8 => \acc : List ConstructorMeta =>
-  matchList [Pair (List U8) U8] [Pair (List ConstructorMeta) U8] ctors
-    (MkPair [List ConstructorMeta] [U8] acc symbolId)
-    (\h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) =>
-      let ctorName = fst [List U8] [U8] h in
-      let arity = snd [List U8] [U8] h in
-      let qName = qualifyCtor moduleName typeName ctorName in
-      let alias = qualify moduleName ctorName in
-      let meta = MkConstructorMeta qName ctorName alias typeName dataId symbolId tag total arity in
-      addCtorMetas moduleName typeName dataId t total (inc tag) (inc symbolId)
-        (append [ConstructorMeta] acc (cons [ConstructorMeta] meta (nil [ConstructorMeta])))
-    )
+poly rec addCtorMetas =
+  \moduleName : List U8 =>
+    \typeName : List U8 =>
+      \dataId : U8 =>
+        \ctors : List (Pair (List U8) U8) =>
+          \total : U8 =>
+            \tag : U8 =>
+              \symbolId : U8 =>
+                \acc : List ConstructorMeta =>
+                  matchList
+                    [Pair (List U8) U8]
+                    [Pair (List ConstructorMeta) U8]
+                    ctors
+                    (MkPair [List ConstructorMeta] [U8] acc symbolId)
+                    (
+                      \h : Pair (List U8) U8 =>
+                        \t : List (Pair (List U8) U8) =>
+                          let ctorName = fst [List U8] [U8] h in
+                          let arity = snd [List U8] [U8] h in
+                          let qName = qualifyCtor moduleName typeName ctorName in
+                          let alias = qualify moduleName ctorName in
+                          let meta = MkConstructorMeta qName ctorName alias typeName dataId symbolId tag total arity in
+                          addCtorMetas
+                            moduleName
+                            typeName
+                            dataId
+                            t
+                            total
+                            (inc tag)
+                            (inc symbolId)
+                            (
+                              append
+                                [ConstructorMeta]
+                                acc
+                                (
+                                  cons
+                                    [ConstructorMeta]
+                                    meta
+                                    (nil [ConstructorMeta])
+                                )
+                            )
+                    )
 
-poly rec collectConstructorsFromDecls = \moduleName : List U8 => \decls : List Decl => \dataTypes : List DataTypeInfo => \symbolId : U8 => \acc : List ConstructorMeta =>
-  matchList [Decl] [Pair (List ConstructorMeta) U8] decls
-    (MkPair [List ConstructorMeta] [U8] acc symbolId)
-    (\h : Decl => \t : List Decl =>
-      match h [Pair (List ConstructorMeta) U8] {
-        | D_Data typeName ctors =>
-            let dataQName = qualify moduleName typeName in
-            match (findDataTypeId dataQName dataTypes) [Pair (List ConstructorMeta) U8] {
-              | None => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-              | Some dataId =>
-                  let total = countCtors ctors #u8(0) in
-                  match (addCtorMetas moduleName typeName dataId ctors total #u8(0) symbolId acc) [Pair (List ConstructorMeta) U8] { | MkPair nextAcc nextSymbolId =>
-                    collectConstructorsFromDecls moduleName t dataTypes nextSymbolId nextAcc
+poly rec collectConstructorsFromDecls =
+  \moduleName : List U8 =>
+    \decls : List Decl =>
+      \dataTypes : List DataTypeInfo =>
+        \symbolId : U8 =>
+          \acc : List ConstructorMeta =>
+            matchList
+              [Decl]
+              [Pair (List ConstructorMeta) U8]
+              decls
+              (MkPair [List ConstructorMeta] [U8] acc symbolId)
+              (
+                \h : Decl =>
+                  \t : List Decl =>
+                    match h [Pair (List ConstructorMeta) U8] {
+                      | D_Data typeName ctors =>
+                        let dataQName = qualify moduleName typeName in
+                        match (findDataTypeId dataQName dataTypes) [Pair (List ConstructorMeta) U8] {
+                          | None =>
+                            collectConstructorsFromDecls
+                              moduleName
+                              t
+                              dataTypes
+                              symbolId
+                              acc
+                          | Some dataId =>
+                            let total = countCtors ctors #u8(0) in
+                            match (addCtorMetas moduleName typeName dataId ctors total #u8(0) symbolId acc) [Pair (List ConstructorMeta) U8] {
+                              | MkPair nextAcc nextSymbolId =>
+                                collectConstructorsFromDecls
+                                  moduleName
+                                  t
+                                  dataTypes
+                                  nextSymbolId
+                                  nextAcc
+                            }
+                        }
+                      | D_Module name =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Import fromName symbolName =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Export name =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Opaque name =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Native name =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Type name =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                      | D_Def kind isRec name body =>
+                        collectConstructorsFromDecls
+                          moduleName
+                          t
+                          dataTypes
+                          symbolId
+                          acc
+                    }
+              )
+
+poly rec collectConstructors =
+  \mods : List ModuleInfo =>
+    \dataTypes : List DataTypeInfo =>
+      \symbolId : U8 =>
+        \acc : List ConstructorMeta =>
+          matchList
+            [ModuleInfo]
+            [Pair (List ConstructorMeta) U8]
+            mods
+            (MkPair [List ConstructorMeta] [U8] acc symbolId)
+            (
+              \h : ModuleInfo =>
+                \t : List ModuleInfo =>
+                  match h [Pair (List ConstructorMeta) U8] {
+                    | MkModuleInfo moduleName decls =>
+                      match (collectConstructorsFromDecls moduleName decls dataTypes symbolId acc) [Pair (List ConstructorMeta) U8] {
+                        | MkPair nextAcc nextSymbolId =>
+                          collectConstructors t dataTypes nextSymbolId nextAcc
+                      }
                   }
-            }
-        | D_Module name => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Import fromName symbolName => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Export name => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Opaque name => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Native name => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Type name => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-        | D_Def kind isRec name body => collectConstructorsFromDecls moduleName t dataTypes symbolId acc
-      })
-
-poly rec collectConstructors = \mods : List ModuleInfo => \dataTypes : List DataTypeInfo => \symbolId : U8 => \acc : List ConstructorMeta =>
-  matchList [ModuleInfo] [Pair (List ConstructorMeta) U8] mods
-    (MkPair [List ConstructorMeta] [U8] acc symbolId)
-    (\h : ModuleInfo => \t : List ModuleInfo =>
-      match h [Pair (List ConstructorMeta) U8] { | MkModuleInfo moduleName decls =>
-        match (collectConstructorsFromDecls moduleName decls dataTypes symbolId acc) [Pair (List ConstructorMeta) U8] { | MkPair nextAcc nextSymbolId =>
-          collectConstructors t dataTypes nextSymbolId nextAcc
-        }
-      })
+            )
 
 poly pseudoConstructors =
-  cons [ConstructorMeta] (MkConstructorMeta "Prelude.false" "false" "Prelude.false" "Bool" #u8(0) #u8(0) #u8(0) #u8(2) #u8(0))
-    (cons [ConstructorMeta] (MkConstructorMeta "Prelude.true" "true" "Prelude.true" "Bool" #u8(0) #u8(1) #u8(1) #u8(2) #u8(0))
-      (cons [ConstructorMeta] (MkConstructorMeta "Prelude.nil" "nil" "Prelude.nil" "List" #u8(1) #u8(2) #u8(0) #u8(2) #u8(0))
-        (cons [ConstructorMeta] (MkConstructorMeta "Prelude.cons" "cons" "Prelude.cons" "List" #u8(1) #u8(3) #u8(1) #u8(2) #u8(2))
-          (nil [ConstructorMeta]))))
+  cons
+    [ConstructorMeta]
+    (
+      MkConstructorMeta "Prelude.false" "false" "Prelude.false" "Bool" #u8(0) #u8(0) #u8(0) #u8(2) #u8(0)
+    )
+    (
+      cons
+        [ConstructorMeta]
+        (
+          MkConstructorMeta "Prelude.true" "true" "Prelude.true" "Bool" #u8(0) #u8(1) #u8(1) #u8(2) #u8(0)
+        )
+        (
+          cons
+            [ConstructorMeta]
+            (
+              MkConstructorMeta "Prelude.nil" "nil" "Prelude.nil" "List" #u8(1) #u8(2) #u8(0) #u8(2) #u8(0)
+            )
+            (
+              cons
+                [ConstructorMeta]
+                (
+                  MkConstructorMeta "Prelude.cons" "cons" "Prelude.cons" "List" #u8(1) #u8(3) #u8(1) #u8(2) #u8(2)
+                )
+                (nil [ConstructorMeta])
+            )
+        )
+    )
 
-poly rec addAlias = \alias : List U8 => \qName : List U8 => \aliases : List ConstructorAliasInfo =>
-  matchList [ConstructorAliasInfo] [List ConstructorAliasInfo] aliases
-    (cons [ConstructorAliasInfo] (MkConstructorAliasInfo alias (Some [List U8] qName)) (nil [ConstructorAliasInfo]))
-    (\h : ConstructorAliasInfo => \t : List ConstructorAliasInfo =>
-      match h [List ConstructorAliasInfo] { | MkConstructorAliasInfo hAlias hTarget =>
-        if [List ConstructorAliasInfo] (eqListU8 hAlias alias)
-          (\u : U8 =>
-            match hTarget [List ConstructorAliasInfo] {
-              | None => aliases
-              | Some existing =>
-                  if [List ConstructorAliasInfo] (eqListU8 existing qName)
-                    (\u : U8 => aliases)
-                    (\u : U8 => cons [ConstructorAliasInfo] (MkConstructorAliasInfo alias (None [List U8])) t)
-            })
-          (\u : U8 => cons [ConstructorAliasInfo] h (addAlias alias qName t))
-      })
+poly rec addAlias =
+  \alias : List U8 =>
+    \qName : List U8 =>
+      \aliases : List ConstructorAliasInfo =>
+        matchList
+          [ConstructorAliasInfo]
+          [List ConstructorAliasInfo]
+          aliases
+          (
+            cons
+              [ConstructorAliasInfo]
+              (MkConstructorAliasInfo alias (Some [List U8] qName))
+              (nil [ConstructorAliasInfo])
+          )
+          (
+            \h : ConstructorAliasInfo =>
+              \t : List ConstructorAliasInfo =>
+                match h [List ConstructorAliasInfo] {
+                  | MkConstructorAliasInfo hAlias hTarget =>
+                    if [List ConstructorAliasInfo] (eqListU8 hAlias alias)
+                      (
+                        \u : U8 =>
+                          match hTarget [List ConstructorAliasInfo] {
+                            | None => aliases
+                            | Some existing =>
+                              if [List ConstructorAliasInfo] (eqListU8 existing qName)
+                                (\u : U8 => aliases)
+                                (
+                                  \u : U8 =>
+                                    cons
+                                      [ConstructorAliasInfo]
+                                      (
+                                        MkConstructorAliasInfo
+                                          alias
+                                          (None [List U8])
+                                      )
+                                      t
+                                )
+                          }
+                      )
+                      (
+                        \u : U8 => cons [ConstructorAliasInfo] h (addAlias alias qName t)
+                      )
+                }
+          )
 
-poly rec buildAliases = \ctors : List ConstructorMeta => \aliases : List ConstructorAliasInfo =>
-  matchList [ConstructorMeta] [List ConstructorAliasInfo] ctors
-    aliases
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      match h [List ConstructorAliasInfo] { | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
-        buildAliases t (addAlias alias qName aliases)
-      })
+poly rec buildAliases =
+  \ctors : List ConstructorMeta =>
+    \aliases : List ConstructorAliasInfo =>
+      matchList
+        [ConstructorMeta]
+        [List ConstructorAliasInfo]
+        ctors
+        aliases
+        (
+          \h : ConstructorMeta =>
+            \t : List ConstructorMeta =>
+              match h [List ConstructorAliasInfo] {
+                | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity => buildAliases t (addAlias alias qName aliases)
+              }
+        )
 
-poly primitivesStartingAt = \firstSymbolId : U8 =>
-  cons [PrimitiveInfo] (MkPrimitiveInfo "Nat.succ" firstSymbolId #u8(1))
-    (cons [PrimitiveInfo] (MkPrimitiveInfo "Nat.add" (addU8 firstSymbolId #u8(1)) #u8(2))
-      (cons [PrimitiveInfo] (MkPrimitiveInfo "Nat.mul" (addU8 firstSymbolId #u8(2)) #u8(2))
-        (cons [PrimitiveInfo] (MkPrimitiveInfo "Nat.lte" (addU8 firstSymbolId #u8(3)) #u8(2))
-          (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.not" (addU8 firstSymbolId #u8(4)) #u8(1))
-            (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.eqU8" (addU8 firstSymbolId #u8(5)) #u8(2))
-              (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.ltU8" (addU8 firstSymbolId #u8(6)) #u8(2))
-                (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.addU8" (addU8 firstSymbolId #u8(7)) #u8(2))
-                  (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.subU8" (addU8 firstSymbolId #u8(8)) #u8(2))
-                    (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.divU8" (addU8 firstSymbolId #u8(9)) #u8(2))
-                      (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.modU8" (addU8 firstSymbolId #u8(10)) #u8(2))
-                        (cons [PrimitiveInfo] (MkPrimitiveInfo "Prelude.error" (addU8 firstSymbolId #u8(11)) #u8(0))
-                          (nil [PrimitiveInfo]))))))))))))
+poly primitivesStartingAt =
+  \firstSymbolId : U8 =>
+    cons
+      [PrimitiveInfo]
+      (MkPrimitiveInfo "Nat.succ" firstSymbolId #u8(1))
+      (
+        cons
+          [PrimitiveInfo]
+          (MkPrimitiveInfo "Nat.add" (addU8 firstSymbolId #u8(1)) #u8(2))
+          (
+            cons
+              [PrimitiveInfo]
+              (MkPrimitiveInfo "Nat.mul" (addU8 firstSymbolId #u8(2)) #u8(2))
+              (
+                cons
+                  [PrimitiveInfo]
+                  (
+                    MkPrimitiveInfo "Nat.lte" (addU8 firstSymbolId #u8(3)) #u8(2)
+                  )
+                  (
+                    cons
+                      [PrimitiveInfo]
+                      (
+                        MkPrimitiveInfo "Prelude.not" (addU8 firstSymbolId #u8(4)) #u8(1)
+                      )
+                      (
+                        cons
+                          [PrimitiveInfo]
+                          (
+                            MkPrimitiveInfo "Prelude.eqU8" (addU8 firstSymbolId #u8(5)) #u8(2)
+                          )
+                          (
+                            cons
+                              [PrimitiveInfo]
+                              (
+                                MkPrimitiveInfo "Prelude.ltU8" (addU8 firstSymbolId #u8(6)) #u8(2)
+                              )
+                              (
+                                cons
+                                  [PrimitiveInfo]
+                                  (
+                                    MkPrimitiveInfo "Prelude.addU8" (addU8 firstSymbolId #u8(7)) #u8(2)
+                                  )
+                                  (
+                                    cons
+                                      [PrimitiveInfo]
+                                      (
+                                        MkPrimitiveInfo "Prelude.subU8" (addU8 firstSymbolId #u8(8)) #u8(2)
+                                      )
+                                      (
+                                        cons
+                                          [PrimitiveInfo]
+                                          (
+                                            MkPrimitiveInfo "Prelude.divU8" (addU8 firstSymbolId #u8(9)) #u8(2)
+                                          )
+                                          (
+                                            cons
+                                              [PrimitiveInfo]
+                                              (
+                                                MkPrimitiveInfo "Prelude.modU8" (addU8 firstSymbolId #u8(10)) #u8(2)
+                                              )
+                                              (
+                                                cons
+                                                  [PrimitiveInfo]
+                                                  (
+                                                    MkPrimitiveInfo "Prelude.error" (addU8 firstSymbolId #u8(11)) #u8(0)
+                                                  )
+                                                  (nil [PrimitiveInfo])
+                                              )
+                                          )
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
+              )
+          )
+      )
 
-poly buildModuleEnv = \records : List ModuleRecord =>
-  match (parseModulesAcc records initialBuildState) [Result (List U8) ModuleEnv] {
-    | Err e => Err [List U8] [ModuleEnv] e
-    | Ok state =>
-        match state [Result (List U8) ModuleEnv] { | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
-          match (collectConstructors mods dataTypes #u8(4) pseudoConstructors) [Result (List U8) ModuleEnv] { | MkPair ctors nextSymbolId =>
-            let aliases = buildAliases ctors (nil [ConstructorAliasInfo]) in
-            let primitives = primitivesStartingAt nextSymbolId in
-            Ok [List U8] [ModuleEnv] (MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives primitives)
+poly buildModuleEnv =
+  \records : List ModuleRecord =>
+    match (parseModulesAcc records initialBuildState) [Result (List U8) ModuleEnv] {
+      | Err e => Err [List U8] [ModuleEnv] e
+      | Ok state =>
+        match state [Result (List U8) ModuleEnv] {
+          | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
+            match (collectConstructors mods dataTypes #u8(4) pseudoConstructors) [Result (List U8) ModuleEnv] {
+              | MkPair ctors nextSymbolId =>
+                let aliases = buildAliases ctors (nil [ConstructorAliasInfo]) in
+                let primitives = primitivesStartingAt nextSymbolId in
+                Ok
+                  [List U8]
+                  [ModuleEnv]
+                  (
+                    MkModuleEnv
+                      mods
+                      imps
+                      exps
+                      defs
+                      dataTypes
+                      ctors
+                      aliases
+                      opaques
+                      natives
+                      primitives
+                  )
+            }
+        }
+    }
+
+poly rec lookupModule =
+  \name : List U8 =>
+    \mods : List ModuleInfo =>
+      matchList
+        [ModuleInfo]
+        [Maybe ModuleInfo]
+        mods
+        (None [ModuleInfo])
+        (
+          \h : ModuleInfo =>
+            \t : List ModuleInfo =>
+              match h [Maybe ModuleInfo] {
+                | MkModuleInfo hName decls =>
+                  if [Maybe ModuleInfo] (eqListU8 hName name)
+                    (\u : U8 => Some [ModuleInfo] h)
+                    (\u : U8 => lookupModule name t)
+              }
+        )
+
+poly rec lookupImport =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \imports : List ImportInfo =>
+        matchList
+          [ImportInfo]
+          [Maybe ImportInfo]
+          imports
+          (None [ImportInfo])
+          (
+            \h : ImportInfo =>
+              \t : List ImportInfo =>
+                match h [Maybe ImportInfo] {
+                  | MkImportInfo hModule hFrom hSymbol =>
+                    if [Maybe ImportInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
+                      (\u : U8 => lookupImport moduleName symbolName t)
+                      (\u : U8 => Some [ImportInfo] h)
+                }
+          )
+
+poly rec lookupExport =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \exports : List ExportInfo =>
+        matchList
+          [ExportInfo]
+          [Maybe ExportInfo]
+          exports
+          (None [ExportInfo])
+          (
+            \h : ExportInfo =>
+              \t : List ExportInfo =>
+                match h [Maybe ExportInfo] {
+                  | MkExportInfo hModule hSymbol =>
+                    if [Maybe ExportInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
+                      (\u : U8 => lookupExport moduleName symbolName t)
+                      (\u : U8 => Some [ExportInfo] h)
+                }
+          )
+
+poly rec lookupDefinition =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \defs : List DefinitionInfo =>
+        matchList
+          [DefinitionInfo]
+          [Maybe DefinitionInfo]
+          defs
+          (None [DefinitionInfo])
+          (
+            \h : DefinitionInfo =>
+              \t : List DefinitionInfo =>
+                match h [Maybe DefinitionInfo] {
+                  | MkDefinitionInfo hModule hSymbol hKind =>
+                    if [Maybe DefinitionInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
+                      (\u : U8 => lookupDefinition moduleName symbolName t)
+                      (\u : U8 => Some [DefinitionInfo] h)
+                }
+          )
+
+poly rec lookupADT =
+  \qName : List U8 =>
+    \dataTypes : List DataTypeInfo =>
+      matchList
+        [DataTypeInfo]
+        [Maybe DataTypeInfo]
+        dataTypes
+        (None [DataTypeInfo])
+        (
+          \h : DataTypeInfo =>
+            \t : List DataTypeInfo =>
+              match h [Maybe DataTypeInfo] {
+                | MkDataTypeInfo hQName hLocal hId =>
+                  if [Maybe DataTypeInfo] (eqListU8 hQName qName)
+                    (\u : U8 => Some [DataTypeInfo] h)
+                    (\u : U8 => lookupADT qName t)
+              }
+        )
+
+poly rec lookupConstructor =
+  \qName : List U8 =>
+    \ctors : List ConstructorMeta =>
+      matchList
+        [ConstructorMeta]
+        [Maybe ConstructorMeta]
+        ctors
+        (None [ConstructorMeta])
+        (
+          \h : ConstructorMeta =>
+            \t : List ConstructorMeta =>
+              match h [Maybe ConstructorMeta] {
+                | MkConstructorMeta hQName local alias dataName dataId symbolId tag total arity =>
+                  if [Maybe ConstructorMeta] (eqListU8 hQName qName)
+                    (\u : U8 => Some [ConstructorMeta] h)
+                    (\u : U8 => lookupConstructor qName t)
+              }
+        )
+
+poly rec lookupConstructorAlias =
+  \alias : List U8 =>
+    \aliases : List ConstructorAliasInfo =>
+      matchList
+        [ConstructorAliasInfo]
+        [Maybe ConstructorAliasInfo]
+        aliases
+        (None [ConstructorAliasInfo])
+        (
+          \h : ConstructorAliasInfo =>
+            \t : List ConstructorAliasInfo =>
+              match h [Maybe ConstructorAliasInfo] {
+                | MkConstructorAliasInfo hAlias hTarget =>
+                  if [Maybe ConstructorAliasInfo] (eqListU8 hAlias alias)
+                    (\u : U8 => Some [ConstructorAliasInfo] h)
+                    (\u : U8 => lookupConstructorAlias alias t)
+              }
+        )
+
+poly rec lookupPrimitive =
+  \qName : List U8 =>
+    \prims : List PrimitiveInfo =>
+      matchList
+        [PrimitiveInfo]
+        [Maybe PrimitiveInfo]
+        prims
+        (None [PrimitiveInfo])
+        (
+          \h : PrimitiveInfo =>
+            \t : List PrimitiveInfo =>
+              match h [Maybe PrimitiveInfo] {
+                | MkPrimitiveInfo hQName hSymbol hArity =>
+                  if [Maybe PrimitiveInfo] (eqListU8 hQName qName)
+                    (\u : U8 => Some [PrimitiveInfo] h)
+                    (\u : U8 => lookupPrimitive qName t)
+              }
+        )
+
+poly rec lookupOpaque =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \opaques : List OpaqueInfo =>
+        matchList
+          [OpaqueInfo]
+          [Maybe OpaqueInfo]
+          opaques
+          (None [OpaqueInfo])
+          (
+            \h : OpaqueInfo =>
+              \t : List OpaqueInfo =>
+                match h [Maybe OpaqueInfo] {
+                  | MkOpaqueInfo hModule hName =>
+                    if [Maybe OpaqueInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hName name)))
+                      (\u : U8 => lookupOpaque moduleName name t)
+                      (\u : U8 => Some [OpaqueInfo] h)
+                }
+          )
+
+poly rec lookupNative =
+  \moduleName : List U8 =>
+    \name : List U8 =>
+      \natives : List NativeInfo =>
+        matchList
+          [NativeInfo]
+          [Maybe NativeInfo]
+          natives
+          (None [NativeInfo])
+          (
+            \h : NativeInfo =>
+              \t : List NativeInfo =>
+                match h [Maybe NativeInfo] {
+                  | MkNativeInfo hModule hName =>
+                    if [Maybe NativeInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hName name)))
+                      (\u : U8 => lookupNative moduleName name t)
+                      (\u : U8 => Some [NativeInfo] h)
+                }
+          )
+
+poly importStatus =
+  \fromName : List U8 =>
+    \symbolName : List U8 =>
+      \mods : List ModuleInfo =>
+        \exports : List ExportInfo =>
+          match (lookupModule fromName mods) [List U8] {
+            | None => "MISSING_MODULE"
+            | Some modInfo =>
+              match (lookupExport fromName symbolName exports) [List U8] {
+                | None => "NOT_EXPORTED"
+                | Some exp => "RESOLVED"
+              }
           }
+
+poly rec isDefined =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \defs : List DefinitionInfo =>
+        match (lookupDefinition moduleName symbolName defs) [Bool] {
+          | Some d => true
+          | None => false
         }
-  }
 
-poly rec lookupModule = \name : List U8 => \mods : List ModuleInfo =>
-  matchList [ModuleInfo] [Maybe ModuleInfo] mods
-    (None [ModuleInfo])
-    (\h : ModuleInfo => \t : List ModuleInfo =>
-      match h [Maybe ModuleInfo] { | MkModuleInfo hName decls =>
-        if [Maybe ModuleInfo] (eqListU8 hName name)
-          (\u : U8 => Some [ModuleInfo] h)
-          (\u : U8 => lookupModule name t)
-      })
+poly rec isConstructorDefined =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \ctors : List ConstructorMeta =>
+        matchList
+          [ConstructorMeta]
+          [Bool]
+          ctors
+          false
+          (
+            \h : ConstructorMeta =>
+              \t : List ConstructorMeta =>
+                match h [Bool] {
+                  | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
+                    if [Bool] (eqListU8 alias (qualify moduleName symbolName))
+                      (\u : U8 => true)
+                      (\u : U8 => isConstructorDefined moduleName symbolName t)
+                }
+          )
 
-poly rec lookupImport = \moduleName : List U8 => \symbolName : List U8 => \imports : List ImportInfo =>
-  matchList [ImportInfo] [Maybe ImportInfo] imports
-    (None [ImportInfo])
-    (\h : ImportInfo => \t : List ImportInfo =>
-      match h [Maybe ImportInfo] { | MkImportInfo hModule hFrom hSymbol =>
-        if [Maybe ImportInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
-          (\u : U8 => lookupImport moduleName symbolName t)
-          (\u : U8 => Some [ImportInfo] h)
-      })
+poly rec countExportOrigins =
+  \symbolName : List U8 =>
+    \exports : List ExportInfo =>
+      \acc : U8 =>
+        matchList
+          [ExportInfo]
+          [U8]
+          exports
+          acc
+          (
+            \h : ExportInfo =>
+              \t : List ExportInfo =>
+                match h [U8] {
+                  | MkExportInfo hModule hSymbol =>
+                    if [U8] (eqListU8 hSymbol symbolName)
+                      (\u : U8 => countExportOrigins symbolName t (inc acc))
+                      (\u : U8 => countExportOrigins symbolName t acc)
+                }
+          )
 
-poly rec lookupExport = \moduleName : List U8 => \symbolName : List U8 => \exports : List ExportInfo =>
-  matchList [ExportInfo] [Maybe ExportInfo] exports
-    (None [ExportInfo])
-    (\h : ExportInfo => \t : List ExportInfo =>
-      match h [Maybe ExportInfo] { | MkExportInfo hModule hSymbol =>
-        if [Maybe ExportInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
-          (\u : U8 => lookupExport moduleName symbolName t)
-          (\u : U8 => Some [ExportInfo] h)
-      })
+poly exportStatus =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \exports : List ExportInfo =>
+        \defs : List DefinitionInfo =>
+          \ctors : List ConstructorMeta =>
+            let origins = countExportOrigins symbolName exports #u8(0) in
+            if [List U8] (ltU8 #u8(1) origins)
+              (\u : U8 => "AMBIGUOUS")
+              (
+                \u : U8 =>
+                  if [List U8] (or (isDefined moduleName symbolName defs) (isConstructorDefined moduleName symbolName ctors))
+                    (\u : U8 => "OK")
+                    (\u : U8 => "EXPORT_UNDEFINED")
+              )
 
-poly rec lookupDefinition = \moduleName : List U8 => \symbolName : List U8 => \defs : List DefinitionInfo =>
-  matchList [DefinitionInfo] [Maybe DefinitionInfo] defs
-    (None [DefinitionInfo])
-    (\h : DefinitionInfo => \t : List DefinitionInfo =>
-      match h [Maybe DefinitionInfo] { | MkDefinitionInfo hModule hSymbol hKind =>
-        if [Maybe DefinitionInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hSymbol symbolName)))
-          (\u : U8 => lookupDefinition moduleName symbolName t)
-          (\u : U8 => Some [DefinitionInfo] h)
-      })
+poly rec emitModuleImportsAcc =
+  \moduleName : List U8 =>
+    \imports : List ImportInfo =>
+      \mods : List ModuleInfo =>
+        \exports : List ExportInfo =>
+          \acc : List U8 =>
+            matchList
+              [ImportInfo]
+              [List U8]
+              imports
+              acc
+              (
+                \h : ImportInfo =>
+                  \t : List ImportInfo =>
+                    match h [List U8] {
+                      | MkImportInfo hModule hFrom hSymbol =>
+                        if [List U8] (eqListU8 hModule moduleName)
+                          (
+                            \u : U8 =>
+                              emitModuleImportsAcc
+                                moduleName
+                                t
+                                mods
+                                exports
+                                (
+                                  append
+                                    [U8]
+                                    (
+                                      emitLine3
+                                        "import "
+                                        hFrom
+                                        hSymbol
+                                        (
+                                          importStatus
+                                            hFrom
+                                            hSymbol
+                                            mods
+                                            exports
+                                        )
+                                    )
+                                    acc
+                                )
+                          )
+                          (
+                            \u : U8 => emitModuleImportsAcc moduleName t mods exports acc
+                          )
+                    }
+              )
 
-poly rec lookupADT = \qName : List U8 => \dataTypes : List DataTypeInfo =>
-  matchList [DataTypeInfo] [Maybe DataTypeInfo] dataTypes
-    (None [DataTypeInfo])
-    (\h : DataTypeInfo => \t : List DataTypeInfo =>
-      match h [Maybe DataTypeInfo] { | MkDataTypeInfo hQName hLocal hId =>
-        if [Maybe DataTypeInfo] (eqListU8 hQName qName)
-          (\u : U8 => Some [DataTypeInfo] h)
-          (\u : U8 => lookupADT qName t)
-      })
+poly emitModuleImports =
+  \moduleName : List U8 =>
+    \imports : List ImportInfo =>
+      \mods : List ModuleInfo =>
+        \exports : List ExportInfo =>
+          emitModuleImportsAcc
+            moduleName
+            (reverse [ImportInfo] imports)
+            mods
+            exports
+            (nil [U8])
 
-poly rec lookupConstructor = \qName : List U8 => \ctors : List ConstructorMeta =>
-  matchList [ConstructorMeta] [Maybe ConstructorMeta] ctors
-    (None [ConstructorMeta])
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      match h [Maybe ConstructorMeta] { | MkConstructorMeta hQName local alias dataName dataId symbolId tag total arity =>
-        if [Maybe ConstructorMeta] (eqListU8 hQName qName)
-          (\u : U8 => Some [ConstructorMeta] h)
-          (\u : U8 => lookupConstructor qName t)
-      })
+poly rec emitModuleExportsAcc =
+  \moduleName : List U8 =>
+    \exports : List ExportInfo =>
+      \defs : List DefinitionInfo =>
+        \ctors : List ConstructorMeta =>
+          \acc : List U8 =>
+            matchList
+              [ExportInfo]
+              [List U8]
+              exports
+              acc
+              (
+                \h : ExportInfo =>
+                  \t : List ExportInfo =>
+                    match h [List U8] {
+                      | MkExportInfo hModule hSymbol =>
+                        if [List U8] (eqListU8 hModule moduleName)
+                          (
+                            \u : U8 =>
+                              emitModuleExportsAcc
+                                moduleName
+                                t
+                                defs
+                                ctors
+                                (
+                                  append
+                                    [U8]
+                                    (
+                                      emitLine2
+                                        "export "
+                                        hSymbol
+                                        (
+                                          exportStatus
+                                            moduleName
+                                            hSymbol
+                                            exports
+                                            defs
+                                            ctors
+                                        )
+                                    )
+                                    acc
+                                )
+                          )
+                          (
+                            \u : U8 => emitModuleExportsAcc moduleName t defs ctors acc
+                          )
+                    }
+              )
 
-poly rec lookupConstructorAlias = \alias : List U8 => \aliases : List ConstructorAliasInfo =>
-  matchList [ConstructorAliasInfo] [Maybe ConstructorAliasInfo] aliases
-    (None [ConstructorAliasInfo])
-    (\h : ConstructorAliasInfo => \t : List ConstructorAliasInfo =>
-      match h [Maybe ConstructorAliasInfo] { | MkConstructorAliasInfo hAlias hTarget =>
-        if [Maybe ConstructorAliasInfo] (eqListU8 hAlias alias)
-          (\u : U8 => Some [ConstructorAliasInfo] h)
-          (\u : U8 => lookupConstructorAlias alias t)
-      })
+poly emitModuleExports =
+  \moduleName : List U8 =>
+    \exports : List ExportInfo =>
+      \defs : List DefinitionInfo =>
+        \ctors : List ConstructorMeta =>
+          emitModuleExportsAcc
+            moduleName
+            (reverse [ExportInfo] exports)
+            defs
+            ctors
+            (nil [U8])
 
-poly rec lookupPrimitive = \qName : List U8 => \prims : List PrimitiveInfo =>
-  matchList [PrimitiveInfo] [Maybe PrimitiveInfo] prims
-    (None [PrimitiveInfo])
-    (\h : PrimitiveInfo => \t : List PrimitiveInfo =>
-      match h [Maybe PrimitiveInfo] { | MkPrimitiveInfo hQName hSymbol hArity =>
-        if [Maybe PrimitiveInfo] (eqListU8 hQName qName)
-          (\u : U8 => Some [PrimitiveInfo] h)
-          (\u : U8 => lookupPrimitive qName t)
-      })
+poly rec emitModuleDefsAcc =
+  \moduleName : List U8 =>
+    \defs : List DefinitionInfo =>
+      \acc : List U8 =>
+        matchList
+          [DefinitionInfo]
+          [List U8]
+          defs
+          acc
+          (
+            \h : DefinitionInfo =>
+              \t : List DefinitionInfo =>
+                match h [List U8] {
+                  | MkDefinitionInfo hModule hName hKind =>
+                    if [List U8] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 =>
+                          emitModuleDefsAcc
+                            moduleName
+                            t
+                            (
+                              append
+                                [U8]
+                                (emitLine2 "definition " hKind hName)
+                                acc
+                            )
+                      )
+                      (\u : U8 => emitModuleDefsAcc moduleName t acc)
+                }
+          )
 
-poly rec lookupOpaque = \moduleName : List U8 => \name : List U8 => \opaques : List OpaqueInfo =>
-  matchList [OpaqueInfo] [Maybe OpaqueInfo] opaques
-    (None [OpaqueInfo])
-    (\h : OpaqueInfo => \t : List OpaqueInfo =>
-      match h [Maybe OpaqueInfo] { | MkOpaqueInfo hModule hName =>
-        if [Maybe OpaqueInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hName name)))
-          (\u : U8 => lookupOpaque moduleName name t)
-          (\u : U8 => Some [OpaqueInfo] h)
-      })
+poly emitModuleDefs =
+  \moduleName : List U8 =>
+    \defs : List DefinitionInfo =>
+      emitModuleDefsAcc moduleName (reverse [DefinitionInfo] defs) (nil [U8])
 
-poly rec lookupNative = \moduleName : List U8 => \name : List U8 => \natives : List NativeInfo =>
-  matchList [NativeInfo] [Maybe NativeInfo] natives
-    (None [NativeInfo])
-    (\h : NativeInfo => \t : List NativeInfo =>
-      match h [Maybe NativeInfo] { | MkNativeInfo hModule hName =>
-        if [Maybe NativeInfo] (or (not (eqListU8 hModule moduleName)) (not (eqListU8 hName name)))
-          (\u : U8 => lookupNative moduleName name t)
-          (\u : U8 => Some [NativeInfo] h)
-      })
+poly rec emitModuleOpaquesAcc =
+  \moduleName : List U8 =>
+    \opaques : List OpaqueInfo =>
+      \acc : List U8 =>
+        matchList
+          [OpaqueInfo]
+          [List U8]
+          opaques
+          acc
+          (
+            \h : OpaqueInfo =>
+              \t : List OpaqueInfo =>
+                match h [List U8] {
+                  | MkOpaqueInfo hModule hName =>
+                    if [List U8] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 =>
+                          emitModuleOpaquesAcc
+                            moduleName
+                            t
+                            (append [U8] (emitLine1 "opaque " hName) acc)
+                      )
+                      (\u : U8 => emitModuleOpaquesAcc moduleName t acc)
+                }
+          )
 
-poly importStatus = \fromName : List U8 => \symbolName : List U8 => \mods : List ModuleInfo => \exports : List ExportInfo =>
-  match (lookupModule fromName mods) [List U8] {
-    | None => "MISSING_MODULE"
-    | Some modInfo =>
-        match (lookupExport fromName symbolName exports) [List U8] {
-          | None => "NOT_EXPORTED"
-          | Some exp => "RESOLVED"
-        }
-  }
+poly emitModuleOpaques =
+  \moduleName : List U8 =>
+    \opaques : List OpaqueInfo =>
+      emitModuleOpaquesAcc moduleName (reverse [OpaqueInfo] opaques) (nil [U8])
 
-poly rec isDefined = \moduleName : List U8 => \symbolName : List U8 => \defs : List DefinitionInfo =>
-  match (lookupDefinition moduleName symbolName defs) [Bool] {
-    | Some d => true
-    | None => false
-  }
+poly rec emitModuleNativesAcc =
+  \moduleName : List U8 =>
+    \natives : List NativeInfo =>
+      \acc : List U8 =>
+        matchList
+          [NativeInfo]
+          [List U8]
+          natives
+          acc
+          (
+            \h : NativeInfo =>
+              \t : List NativeInfo =>
+                match h [List NativeInfo] {
+                  | MkNativeInfo hModule hName =>
+                    if [List U8] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 =>
+                          emitModuleNativesAcc
+                            moduleName
+                            t
+                            (append [U8] (emitLine1 "native " hName) acc)
+                      )
+                      (\u : U8 => emitModuleNativesAcc moduleName t acc)
+                }
+          )
 
-poly rec isConstructorDefined = \moduleName : List U8 => \symbolName : List U8 => \ctors : List ConstructorMeta =>
-  matchList [ConstructorMeta] [Bool] ctors
-    false
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      match h [Bool] { | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
-        if [Bool] (eqListU8 alias (qualify moduleName symbolName))
-          (\u : U8 => true)
-          (\u : U8 => isConstructorDefined moduleName symbolName t)
-      })
+poly emitModuleNatives =
+  \moduleName : List U8 =>
+    \natives : List NativeInfo =>
+      emitModuleNativesAcc moduleName (reverse [NativeInfo] natives) (nil [U8])
 
-poly rec countExportOrigins = \symbolName : List U8 => \exports : List ExportInfo => \acc : U8 =>
-  matchList [ExportInfo] [U8] exports acc
-    (\h : ExportInfo => \t : List ExportInfo =>
-      match h [U8] { | MkExportInfo hModule hSymbol =>
-        if [U8] (eqListU8 hSymbol symbolName)
-          (\u : U8 => countExportOrigins symbolName t (inc acc))
-          (\u : U8 => countExportOrigins symbolName t acc)
-      })
+poly rec emitModulesAcc =
+  \mods : List ModuleInfo =>
+    \fullMods : List ModuleInfo =>
+      \imports : List ImportInfo =>
+        \exports : List ExportInfo =>
+          \defs : List DefinitionInfo =>
+            \ctors : List ConstructorMeta =>
+              \opaques : List OpaqueInfo =>
+                \natives : List NativeInfo =>
+                  \acc : List U8 =>
+                    matchList
+                      [ModuleInfo]
+                      [List U8]
+                      mods
+                      acc
+                      (
+                        \h : ModuleInfo =>
+                          \t : List ModuleInfo =>
+                            match h [List U8] {
+                              | MkModuleInfo moduleName decls =>
+                                let head = emitLine1 "module " moduleName in
+                                let impBlock = append [U8] (emitU8Line "imports " (count [ImportInfo] (moduleImports moduleName imports))) (emitModuleImports moduleName imports fullMods exports) in
+                                let expBlock = append [U8] (emitU8Line "exports " (count [ExportInfo] (moduleExports moduleName exports))) (emitModuleExports moduleName exports defs ctors) in
+                                let defBlock = append [U8] (emitU8Line "definitions " (count [DefinitionInfo] (moduleDefs moduleName defs))) (emitModuleDefs moduleName defs) in
+                                let opaqueBlock = append [U8] (emitU8Line "opaque " (count [OpaqueInfo] (moduleOpaques moduleName opaques))) (emitModuleOpaques moduleName opaques) in
+                                let nativeBlock = append [U8] (emitU8Line "native " (count [NativeInfo] (moduleNatives moduleName natives))) (emitModuleNatives moduleName natives) in
+                                let modSummary = append [U8] head (append [U8] impBlock (append [U8] expBlock (append [U8] defBlock (append [U8] opaqueBlock nativeBlock)))) in
+                                emitModulesAcc
+                                  t
+                                  fullMods
+                                  imports
+                                  exports
+                                  defs
+                                  ctors
+                                  opaques
+                                  natives
+                                  (append [U8] modSummary acc)
+                            }
+                      )
 
-poly exportStatus = \moduleName : List U8 => \symbolName : List U8 => \exports : List ExportInfo => \defs : List DefinitionInfo => \ctors : List ConstructorMeta =>
-  let origins = countExportOrigins symbolName exports #u8(0) in
-  if [List U8] (ltU8 #u8(1) origins)
-    (\u : U8 => "AMBIGUOUS")
-    (\u : U8 =>
-      if [List U8] (or (isDefined moduleName symbolName defs) (isConstructorDefined moduleName symbolName ctors))
-        (\u : U8 => "OK")
-        (\u : U8 => "EXPORT_UNDEFINED"))
+poly emitModules =
+  \mods : List ModuleInfo =>
+    \imports : List ImportInfo =>
+      \exports : List ExportInfo =>
+        \defs : List DefinitionInfo =>
+          \ctors : List ConstructorMeta =>
+            \opaques : List OpaqueInfo =>
+              \natives : List NativeInfo =>
+                emitModulesAcc
+                  (reverse [ModuleInfo] mods)
+                  mods
+                  imports
+                  exports
+                  defs
+                  ctors
+                  opaques
+                  natives
+                  (nil [U8])
 
-poly rec emitModuleImportsAcc = \moduleName : List U8 => \imports : List ImportInfo => \mods : List ModuleInfo => \exports : List ExportInfo => \acc : List U8 =>
-  matchList [ImportInfo] [List U8] imports
-    acc
-    (\h : ImportInfo => \t : List ImportInfo =>
-      match h [List U8] { | MkImportInfo hModule hFrom hSymbol =>
-        if [List U8] (eqListU8 hModule moduleName)
-          (\u : U8 =>
-            emitModuleImportsAcc moduleName t mods exports
-              (append [U8] (emitLine3 "import " hFrom hSymbol (importStatus hFrom hSymbol mods exports)) acc))
-          (\u : U8 => emitModuleImportsAcc moduleName t mods exports acc)
-      })
+poly rec moduleImportsAcc =
+  \moduleName : List U8 =>
+    \imports : List ImportInfo =>
+      \acc : List ImportInfo =>
+        matchList
+          [ImportInfo]
+          [List ImportInfo]
+          imports
+          acc
+          (
+            \h : ImportInfo =>
+              \t : List ImportInfo =>
+                match h [List ImportInfo] {
+                  | MkImportInfo hModule hFrom hSymbol =>
+                    if [List ImportInfo] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 => moduleImportsAcc moduleName t (cons [ImportInfo] h acc)
+                      )
+                      (\u : U8 => moduleImportsAcc moduleName t acc)
+                }
+          )
 
-poly emitModuleImports = \moduleName : List U8 => \imports : List ImportInfo => \mods : List ModuleInfo => \exports : List ExportInfo =>
-  emitModuleImportsAcc moduleName (reverse [ImportInfo] imports) mods exports (nil [U8])
+poly moduleImports =
+  \moduleName : List U8 =>
+    \imports : List ImportInfo =>
+      reverse
+        [ImportInfo]
+        (moduleImportsAcc moduleName imports (nil [ImportInfo]))
 
-poly rec emitModuleExportsAcc = \moduleName : List U8 => \exports : List ExportInfo => \defs : List DefinitionInfo => \ctors : List ConstructorMeta => \acc : List U8 =>
-  matchList [ExportInfo] [List U8] exports
-    acc
-    (\h : ExportInfo => \t : List ExportInfo =>
-      match h [List U8] { | MkExportInfo hModule hSymbol =>
-        if [List U8] (eqListU8 hModule moduleName)
-          (\u : U8 =>
-            emitModuleExportsAcc moduleName t defs ctors
-              (append [U8] (emitLine2 "export " hSymbol (exportStatus moduleName hSymbol exports defs ctors)) acc))
-          (\u : U8 => emitModuleExportsAcc moduleName t defs ctors acc)
-      })
+poly rec moduleExportsAcc =
+  \moduleName : List U8 =>
+    \exports : List ExportInfo =>
+      \acc : List ExportInfo =>
+        matchList
+          [ExportInfo]
+          [List ExportInfo]
+          exports
+          acc
+          (
+            \h : ExportInfo =>
+              \t : List ExportInfo =>
+                match h [List ExportInfo] {
+                  | MkExportInfo hModule hSymbol =>
+                    if [List ExportInfo] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 => moduleExportsAcc moduleName t (cons [ExportInfo] h acc)
+                      )
+                      (\u : U8 => moduleExportsAcc moduleName t acc)
+                }
+          )
 
-poly emitModuleExports = \moduleName : List U8 => \exports : List ExportInfo => \defs : List DefinitionInfo => \ctors : List ConstructorMeta =>
-  emitModuleExportsAcc moduleName (reverse [ExportInfo] exports) defs ctors (nil [U8])
+poly moduleExports =
+  \moduleName : List U8 =>
+    \exports : List ExportInfo =>
+      reverse
+        [ExportInfo]
+        (moduleExportsAcc moduleName exports (nil [ExportInfo]))
 
-poly rec emitModuleDefsAcc = \moduleName : List U8 => \defs : List DefinitionInfo => \acc : List U8 =>
-  matchList [DefinitionInfo] [List U8] defs
-    acc
-    (\h : DefinitionInfo => \t : List DefinitionInfo =>
-      match h [List U8] { | MkDefinitionInfo hModule hName hKind =>
-        if [List U8] (eqListU8 hModule moduleName)
-          (\u : U8 => emitModuleDefsAcc moduleName t (append [U8] (emitLine2 "definition " hKind hName) acc))
-          (\u : U8 => emitModuleDefsAcc moduleName t acc)
-      })
+poly rec moduleDefsAcc =
+  \moduleName : List U8 =>
+    \defs : List DefinitionInfo =>
+      \acc : List DefinitionInfo =>
+        matchList
+          [DefinitionInfo]
+          [List DefinitionInfo]
+          defs
+          acc
+          (
+            \h : DefinitionInfo =>
+              \t : List DefinitionInfo =>
+                match h [List DefinitionInfo] {
+                  | MkDefinitionInfo hModule hName hKind =>
+                    if [List DefinitionInfo] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 => moduleDefsAcc moduleName t (cons [DefinitionInfo] h acc)
+                      )
+                      (\u : U8 => moduleDefsAcc moduleName t acc)
+                }
+          )
 
-poly emitModuleDefs = \moduleName : List U8 => \defs : List DefinitionInfo =>
-  emitModuleDefsAcc moduleName (reverse [DefinitionInfo] defs) (nil [U8])
+poly moduleDefs =
+  \moduleName : List U8 =>
+    \defs : List DefinitionInfo =>
+      reverse
+        [DefinitionInfo]
+        (moduleDefsAcc moduleName defs (nil [DefinitionInfo]))
 
+poly rec moduleOpaquesAcc =
+  \moduleName : List U8 =>
+    \opaques : List OpaqueInfo =>
+      \acc : List OpaqueInfo =>
+        matchList
+          [OpaqueInfo]
+          [List OpaqueInfo]
+          opaques
+          acc
+          (
+            \h : OpaqueInfo =>
+              \t : List OpaqueInfo =>
+                match h [List OpaqueInfo] {
+                  | MkOpaqueInfo hModule hName =>
+                    if [List OpaqueInfo] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 => moduleOpaquesAcc moduleName t (cons [OpaqueInfo] h acc)
+                      )
+                      (\u : U8 => moduleOpaquesAcc moduleName t acc)
+                }
+          )
 
-poly rec emitModuleOpaquesAcc = \moduleName : List U8 => \opaques : List OpaqueInfo => \acc : List U8 =>
-  matchList [OpaqueInfo] [List U8] opaques
-    acc
-    (\h : OpaqueInfo => \t : List OpaqueInfo =>
-      match h [List U8] { | MkOpaqueInfo hModule hName =>
-        if [List U8] (eqListU8 hModule moduleName)
-          (\u : U8 => emitModuleOpaquesAcc moduleName t (append [U8] (emitLine1 "opaque " hName) acc))
-          (\u : U8 => emitModuleOpaquesAcc moduleName t acc)
-      })
+poly moduleOpaques =
+  \moduleName : List U8 =>
+    \opaques : List OpaqueInfo =>
+      reverse
+        [OpaqueInfo]
+        (moduleOpaquesAcc moduleName opaques (nil [OpaqueInfo]))
 
-poly emitModuleOpaques = \moduleName : List U8 => \opaques : List OpaqueInfo =>
-  emitModuleOpaquesAcc moduleName (reverse [OpaqueInfo] opaques) (nil [U8])
+poly rec moduleNativesAcc =
+  \moduleName : List U8 =>
+    \natives : List NativeInfo =>
+      \acc : List NativeInfo =>
+        matchList
+          [NativeInfo]
+          [List NativeInfo]
+          natives
+          acc
+          (
+            \h : NativeInfo =>
+              \t : List NativeInfo =>
+                match h [List NativeInfo] {
+                  | MkNativeInfo hModule hName =>
+                    if [List NativeInfo] (eqListU8 hModule moduleName)
+                      (
+                        \u : U8 => moduleNativesAcc moduleName t (cons [NativeInfo] h acc)
+                      )
+                      (\u : U8 => moduleNativesAcc moduleName t acc)
+                }
+          )
 
-poly rec emitModuleNativesAcc = \moduleName : List U8 => \natives : List NativeInfo => \acc : List U8 =>
-  matchList [NativeInfo] [List U8] natives
-    acc
-    (\h : NativeInfo => \t : List NativeInfo =>
-      match h [List NativeInfo] { | MkNativeInfo hModule hName =>
-        if [List U8] (eqListU8 hModule moduleName)
-          (\u : U8 => emitModuleNativesAcc moduleName t (append [U8] (emitLine1 "native " hName) acc))
-          (\u : U8 => emitModuleNativesAcc moduleName t acc)
-      })
+poly moduleNatives =
+  \moduleName : List U8 =>
+    \natives : List NativeInfo =>
+      reverse
+        [NativeInfo]
+        (moduleNativesAcc moduleName natives (nil [NativeInfo]))
 
-poly emitModuleNatives = \moduleName : List U8 => \natives : List NativeInfo =>
-  emitModuleNativesAcc moduleName (reverse [NativeInfo] natives) (nil [U8])
-
-
-poly rec emitModulesAcc = \mods : List ModuleInfo => \fullMods : List ModuleInfo => \imports : List ImportInfo => \exports : List ExportInfo => \defs : List DefinitionInfo => \ctors : List ConstructorMeta => \opaques : List OpaqueInfo => \natives : List NativeInfo => \acc : List U8 =>
-  matchList [ModuleInfo] [List U8] mods
-    acc
-    (\h : ModuleInfo => \t : List ModuleInfo =>
-      match h [List U8] { | MkModuleInfo moduleName decls =>
-        let head = emitLine1 "module " moduleName in
-        let impBlock = append [U8] (emitU8Line "imports " (count [ImportInfo] (moduleImports moduleName imports))) (emitModuleImports moduleName imports fullMods exports) in
-        let expBlock = append [U8] (emitU8Line "exports " (count [ExportInfo] (moduleExports moduleName exports))) (emitModuleExports moduleName exports defs ctors) in
-        let defBlock = append [U8] (emitU8Line "definitions " (count [DefinitionInfo] (moduleDefs moduleName defs))) (emitModuleDefs moduleName defs) in
-        let opaqueBlock = append [U8] (emitU8Line "opaque " (count [OpaqueInfo] (moduleOpaques moduleName opaques))) (emitModuleOpaques moduleName opaques) in
-        let nativeBlock = append [U8] (emitU8Line "native " (count [NativeInfo] (moduleNatives moduleName natives))) (emitModuleNatives moduleName natives) in
-        let modSummary = append [U8] head (append [U8] impBlock (append [U8] expBlock (append [U8] defBlock (append [U8] opaqueBlock nativeBlock)))) in
-        emitModulesAcc t fullMods imports exports defs ctors opaques natives (append [U8] modSummary acc)
-      })
-
-poly emitModules = \mods : List ModuleInfo => \imports : List ImportInfo => \exports : List ExportInfo => \defs : List DefinitionInfo => \ctors : List ConstructorMeta => \opaques : List OpaqueInfo => \natives : List NativeInfo =>
-  emitModulesAcc (reverse [ModuleInfo] mods) mods imports exports defs ctors opaques natives (nil [U8])
-
-poly rec moduleImportsAcc = \moduleName : List U8 => \imports : List ImportInfo => \acc : List ImportInfo =>
-  matchList [ImportInfo] [List ImportInfo] imports
-    acc
-    (\h : ImportInfo => \t : List ImportInfo =>
-      match h [List ImportInfo] { | MkImportInfo hModule hFrom hSymbol =>
-        if [List ImportInfo] (eqListU8 hModule moduleName)
-          (\u : U8 => moduleImportsAcc moduleName t (cons [ImportInfo] h acc))
-          (\u : U8 => moduleImportsAcc moduleName t acc)
-      })
-
-poly moduleImports = \moduleName : List U8 => \imports : List ImportInfo =>
-  reverse [ImportInfo] (moduleImportsAcc moduleName imports (nil [ImportInfo]))
-
-poly rec moduleExportsAcc = \moduleName : List U8 => \exports : List ExportInfo => \acc : List ExportInfo =>
-  matchList [ExportInfo] [List ExportInfo] exports
-    acc
-    (\h : ExportInfo => \t : List ExportInfo =>
-      match h [List ExportInfo] { | MkExportInfo hModule hSymbol =>
-        if [List ExportInfo] (eqListU8 hModule moduleName)
-          (\u : U8 => moduleExportsAcc moduleName t (cons [ExportInfo] h acc))
-          (\u : U8 => moduleExportsAcc moduleName t acc)
-      })
-
-poly moduleExports = \moduleName : List U8 => \exports : List ExportInfo =>
-  reverse [ExportInfo] (moduleExportsAcc moduleName exports (nil [ExportInfo]))
-
-poly rec moduleDefsAcc = \moduleName : List U8 => \defs : List DefinitionInfo => \acc : List DefinitionInfo =>
-  matchList [DefinitionInfo] [List DefinitionInfo] defs
-    acc
-    (\h : DefinitionInfo => \t : List DefinitionInfo =>
-      match h [List DefinitionInfo] { | MkDefinitionInfo hModule hName hKind =>
-        if [List DefinitionInfo] (eqListU8 hModule moduleName)
-          (\u : U8 => moduleDefsAcc moduleName t (cons [DefinitionInfo] h acc))
-          (\u : U8 => moduleDefsAcc moduleName t acc)
-      })
-
-poly moduleDefs = \moduleName : List U8 => \defs : List DefinitionInfo =>
-  reverse [DefinitionInfo] (moduleDefsAcc moduleName defs (nil [DefinitionInfo]))
-
-poly rec moduleOpaquesAcc = \moduleName : List U8 => \opaques : List OpaqueInfo => \acc : List OpaqueInfo =>
-  matchList [OpaqueInfo] [List OpaqueInfo] opaques
-    acc
-    (\h : OpaqueInfo => \t : List OpaqueInfo =>
-      match h [List OpaqueInfo] { | MkOpaqueInfo hModule hName =>
-        if [List OpaqueInfo] (eqListU8 hModule moduleName)
-          (\u : U8 => moduleOpaquesAcc moduleName t (cons [OpaqueInfo] h acc))
-          (\u : U8 => moduleOpaquesAcc moduleName t acc)
-      })
-
-poly moduleOpaques = \moduleName : List U8 => \opaques : List OpaqueInfo =>
-  reverse [OpaqueInfo] (moduleOpaquesAcc moduleName opaques (nil [OpaqueInfo]))
-
-poly rec moduleNativesAcc = \moduleName : List U8 => \natives : List NativeInfo => \acc : List NativeInfo =>
-  matchList [NativeInfo] [List NativeInfo] natives
-    acc
-    (\h : NativeInfo => \t : List NativeInfo =>
-      match h [List NativeInfo] { | MkNativeInfo hModule hName =>
-        if [List NativeInfo] (eqListU8 hModule moduleName)
-          (\u : U8 => moduleNativesAcc moduleName t (cons [NativeInfo] h acc))
-          (\u : U8 => moduleNativesAcc moduleName t acc)
-      })
-
-poly moduleNatives = \moduleName : List U8 => \natives : List NativeInfo =>
-  reverse [NativeInfo] (moduleNativesAcc moduleName natives (nil [NativeInfo]))
-
-poly emitDataType = \info : DataTypeInfo =>
-  match info [List U8] { | MkDataTypeInfo qName local id =>
-    append [U8] "datatype " (append [U8] (u8ToDigits id) (append [U8] space (append [U8] qName (append [U8] space (append [U8] local newline)))))
-  }
-
-poly rec emitDataTypesAcc = \dataTypes : List DataTypeInfo => \acc : List U8 =>
-  matchList [DataTypeInfo] [List U8] dataTypes
-    acc
-    (\h : DataTypeInfo => \t : List DataTypeInfo =>
-      emitDataTypesAcc t (append [U8] (emitDataType h) acc))
-
-poly emitDataTypes = \dataTypes : List DataTypeInfo =>
-  emitDataTypesAcc (reverse [DataTypeInfo] dataTypes) (nil [U8])
-
-poly emitConstructor = \info : ConstructorMeta =>
-  match info [List U8] { | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
-    let s0 = append [U8] "constructor " (u8ToDigits symbolId) in
-    let s1 = append [U8] s0 (append [U8] space qName) in
-    let s2 = append [U8] s1 (append [U8] space local) in
-    let s3 = append [U8] s2 (append [U8] space alias) in
-    let s4 = append [U8] s3 (append [U8] " data#" (u8ToDigits dataId)) in
-    let s5 = append [U8] s4 (append [U8] " tag " (u8ToDigits tag)) in
-    let s6 = append [U8] s5 (append [U8] " total " (u8ToDigits total)) in
-    append [U8] s6 (append [U8] " arity " (append [U8] (u8ToDigits arity) newline))
-  }
-
-poly rec emitConstructorsAcc = \ctors : List ConstructorMeta => \acc : List U8 =>
-  matchList [ConstructorMeta] [List U8] ctors
-    acc
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      emitConstructorsAcc t (append [U8] (emitConstructor h) acc))
-
-poly emitConstructors = \ctors : List ConstructorMeta =>
-  emitConstructorsAcc (reverse [ConstructorMeta] ctors) (nil [U8])
-
-poly emitAlias = \info : ConstructorAliasInfo =>
-  match info [List U8] { | MkConstructorAliasInfo alias target =>
-    match target [List U8] {
-      | None => emitLine2 "alias " alias ambiguousText
-      | Some qName => emitLine2 "alias " alias qName
+poly emitDataType =
+  \info : DataTypeInfo =>
+    match info [List U8] {
+      | MkDataTypeInfo qName local id =>
+        append
+          [U8]
+          "datatype "
+          (
+            append
+              [U8]
+              (u8ToDigits id)
+              (
+                append
+                  [U8]
+                  space
+                  (
+                    append
+                      [U8]
+                      qName
+                      (append [U8] space (append [U8] local newline))
+                  )
+              )
+          )
     }
-  }
 
-poly rec emitAliasesAcc = \aliases : List ConstructorAliasInfo => \acc : List U8 =>
-  matchList [ConstructorAliasInfo] [List U8] aliases
-    acc
-    (\h : ConstructorAliasInfo => \t : List ConstructorAliasInfo =>
-      emitAliasesAcc t (append [U8] (emitAlias h) acc))
+poly rec emitDataTypesAcc =
+  \dataTypes : List DataTypeInfo =>
+    \acc : List U8 =>
+      matchList
+        [DataTypeInfo]
+        [List U8]
+        dataTypes
+        acc
+        (
+          \h : DataTypeInfo =>
+            \t : List DataTypeInfo => emitDataTypesAcc t (append [U8] (emitDataType h) acc)
+        )
 
-poly emitAliases = \aliases : List ConstructorAliasInfo =>
-  emitAliasesAcc (reverse [ConstructorAliasInfo] aliases) (nil [U8])
+poly emitDataTypes =
+  \dataTypes : List DataTypeInfo =>
+    emitDataTypesAcc (reverse [DataTypeInfo] dataTypes) (nil [U8])
 
-poly emitPrimitive = \info : PrimitiveInfo =>
-  match info [List U8] { | MkPrimitiveInfo qName symbolId arity =>
-    append [U8] "primitive "
-      (append [U8] (u8ToDigits symbolId)
-        (append [U8] space
-          (append [U8] qName
-            (append [U8] " arity "
-              (append [U8] (u8ToDigits arity) newline)))))
-  }
-
-poly rec emitPrimitivesAcc = \prims : List PrimitiveInfo => \acc : List U8 =>
-  matchList [PrimitiveInfo] [List U8] prims
-    acc
-    (\h : PrimitiveInfo => \t : List PrimitiveInfo =>
-      emitPrimitivesAcc t (append [U8] (emitPrimitive h) acc))
-
-poly emitPrimitives = \prims : List PrimitiveInfo =>
-  emitPrimitivesAcc (reverse [PrimitiveInfo] prims) (nil [U8])
-
-poly rec insertDataEnvCtors = \ctors : List ConstructorMeta => \env : DataEnv =>
-  matchList [ConstructorMeta] [DataEnv] ctors
-    env
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      match h [DataEnv] { | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
-        match env [DataEnv] { | MkDataEnv cEnv aEnv =>
-          let info = MkCtorInfo tag total arity dataName in
-          insertDataEnvCtors t (MkDataEnv (insert [List U8] [CtorInfo] lteListU8 local info cEnv) aEnv)
-        }
-      })
-
-poly rec ctorNamesForData = \dataId : U8 => \ctors : List ConstructorMeta =>
-  matchList [ConstructorMeta] [List (List U8)] ctors
-    (nil [List U8])
-    (\h : ConstructorMeta => \t : List ConstructorMeta =>
-      match h [List (List U8)] { | MkConstructorMeta qName local alias dataName hDataId symbolId tag total arity =>
-        if [List (List U8)] (eqU8 hDataId dataId)
-          (\u : U8 => cons [List U8] local (ctorNamesForData dataId t))
-          (\u : U8 => ctorNamesForData dataId t)
-      })
-
-poly rec insertDataEnvAdts = \dataTypes : List DataTypeInfo => \ctors : List ConstructorMeta => \env : DataEnv =>
-  matchList [DataTypeInfo] [DataEnv] dataTypes
-    env
-    (\h : DataTypeInfo => \t : List DataTypeInfo =>
-      match h [DataEnv] { | MkDataTypeInfo qName local dataId =>
-        match env [DataEnv] { | MkDataEnv cEnv aEnv =>
-          let names = ctorNamesForData dataId ctors in
-          insertDataEnvAdts t ctors (MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 local (MkADTInfo names) aEnv))
-        }
-      })
-
-poly dataEnvFromModuleEnv = \env : ModuleEnv =>
-  match env [DataEnv] { | MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives prims =>
-    let emptyEnv = MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo]) in
-    insertDataEnvAdts dataTypes ctors (insertDataEnvCtors ctors emptyEnv)
-  }
-
-poly emitModuleEnvSummary = \env : ModuleEnv =>
-  match env [List U8] { | MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives prims =>
-    let header = append [U8] "OK\nversion module-env-v1\nmodules " (append [U8] (u8ToDigits (count [ModuleInfo] mods)) newline) in
-    let dataHeader = emitU8Line "data-types " (count [DataTypeInfo] dataTypes) in
-    let ctorHeader = emitU8Line "constructors " (count [ConstructorMeta] ctors) in
-    let aliasHeader = emitU8Line "aliases " (count [ConstructorAliasInfo] aliases) in
-    let primHeader = emitU8Line "primitives " (count [PrimitiveInfo] prims) in
-    let s0 = append [U8] header (emitModules mods imps exps defs ctors opaques natives) in
-    let s1 = append [U8] s0 dataHeader in
-    let s2 = append [U8] s1 (emitDataTypes dataTypes) in
-    let s3 = append [U8] s2 ctorHeader in
-    let s4 = append [U8] s3 (emitConstructors ctors) in
-    let s5 = append [U8] s4 aliasHeader in
-    let s6 = append [U8] s5 (emitAliases aliases) in
-    append [U8] s6 (append [U8] primHeader (emitPrimitives prims))
-  }
-
-poly emitBundleModuleEnvSummary = \bundle : BundleSummary =>
-  match bundle [Result (List U8) (List U8)] { | MkBundleSummary entry target wrapper modsCountDigits mods =>
-    match (buildModuleEnv mods) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok env => Ok [List U8] [List U8] (emitModuleEnvSummary env)
+poly emitConstructor =
+  \info : ConstructorMeta =>
+    match info [List U8] {
+      | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
+        let s0 = append [U8] "constructor " (u8ToDigits symbolId) in
+        let s1 = append [U8] s0 (append [U8] space qName) in
+        let s2 = append [U8] s1 (append [U8] space local) in
+        let s3 = append [U8] s2 (append [U8] space alias) in
+        let s4 = append [U8] s3 (append [U8] " data#" (u8ToDigits dataId)) in
+        let s5 = append [U8] s4 (append [U8] " tag " (u8ToDigits tag)) in
+        let s6 = append [U8] s5 (append [U8] " total " (u8ToDigits total)) in
+        append
+          [U8]
+          s6
+          (append [U8] " arity " (append [U8] (u8ToDigits arity) newline))
     }
-  }
 
-poly rec writeAll = \bytes : List U8 =>
-  matchList [U8] [U8] bytes
-    #u8(0)
-    (\h : U8 => \t : List U8 =>
-      writeOne h [U8] (\u : U8 => writeAll t))
+poly rec emitConstructorsAcc =
+  \ctors : List ConstructorMeta =>
+    \acc : List U8 =>
+      matchList
+        [ConstructorMeta]
+        [List U8]
+        ctors
+        acc
+        (
+          \h : ConstructorMeta =>
+            \t : List ConstructorMeta => emitConstructorsAcc t (append [U8] (emitConstructor h) acc)
+        )
 
-poly main = \source : List U8 =>
-  match (parseBundleSummary source) [U8] {
-    | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
-    | Ok bundle =>
+poly emitConstructors =
+  \ctors : List ConstructorMeta =>
+    emitConstructorsAcc (reverse [ConstructorMeta] ctors) (nil [U8])
+
+poly emitAlias =
+  \info : ConstructorAliasInfo =>
+    match info [List U8] {
+      | MkConstructorAliasInfo alias target =>
+        match target [List U8] {
+          | None => emitLine2 "alias " alias ambiguousText
+          | Some qName => emitLine2 "alias " alias qName
+        }
+    }
+
+poly rec emitAliasesAcc =
+  \aliases : List ConstructorAliasInfo =>
+    \acc : List U8 =>
+      matchList
+        [ConstructorAliasInfo]
+        [List U8]
+        aliases
+        acc
+        (
+          \h : ConstructorAliasInfo =>
+            \t : List ConstructorAliasInfo => emitAliasesAcc t (append [U8] (emitAlias h) acc)
+        )
+
+poly emitAliases =
+  \aliases : List ConstructorAliasInfo =>
+    emitAliasesAcc (reverse [ConstructorAliasInfo] aliases) (nil [U8])
+
+poly emitPrimitive =
+  \info : PrimitiveInfo =>
+    match info [List U8] {
+      | MkPrimitiveInfo qName symbolId arity =>
+        append
+          [U8]
+          "primitive "
+          (
+            append
+              [U8]
+              (u8ToDigits symbolId)
+              (
+                append
+                  [U8]
+                  space
+                  (
+                    append
+                      [U8]
+                      qName
+                      (
+                        append
+                          [U8]
+                          " arity "
+                          (append [U8] (u8ToDigits arity) newline)
+                      )
+                  )
+              )
+          )
+    }
+
+poly rec emitPrimitivesAcc =
+  \prims : List PrimitiveInfo =>
+    \acc : List U8 =>
+      matchList
+        [PrimitiveInfo]
+        [List U8]
+        prims
+        acc
+        (
+          \h : PrimitiveInfo =>
+            \t : List PrimitiveInfo => emitPrimitivesAcc t (append [U8] (emitPrimitive h) acc)
+        )
+
+poly emitPrimitives =
+  \prims : List PrimitiveInfo => emitPrimitivesAcc (reverse [PrimitiveInfo] prims) (nil [U8])
+
+poly rec insertDataEnvCtors =
+  \ctors : List ConstructorMeta =>
+    \env : DataEnv =>
+      matchList
+        [ConstructorMeta]
+        [DataEnv]
+        ctors
+        env
+        (
+          \h : ConstructorMeta =>
+            \t : List ConstructorMeta =>
+              match h [DataEnv] {
+                | MkConstructorMeta qName local alias dataName dataId symbolId tag total arity =>
+                  match env [DataEnv] {
+                    | MkDataEnv cEnv aEnv =>
+                      let info = MkCtorInfo tag total arity dataName in
+                      insertDataEnvCtors
+                        t
+                        (
+                          MkDataEnv
+                            (
+                              insert
+                                [List U8]
+                                [CtorInfo]
+                                lteListU8
+                                local
+                                info
+                                cEnv
+                            )
+                            aEnv
+                        )
+                  }
+              }
+        )
+
+poly rec ctorNamesForData =
+  \dataId : U8 =>
+    \ctors : List ConstructorMeta =>
+      matchList
+        [ConstructorMeta]
+        [List (List U8)]
+        ctors
+        (nil [List U8])
+        (
+          \h : ConstructorMeta =>
+            \t : List ConstructorMeta =>
+              match h [List (List U8)] {
+                | MkConstructorMeta qName local alias dataName hDataId symbolId tag total arity =>
+                  if [List (List U8)] (eqU8 hDataId dataId)
+                    (
+                      \u : U8 => cons [List U8] local (ctorNamesForData dataId t)
+                    )
+                    (\u : U8 => ctorNamesForData dataId t)
+              }
+        )
+
+poly rec insertDataEnvAdts =
+  \dataTypes : List DataTypeInfo =>
+    \ctors : List ConstructorMeta =>
+      \env : DataEnv =>
+        matchList
+          [DataTypeInfo]
+          [DataEnv]
+          dataTypes
+          env
+          (
+            \h : DataTypeInfo =>
+              \t : List DataTypeInfo =>
+                match h [DataEnv] {
+                  | MkDataTypeInfo qName local dataId =>
+                    match env [DataEnv] {
+                      | MkDataEnv cEnv aEnv =>
+                        let names = ctorNamesForData dataId ctors in
+                        insertDataEnvAdts
+                          t
+                          ctors
+                          (
+                            MkDataEnv
+                              cEnv
+                              (
+                                insert
+                                  [List U8]
+                                  [ADTInfo]
+                                  lteListU8
+                                  local
+                                  (MkADTInfo names)
+                                  aEnv
+                              )
+                          )
+                    }
+                }
+          )
+
+poly dataEnvFromModuleEnv =
+  \env : ModuleEnv =>
+    match env [DataEnv] {
+      | MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives prims =>
+        let emptyEnv = MkDataEnv (empty [List U8] [CtorInfo]) (empty [List U8] [ADTInfo]) in
+        insertDataEnvAdts dataTypes ctors (insertDataEnvCtors ctors emptyEnv)
+    }
+
+poly emitModuleEnvSummary =
+  \env : ModuleEnv =>
+    match env [List U8] {
+      | MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives prims =>
+        let header = append [U8] "OK\nversion module-env-v1\nmodules " (append [U8] (u8ToDigits (count [ModuleInfo] mods)) newline) in
+        let dataHeader = emitU8Line "data-types " (count [DataTypeInfo] dataTypes) in
+        let ctorHeader = emitU8Line "constructors " (count [ConstructorMeta] ctors) in
+        let aliasHeader = emitU8Line "aliases " (count [ConstructorAliasInfo] aliases) in
+        let primHeader = emitU8Line "primitives " (count [PrimitiveInfo] prims) in
+        let s0 = append [U8] header (emitModules mods imps exps defs ctors opaques natives) in
+        let s1 = append [U8] s0 dataHeader in
+        let s2 = append [U8] s1 (emitDataTypes dataTypes) in
+        let s3 = append [U8] s2 ctorHeader in
+        let s4 = append [U8] s3 (emitConstructors ctors) in
+        let s5 = append [U8] s4 aliasHeader in
+        let s6 = append [U8] s5 (emitAliases aliases) in
+        append [U8] s6 (append [U8] primHeader (emitPrimitives prims))
+    }
+
+poly emitBundleModuleEnvSummary =
+  \bundle : BundleSummary =>
+    match bundle [Result (List U8) (List U8)] {
+      | MkBundleSummary entry target wrapper modsCountDigits mods =>
+        match (buildModuleEnv mods) [Result (List U8) (List U8)] {
+          | Err e => Err [List U8] [List U8] e
+          | Ok env => Ok [List U8] [List U8] (emitModuleEnvSummary env)
+        }
+    }
+
+poly rec writeAll =
+  \bytes : List U8 =>
+    matchList [U8] [U8] bytes #u8(0) (\h : U8 => \t : List U8 => writeOne h [U8] (\u : U8 => writeAll t))
+
+poly main =
+  \source : List U8 =>
+    match (parseBundleSummary source) [U8] {
+      | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
+      | Ok bundle =>
         match (emitBundleModuleEnvSummary bundle) [U8] {
           | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
           | Ok summary => writeAll summary
         }
-  }
+    }

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -1,169 +1,331 @@
 module Parser
 
 import Prelude eqListU8
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Lexer ParseError
+
 import Lexer MkParseError
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude eqU8
+
 import Prelude ltU8
+
 import Prelude addU8
+
 import Prelude subU8
+
 import Prelude U8
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude and
+
 import Prelude or
+
 import Prelude if
+
 import Prelude reverse
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer tokenText
+
 import Lexer tokenNatValue
+
 import Lexer T_LParen
+
 import Lexer T_RParen
+
 import Lexer T_LBrace
+
 import Lexer T_RBrace
+
 import Lexer T_LBracket
+
 import Lexer T_RBracket
+
 import Lexer T_Backslash
+
 import Lexer T_Arrow
+
 import Lexer T_FatArrow
+
 import Lexer T_Eq
+
 import Lexer T_Colon
+
 import Lexer T_Hash
+
 import Lexer T_Pipe
+
 import Lexer T_Dot
+
 import Lexer T_Comma
+
 import Lexer T_KwPoly
+
 import Lexer T_KwRec
+
 import Lexer T_KwLet
+
 import Lexer T_KwIn
+
 import Lexer T_KwMatch
+
 import Lexer T_KwModule
+
 import Lexer T_KwImport
+
 import Lexer T_KwExport
+
 import Lexer T_KwNative
+
 import Lexer T_KwOpaque
+
 import Lexer T_KwCombinator
+
 import Lexer T_KwType
+
 import Lexer T_KwData
+
 import Lexer T_Ident
+
 import Lexer T_Nat
+
 import Lexer T_EOF
 
 export Pattern
+
 export P_Ctor
+
 export Expr
+
 export E_Var
+
 export E_App
+
 export E_Lam
+
 export E_Let
+
 export E_Nat
+
 export E_Match
+
 export DefKind
+
 export K_Poly
+
 export K_Combinator
+
 export Decl
+
 export D_Module
+
 export D_Import
+
 export D_Export
+
 export D_Opaque
+
 export D_Native
+
 export D_Type
+
 export D_Data
+
 export D_Def
+
 export checkedIncrementU8
+
 export expect
+
 export expectIdent
+
 export skipUntil
+
 export skipToTopLevelDecl
+
 export parseError
+
 export identTag
+
 export natTag
+
 export lParenTag
+
 export rParenTag
+
 export lBraceTag
+
 export rBraceTag
+
 export lBracketTag
+
 export rBracketTag
+
 export backslashTag
+
 export hashTag
+
 export fatArrowTag
+
 export eqTag
+
 export pipeTag
+
 export colonTag
+
 export commaTag
+
 export dotTag
+
 export eofTag
+
 export kwPolyTag
+
 export kwRecTag
+
 export kwLetTag
+
 export kwInTag
+
 export kwMatchTag
+
 export kwModuleTag
+
 export kwImportTag
+
 export kwExportTag
+
 export kwNativeTag
+
 export kwOpaqueTag
+
 export kwCombinatorTag
+
 export kwTypeTag
+
 export kwDataTag
+
 export fstNameToken
+
 export sndNameToken
+
 export fstExprToken
+
 export sndExprToken
+
 export fstArgsToken
+
 export sndArgsToken
+
 export fstPatternExprToken
+
 export sndPatternExprToken
+
 export fstArmsToken
+
 export sndArmsToken
+
 export fstDeclToken
+
 export sndDeclToken
+
 export isTopLevelStartToken
+
 export parsePatternArgs
+
 export parseMatchArm
+
 export parseMatchArms
+
 export isAtomStart
+
 export parseLiteralAtomWith
+
 export buildListExpr
+
 export parseListElements
+
 export parseBraceBodyWith
+
 export skipTypeArg
+
 export parseCtorArity
+
 export parseAtomWith
+
 export parseAppLoopWith
+
 export parseAppWith
+
 export parseAppLoopNoBraceWith
+
 export parseAppNoBraceWith
+
 export parseMatchArmWith
+
 export parseMatchArmsWith
+
 export parseAtom
+
 export parseApp
+
 export parseExpr
+
 export parseNamedDef
+
 export parseDecl
+
 export parseProgramAcc
+
 export parseProgram
+
 export Type
+
 export Ty_Var
+
 export Ty_App
+
 export Ty_Arrow
+
 export Ty_Forall
+
 export parseSimpleType
+
 export parseTypeApplication
+
 export parseType
+
 export arrowTag
 
 data Type =
@@ -200,10 +362,11 @@ data Decl =
 poly parseError =
   MkParseError "Parse error"
 
-poly checkedIncrementU8 = \n : U8 =>
-  if [Result ParseError U8] (ltU8 n #u8(255))
-    (\u : U8 => Ok [ParseError] [U8] (addU8 n #u8(1)))
-    (\u : U8 => Err [ParseError] [U8] parseError)
+poly checkedIncrementU8 =
+  \n : U8 =>
+    if [Result ParseError U8] (ltU8 n #u8(255))
+      (\u : U8 => Ok [ParseError] [U8] (addU8 n #u8(1)))
+      (\u : U8 => Err [ParseError] [U8] parseError)
 
 poly identTag =
   tokenTag (T_Ident (nil [U8]))
@@ -298,1054 +461,1830 @@ poly kwTypeTag =
 poly kwDataTag =
   tokenTag T_KwData
 
-poly fstTypeToken = \p : Pair Type (List Token) =>
-  fst [Type] [List Token] p
+poly fstTypeToken =
+  \p : Pair Type (List Token) => fst [Type] [List Token] p
 
-poly sndTypeToken = \p : Pair Type (List Token) =>
-  snd [Type] [List Token] p
+poly sndTypeToken =
+  \p : Pair Type (List Token) => snd [Type] [List Token] p
 
-poly fstNameToken = \p : Pair (List U8) (List Token) =>
-  fst [List U8] [List Token] p
+poly fstNameToken =
+  \p : Pair (List U8) (List Token) => fst [List U8] [List Token] p
 
-poly sndNameToken = \p : Pair (List U8) (List Token) =>
-  snd [List U8] [List Token] p
+poly sndNameToken =
+  \p : Pair (List U8) (List Token) => snd [List U8] [List Token] p
 
-poly fstExprToken = \p : Pair Expr (List Token) =>
-  fst [Expr] [List Token] p
+poly fstExprToken =
+  \p : Pair Expr (List Token) => fst [Expr] [List Token] p
 
-poly sndExprToken = \p : Pair Expr (List Token) =>
-  snd [Expr] [List Token] p
+poly sndExprToken =
+  \p : Pair Expr (List Token) => snd [Expr] [List Token] p
 
-poly fstArgsToken = \p : Pair (List (List U8)) (List Token) =>
-  fst [List (List U8)] [List Token] p
+poly fstArgsToken =
+  \p : Pair (List (List U8)) (List Token) => fst [List (List U8)] [List Token] p
 
-poly sndArgsToken = \p : Pair (List (List U8)) (List Token) =>
-  snd [List (List U8)] [List Token] p
+poly sndArgsToken =
+  \p : Pair (List (List U8)) (List Token) => snd [List (List U8)] [List Token] p
 
-poly fstPatternExprToken = \p : Pair (Pair Pattern Expr) (List Token) =>
-  fst [Pair Pattern Expr] [List Token] p
+poly fstPatternExprToken =
+  \p : Pair (Pair Pattern Expr) (List Token) => fst [Pair Pattern Expr] [List Token] p
 
-poly sndPatternExprToken = \p : Pair (Pair Pattern Expr) (List Token) =>
-  snd [Pair Pattern Expr] [List Token] p
+poly sndPatternExprToken =
+  \p : Pair (Pair Pattern Expr) (List Token) => snd [Pair Pattern Expr] [List Token] p
 
-poly fstArmsToken = \p : Pair (List (Pair Pattern Expr)) (List Token) =>
-  fst [List (Pair Pattern Expr)] [List Token] p
+poly fstArmsToken =
+  \p : Pair (List (Pair Pattern Expr)) (List Token) => fst [List (Pair Pattern Expr)] [List Token] p
 
-poly sndArmsToken = \p : Pair (List (Pair Pattern Expr)) (List Token) =>
-  snd [List (Pair Pattern Expr)] [List Token] p
+poly sndArmsToken =
+  \p : Pair (List (Pair Pattern Expr)) (List Token) => snd [List (Pair Pattern Expr)] [List Token] p
 
-poly fstDeclToken = \p : Pair Decl (List Token) =>
-  fst [Decl] [List Token] p
+poly fstDeclToken =
+  \p : Pair Decl (List Token) => fst [Decl] [List Token] p
 
-poly sndDeclToken = \p : Pair Decl (List Token) =>
-  snd [Decl] [List Token] p
+poly sndDeclToken =
+  \p : Pair Decl (List Token) => snd [Decl] [List Token] p
 
-poly isTopLevelStartTag = \tag : U8 =>
-  or (eqU8 tag kwPolyTag)
-     (if [Bool] (ltU8 tag #u8(21)) (\u : U8 => false) (\u : U8 =>
-      if [Bool] (ltU8 tag #u8(29)) (\u : U8 => true)  (\u : U8 => false)))
+poly isTopLevelStartTag =
+  \tag : U8 =>
+    or
+      (eqU8 tag kwPolyTag)
+      (
+        if [Bool] (ltU8 tag #u8(21))
+          (\u : U8 => false)
+          (
+            \u : U8 =>
+              if [Bool] (ltU8 tag #u8(29))
+                (\u : U8 => true)
+                (\u : U8 => false)
+          )
+      )
 
-poly isTopLevelStartToken = \tok : Token =>
-  isTopLevelStartTag (tokenTag tok)
+poly isTopLevelStartToken =
+  \tok : Token => isTopLevelStartTag (tokenTag tok)
 
-poly expect = \toks : List Token => \expectedTag : U8 =>
-  matchList [Token] [Result ParseError (List Token)] toks
-    (Err [ParseError] [List Token] parseError)
-    (\h : Token => \t : List Token =>
-      if [Result ParseError (List Token)]
-        (eqU8 (tokenTag h) expectedTag)
-        (\u : U8 => Ok [ParseError] [List Token] t)
-        (\u : U8 => Err [ParseError] [List Token] parseError)
-    )
+poly expect =
+  \toks : List Token =>
+    \expectedTag : U8 =>
+      matchList
+        [Token]
+        [Result ParseError (List Token)]
+        toks
+        (Err [ParseError] [List Token] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              if [Result ParseError (List Token)] (eqU8 (tokenTag h) expectedTag)
+                (\u : U8 => Ok [ParseError] [List Token] t)
+                (\u : U8 => Err [ParseError] [List Token] parseError)
+        )
 
-poly expectIdent = \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair (List U8) (List Token))] toks
-    (Err [ParseError] [Pair (List U8) (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      if [Result ParseError (Pair (List U8) (List Token))]
-        (eqU8 (tokenTag h) identTag)
-        (\u : U8 =>
-          Ok [ParseError] [Pair (List U8) (List Token)]
-            (MkPair [List U8] [List Token] (tokenText h) t))
-        (\u : U8 =>
-          Err [ParseError] [Pair (List U8) (List Token)] parseError)
-    )
+poly expectIdent =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (Pair (List U8) (List Token))]
+      toks
+      (Err [ParseError] [Pair (List U8) (List Token)] parseError)
+      (
+        \h : Token =>
+          \t : List Token =>
+            if [Result ParseError (Pair (List U8) (List Token))] (eqU8 (tokenTag h) identTag)
+              (
+                \u : U8 =>
+                  Ok
+                    [ParseError]
+                    [Pair (List U8) (List Token)]
+                    (MkPair [List U8] [List Token] (tokenText h) t)
+              )
+              (
+                \u : U8 => Err [ParseError] [Pair (List U8) (List Token)] parseError
+              )
+      )
 
-poly rec skipAfter = \toks : List Token => \targetTag : U8 =>
-  matchList [Token] [Result ParseError (List Token)] toks
-    (Err [ParseError] [List Token] parseError)
-    (\h : Token => \t : List Token =>
-      if [Result ParseError (List Token)]
-        (eqU8 (tokenTag h) targetTag)
-        (\u : U8 => Ok [ParseError] [List Token] t)
-        (\u : U8 => skipAfter t targetTag)
-    )
+poly rec skipAfter =
+  \toks : List Token =>
+    \targetTag : U8 =>
+      matchList
+        [Token]
+        [Result ParseError (List Token)]
+        toks
+        (Err [ParseError] [List Token] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              if [Result ParseError (List Token)] (eqU8 (tokenTag h) targetTag)
+                (\u : U8 => Ok [ParseError] [List Token] t)
+                (\u : U8 => skipAfter t targetTag)
+        )
 
-poly rec skipUntil = \toks : List Token => \targetTag : U8 =>
-  matchList [Token] [Result ParseError (List Token)] toks
-    (Err [ParseError] [List Token] parseError)
-    (\h : Token => \t : List Token =>
-      if [Result ParseError (List Token)]
-        (eqU8 (tokenTag h) targetTag)
-        (\u : U8 => Ok [ParseError] [List Token] toks)
-        (\u : U8 => skipUntil t targetTag)
-    )
+poly rec skipUntil =
+  \toks : List Token =>
+    \targetTag : U8 =>
+      matchList
+        [Token]
+        [Result ParseError (List Token)]
+        toks
+        (Err [ParseError] [List Token] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              if [Result ParseError (List Token)] (eqU8 (tokenTag h) targetTag)
+                (\u : U8 => Ok [ParseError] [List Token] toks)
+                (\u : U8 => skipUntil t targetTag)
+        )
 
-poly rec skipToTopLevelDecl = \toks : List Token =>
-  matchList [Token] [Result ParseError (List Token)] toks
-    (Ok [ParseError] [List Token] (nil [Token]))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (List Token)] (eqU8 tag eofTag)
-        (\u : U8 => Ok [ParseError] [List Token] toks)
-        (\u : U8 =>
-          if [Result ParseError (List Token)] (isTopLevelStartTag tag)
-            (\u : U8 => Ok [ParseError] [List Token] toks)
-            (\u : U8 => skipToTopLevelDecl t))
-    )
+poly rec skipToTopLevelDecl =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (List Token)]
+      toks
+      (Ok [ParseError] [List Token] (nil [Token]))
+      (
+        \h : Token =>
+          \t : List Token =>
+            let tag = tokenTag h in
+            if [Result ParseError (List Token)] (eqU8 tag eofTag)
+              (\u : U8 => Ok [ParseError] [List Token] toks)
+              (
+                \u : U8 =>
+                  if [Result ParseError (List Token)] (isTopLevelStartTag tag)
+                    (\u : U8 => Ok [ParseError] [List Token] toks)
+                    (\u : U8 => skipToTopLevelDecl t)
+              )
+      )
 
-poly rec parsePatternArgs = \toks : List Token => \acc : List (List U8) =>
-  matchList [Token] [Result ParseError (Pair (List (List U8)) (List Token))] toks
-    (Err [ParseError] [Pair (List (List U8)) (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair (List (List U8)) (List Token))]
-        (eqU8 tag fatArrowTag)
-        (\u : U8 =>
-          Ok [ParseError] [Pair (List (List U8)) (List Token)]
-            (MkPair [List (List U8)] [List Token] (reverse [List U8] acc) toks))
-        (\u : U8 =>
-          if [Result ParseError (Pair (List (List U8)) (List Token))]
-            (eqU8 tag identTag)
-            (\u : U8 =>
-              parsePatternArgs t (cons [List U8] (tokenText h) acc))
-            (\u : U8 =>
-              Err [ParseError] [Pair (List (List U8)) (List Token)] parseError))
-    )
+poly rec parsePatternArgs =
+  \toks : List Token =>
+    \acc : List (List U8) =>
+      matchList
+        [Token]
+        [Result ParseError (Pair (List (List U8)) (List Token))]
+        toks
+        (Err [ParseError] [Pair (List (List U8)) (List Token)] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair (List (List U8)) (List Token))] (eqU8 tag fatArrowTag)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair (List (List U8)) (List Token)]
+                      (
+                        MkPair
+                          [List (List U8)]
+                          [List Token]
+                          (reverse [List U8] acc)
+                          toks
+                      )
+                )
+                (
+                  \u : U8 =>
+                    if [Result ParseError (Pair (List (List U8)) (List Token))] (eqU8 tag identTag)
+                      (
+                        \u : U8 => parsePatternArgs t (cons [List U8] (tokenText h) acc)
+                      )
+                      (
+                        \u : U8 =>
+                          Err
+                            [ParseError]
+                            [Pair (List (List U8)) (List Token)]
+                            parseError
+                      )
+                )
+        )
 
-poly parseMatchArmWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
-  match (expect toks pipeTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
-    | Err e => Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
-    | Ok afterPipe =>
-      match (expectIdent afterPipe) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
-        | Err e => Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
-        | Ok ctorRes =>
-          let ctorName = fstNameToken ctorRes in
-          let afterCtor = sndNameToken ctorRes in
-          match (parsePatternArgs afterCtor (nil [List U8])) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
-            | Err e => Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
-            | Ok argRes =>
-              let args = fstArgsToken argRes in
-              let atArrow = sndArgsToken argRes in
-              match (expect atArrow fatArrowTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
-                | Err e => Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
-                | Ok bodyToks =>
-                  match (recurse bodyToks) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
-                    | Err e => Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
-                    | Ok bodyRes =>
-                      let body = fstExprToken bodyRes in
-                      let rest = sndExprToken bodyRes in
-                      Ok [ParseError] [Pair (Pair Pattern Expr) (List Token)]
-                        (MkPair [Pair Pattern Expr] [List Token]
-                          (MkPair [Pattern] [Expr] (P_Ctor ctorName args) body)
-                          rest)
+poly parseMatchArmWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      match (expect toks pipeTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+        | Err e =>
+          Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+        | Ok afterPipe =>
+          match (expectIdent afterPipe) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+            | Err e =>
+              Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+            | Ok ctorRes =>
+              let ctorName = fstNameToken ctorRes in
+              let afterCtor = sndNameToken ctorRes in
+              match (parsePatternArgs afterCtor (nil [List U8])) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+                | Err e =>
+                  Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+                | Ok argRes =>
+                  let args = fstArgsToken argRes in
+                  let atArrow = sndArgsToken argRes in
+                  match (expect atArrow fatArrowTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+                    | Err e =>
+                      Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+                    | Ok bodyToks =>
+                      match (recurse bodyToks) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+                        | Err e =>
+                          Err
+                            [ParseError]
+                            [Pair (Pair Pattern Expr) (List Token)]
+                            e
+                        | Ok bodyRes =>
+                          let body = fstExprToken bodyRes in
+                          let rest = sndExprToken bodyRes in
+                          Ok
+                            [ParseError]
+                            [Pair (Pair Pattern Expr) (List Token)]
+                            (
+                              MkPair
+                                [Pair Pattern Expr]
+                                [List Token]
+                                (
+                                  MkPair
+                                    [Pattern]
+                                    [Expr]
+                                    (P_Ctor ctorName args)
+                                    body
+                                )
+                                rest
+                            )
+                      }
                   }
               }
           }
       }
-  }
 
-poly rec parseMatchArmsWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token => \acc : List (Pair Pattern Expr) =>
-  matchList [Token] [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] toks
-    (Err [ParseError] [Pair (List (Pair Pattern Expr)) (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
-        (eqU8 tag rBraceTag)
-        (\u : U8 =>
-          Ok [ParseError] [Pair (List (Pair Pattern Expr)) (List Token)]
-            (MkPair [List (Pair Pattern Expr)] [List Token] (reverse [Pair Pattern Expr] acc) t))
-        (\u : U8 =>
-          if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
-            (eqU8 tag pipeTag)
-            (\u : U8 =>
-              match (parseMatchArmWith recurse toks) [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] {
-                | Err e => Err [ParseError] [Pair (List (Pair Pattern Expr)) (List Token)] e
-                | Ok armRes =>
-                  let arm = fstPatternExprToken armRes in
-                  let rest = sndPatternExprToken armRes in
-                  parseMatchArmsWith recurse rest (cons [Pair Pattern Expr] arm acc)
-              })
-            (\u : U8 =>
-              Err [ParseError] [Pair (List (Pair Pattern Expr)) (List Token)] parseError))
-    )
+poly rec parseMatchArmsWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      \acc : List (Pair Pattern Expr) =>
+        matchList
+          [Token]
+          [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
+          toks
+          (
+            Err
+              [ParseError]
+              [Pair (List (Pair Pattern Expr)) (List Token)]
+              parseError
+          )
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] (eqU8 tag rBraceTag)
+                  (
+                    \u : U8 =>
+                      Ok
+                        [ParseError]
+                        [Pair (List (Pair Pattern Expr)) (List Token)]
+                        (
+                          MkPair
+                            [List (Pair Pattern Expr)]
+                            [List Token]
+                            (reverse [Pair Pattern Expr] acc)
+                            t
+                        )
+                  )
+                  (
+                    \u : U8 =>
+                      if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] (eqU8 tag pipeTag)
+                        (
+                          \u : U8 =>
+                            match (parseMatchArmWith recurse toks) [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] {
+                              | Err e =>
+                                Err
+                                  [ParseError]
+                                  [Pair (List (Pair Pattern Expr)) (List Token)]
+                                  e
+                              | Ok armRes =>
+                                let arm = fstPatternExprToken armRes in
+                                let rest = sndPatternExprToken armRes in
+                                parseMatchArmsWith
+                                  recurse
+                                  rest
+                                  (cons [Pair Pattern Expr] arm acc)
+                            }
+                        )
+                        (
+                          \u : U8 =>
+                            Err
+                              [ParseError]
+                              [Pair (List (Pair Pattern Expr)) (List Token)]
+                              parseError
+                        )
+                  )
+          )
 
-poly isAtomStartTag = \tag : U8 =>
-  if [Bool]
-    (eqU8 tag identTag)
-    (\u : U8 => true)
-    (\u : U8 =>
-      if [Bool]
-        (eqU8 tag natTag)
-        (\u : U8 => true)
-        (\u : U8 =>
-          if [Bool] (eqU8 tag lParenTag)
+poly isAtomStartTag =
+  \tag : U8 =>
+    if [Bool] (eqU8 tag identTag)
+      (\u : U8 => true)
+      (
+        \u : U8 =>
+          if [Bool] (eqU8 tag natTag)
             (\u : U8 => true)
-            (\u : U8 =>
-              if [Bool] (eqU8 tag commaTag)
-                (\u : U8 => true)
-                (\u : U8 =>
-                  if [Bool] (eqU8 tag dotTag)
-                    (\u : U8 => true)
-                    (\u : U8 =>
-                      if [Bool] (eqU8 tag hashTag)
+            (
+              \u : U8 =>
+                if [Bool] (eqU8 tag lParenTag)
+                  (\u : U8 => true)
+                  (
+                    \u : U8 =>
+                      if [Bool] (eqU8 tag commaTag)
                         (\u : U8 => true)
-                        (\u : U8 => eqU8 tag lBraceTag))))))
-
-poly isAtomStart = \tok : Token =>
-  isAtomStartTag (tokenTag tok)
-
-poly rec buildListExpr = \elements : List Expr =>
-  matchList [Expr] [Expr] elements
-    (E_Var "nil")
-    (\h : Expr => \t : List Expr =>
-      E_App (E_App (E_Var "cons") h) (buildListExpr t))
-
-poly parseLiteralAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
-    (Err [ParseError] [Pair Expr (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag identTag)
-        (\u : U8 =>
-          Ok [ParseError] [Pair Expr (List Token)]
-            (MkPair [Expr] [List Token] (E_Var (tokenText h)) t))
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-            (eqU8 tag natTag)
-            (\u : U8 =>
-              Ok [ParseError] [Pair Expr (List Token)]
-                (MkPair [Expr] [List Token] (E_Nat (tokenNatValue h)) t))
-            (\u : U8 =>
-              if [Result ParseError (Pair Expr (List Token))]
-                (eqU8 tag lParenTag)
-                (\u : U8 =>
-                  match (recurse t) [Result ParseError (Pair Expr (List Token))] {
-                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok res =>
-                      let inner = fstExprToken res in
-                      let rest = sndExprToken res in
-                      match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok final =>
-                          Ok [ParseError] [Pair Expr (List Token)]
-                            (MkPair [Expr] [List Token] inner final)
-                      }
-                  })
-                (\u : U8 =>
-                  if [Result ParseError (Pair Expr (List Token))]
-                    (eqU8 tag commaTag)
-                    (\u : U8 =>
-                      Ok [ParseError] [Pair Expr (List Token)]
-                        (MkPair [Expr] [List Token] (E_Var ",") t))
-                    (\u : U8 =>
-                      if [Result ParseError (Pair Expr (List Token))]
-                        (eqU8 tag dotTag)
-                        (\u : U8 =>
-                          Ok [ParseError] [Pair Expr (List Token)]
-                            (MkPair [Expr] [List Token] (E_Var ".") t))
-                        (\u : U8 =>
-                          if [Result ParseError (Pair Expr (List Token))]
-                            (eqU8 tag hashTag)
-                            (\u : U8 =>
-                              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                | Ok tvRes =>
-                                  match tvRes [Result ParseError (Pair Expr (List Token))] {
-                                    | MkPair tyVar afterTyVar =>
-                                      if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                                        (\u : U8 =>
-                                          match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                            | Ok afterOpen =>
-                                              matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen
-                                                (Err [ParseError] [Pair Expr (List Token)] parseError)
-                                                (\natTok : Token => \afterNat : List Token =>
-                                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                                    (\u : U8 =>
-                                                      match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                        | Ok rest =>
-                                                          Ok [ParseError] [Pair Expr (List Token)]
-                                                            (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)
-                                                      })
-                                                    (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
-                                          })
-                                        (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)
-                                  }
-                              })
-                            (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
-                    )
-                )
+                        (
+                          \u : U8 =>
+                            if [Bool] (eqU8 tag dotTag)
+                              (\u : U8 => true)
+                              (
+                                \u : U8 =>
+                                  if [Bool] (eqU8 tag hashTag)
+                                    (\u : U8 => true)
+                                    (\u : U8 => eqU8 tag lBraceTag)
+                              )
+                        )
+                  )
             )
+      )
+
+poly isAtomStart =
+  \tok : Token => isAtomStartTag (tokenTag tok)
+
+poly rec buildListExpr =
+  \elements : List Expr =>
+    matchList
+      [Expr]
+      [Expr]
+      elements
+      (E_Var "nil")
+      (
+        \h : Expr =>
+          \t : List Expr => E_App (E_App (E_Var "cons") h) (buildListExpr t)
+      )
+
+poly parseLiteralAtomWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      matchList
+        [Token]
+        [Result ParseError (Pair Expr (List Token))]
+        toks
+        (Err [ParseError] [Pair Expr (List Token)] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag identTag)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair Expr (List Token)]
+                      (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)
+                )
+                (
+                  \u : U8 =>
+                    if [Result ParseError (Pair Expr (List Token))] (eqU8 tag natTag)
+                      (
+                        \u : U8 =>
+                          Ok
+                            [ParseError]
+                            [Pair Expr (List Token)]
+                            (
+                              MkPair
+                                [Expr]
+                                [List Token]
+                                (E_Nat (tokenNatValue h))
+                                t
+                            )
+                      )
+                      (
+                        \u : U8 =>
+                          if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lParenTag)
+                            (
+                              \u : U8 =>
+                                match (recurse t) [Result ParseError (Pair Expr (List Token))] {
+                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                  | Ok res =>
+                                    let inner = fstExprToken res in
+                                    let rest = sndExprToken res in
+                                    match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                      | Ok final =>
+                                        Ok
+                                          [ParseError]
+                                          [Pair Expr (List Token)]
+                                          (
+                                            MkPair
+                                              [Expr]
+                                              [List Token]
+                                              inner
+                                              final
+                                          )
+                                    }
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag commaTag)
+                                  (
+                                    \u : U8 =>
+                                      Ok
+                                        [ParseError]
+                                        [Pair Expr (List Token)]
+                                        (
+                                          MkPair
+                                            [Expr]
+                                            [List Token]
+                                            (E_Var ",")
+                                            t
+                                        )
+                                  )
+                                  (
+                                    \u : U8 =>
+                                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag dotTag)
+                                        (
+                                          \u : U8 =>
+                                            Ok
+                                              [ParseError]
+                                              [Pair Expr (List Token)]
+                                              (
+                                                MkPair
+                                                  [Expr]
+                                                  [List Token]
+                                                  (E_Var ".")
+                                                  t
+                                              )
+                                        )
+                                        (
+                                          \u : U8 =>
+                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
+                                              (
+                                                \u : U8 =>
+                                                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
+                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                    | Ok tvRes =>
+                                                      match tvRes [Result ParseError (Pair Expr (List Token))] {
+                                                        | MkPair tyVar afterTyVar =>
+                                                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
+                                                            (
+                                                              \u : U8 =>
+                                                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                                  | Ok afterOpen =>
+                                                                    matchList
+                                                                      [Token]
+                                                                      [Result ParseError (Pair Expr (List Token))]
+                                                                      afterOpen
+                                                                      (
+                                                                        Err
+                                                                          [ParseError]
+                                                                          [Pair Expr (List Token)]
+                                                                          parseError
+                                                                      )
+                                                                      (
+                                                                        \natTok : Token =>
+                                                                          \afterNat : List Token =>
+                                                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
+                                                                              (
+                                                                                \u : U8 =>
+                                                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                                                    | Ok rest =>
+                                                                                      Ok
+                                                                                        [ParseError]
+                                                                                        [Pair Expr (List Token)]
+                                                                                        (
+                                                                                          MkPair
+                                                                                            [Expr]
+                                                                                            [List Token]
+                                                                                            (
+                                                                                              E_Nat
+                                                                                                (
+                                                                                                  tokenNatValue
+                                                                                                    natTok
+                                                                                                )
+                                                                                            )
+                                                                                            rest
+                                                                                        )
+                                                                                  }
+                                                                              )
+                                                                              (
+                                                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                                                              )
+                                                                      )
+                                                                }
+                                                            )
+                                                            (
+                                                              \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                                            )
+                                                      }
+                                                  }
+                                              )
+                                              (
+                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                              )
+                                        )
+                                  )
+                            )
+                      )
+                )
         )
-    )
 
-poly rec parseListElements = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token => \acc : List Expr =>
-  matchList [Token] [Result ParseError (Pair (List Expr) (List Token))] toks
-    (Err [ParseError] [Pair (List Expr) (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair (List Expr) (List Token))] (eqU8 tag rBraceTag)
-        (\u : U8 => Ok [ParseError] [Pair (List Expr) (List Token)] (MkPair [List Expr] [List Token] (reverse [Expr] acc) t))
-        (\u : U8 =>
-          match (parseLiteralAtomWith recurse toks) [Result ParseError (Pair (List Expr) (List Token))] {
-            | Err e => Err [ParseError] [Pair (List Expr) (List Token)] e
-            | Ok elemRes =>
-                let elem = fstExprToken elemRes in
-                let rest = sndExprToken elemRes in
-                parseListElements recurse rest (cons [Expr] elem acc)
-          })
-    )
+poly rec parseListElements =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      \acc : List Expr =>
+        matchList
+          [Token]
+          [Result ParseError (Pair (List Expr) (List Token))]
+          toks
+          (Err [ParseError] [Pair (List Expr) (List Token)] parseError)
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                if [Result ParseError (Pair (List Expr) (List Token))] (eqU8 tag rBraceTag)
+                  (
+                    \u : U8 =>
+                      Ok
+                        [ParseError]
+                        [Pair (List Expr) (List Token)]
+                        (MkPair [List Expr] [List Token] (reverse [Expr] acc) t)
+                  )
+                  (
+                    \u : U8 =>
+                      match (parseLiteralAtomWith recurse toks) [Result ParseError (Pair (List Expr) (List Token))] {
+                        | Err e => Err [ParseError] [Pair (List Expr) (List Token)] e
+                        | Ok elemRes =>
+                          let elem = fstExprToken elemRes in
+                          let rest = sndExprToken elemRes in
+                          parseListElements recurse rest (cons [Expr] elem acc)
+                      }
+                  )
+          )
 
-poly parseBraceBodyWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \afterBrace : List Token =>
-  match (parseType afterBrace) [Result ParseError (Pair Expr (List Token))] {
-    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-    | Ok type1Res =>
-        let afterType1 = sndTypeToken type1Res in
-        matchList [Token] [Result ParseError (Pair Expr (List Token))] afterType1
-          (Err [ParseError] [Pair Expr (List Token)] parseError)
-          (\h : Token => \t : List Token =>
-            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag h) commaTag)
-              (\u : U8 =>
-                match (parseType t) [Result ParseError (Pair Expr (List Token))] {
-                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                  | Ok type2Res =>
-                      let afterType2 = sndTypeToken type2Res in
-                      match (expect afterType2 pipeTag) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok afterPipe =>
-                            match (parseLiteralAtomWith recurse afterPipe) [Result ParseError (Pair Expr (List Token))] {
+poly parseBraceBodyWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \afterBrace : List Token =>
+      match (parseType afterBrace) [Result ParseError (Pair Expr (List Token))] {
+        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+        | Ok type1Res =>
+          let afterType1 = sndTypeToken type1Res in
+          matchList
+            [Token]
+            [Result ParseError (Pair Expr (List Token))]
+            afterType1
+            (Err [ParseError] [Pair Expr (List Token)] parseError)
+            (
+              \h : Token =>
+                \t : List Token =>
+                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag h) commaTag)
+                    (
+                      \u : U8 =>
+                        match (parseType t) [Result ParseError (Pair Expr (List Token))] {
+                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                          | Ok type2Res =>
+                            let afterType2 = sndTypeToken type2Res in
+                            match (expect afterType2 pipeTag) [Result ParseError (Pair Expr (List Token))] {
                               | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                              | Ok firstRes =>
-                                  let first = fstExprToken firstRes in
-                                  let afterFirst = sndExprToken firstRes in
-                                  match (expect afterFirst commaTag) [Result ParseError (Pair Expr (List Token))] {
-                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                    | Ok afterComma =>
+                              | Ok afterPipe =>
+                                match (parseLiteralAtomWith recurse afterPipe) [Result ParseError (Pair Expr (List Token))] {
+                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                  | Ok firstRes =>
+                                    let first = fstExprToken firstRes in
+                                    let afterFirst = sndExprToken firstRes in
+                                    match (expect afterFirst commaTag) [Result ParseError (Pair Expr (List Token))] {
+                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                      | Ok afterComma =>
                                         match (parseLiteralAtomWith recurse afterComma) [Result ParseError (Pair Expr (List Token))] {
                                           | Err e => Err [ParseError] [Pair Expr (List Token)] e
                                           | Ok secondRes =>
-                                              let second = fstExprToken secondRes in
-                                              let afterSecond = sndExprToken secondRes in
-                                              match (expect afterSecond rBraceTag) [Result ParseError (Pair Expr (List Token))] {
-                                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                | Ok rest =>
-                                                    Ok [ParseError] [Pair Expr (List Token)]
-                                                      (MkPair [Expr] [List Token]
-                                                        (E_App (E_App (E_Var "MkPair") first) second)
-                                                        rest)
-                                              }
+                                            let second = fstExprToken secondRes in
+                                            let afterSecond = sndExprToken secondRes in
+                                            match (expect afterSecond rBraceTag) [Result ParseError (Pair Expr (List Token))] {
+                                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                              | Ok rest =>
+                                                Ok
+                                                  [ParseError]
+                                                  [Pair Expr (List Token)]
+                                                  (
+                                                    MkPair
+                                                      [Expr]
+                                                      [List Token]
+                                                      (
+                                                        E_App
+                                                          (
+                                                            E_App
+                                                              (E_Var "MkPair")
+                                                              first
+                                                          )
+                                                          second
+                                                      )
+                                                      rest
+                                                  )
+                                            }
                                         }
-                                  }
+                                    }
+                                }
                             }
-                      }
-                })
-              (\u : U8 =>
-                match (expect afterType1 pipeTag) [Result ParseError (Pair Expr (List Token))] {
-                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                  | Ok afterPipe =>
-                      match (parseListElements recurse afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok listRes =>
-                            let elements = fst [List Expr] [List Token] listRes in
-                            let rest = snd [List Expr] [List Token] listRes in
-                            Ok [ParseError] [Pair Expr (List Token)]
-                              (MkPair [Expr] [List Token] (buildListExpr elements) rest)
-                      }
-                }))
-  }
-
-poly parseAtomWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
-    (Err [ParseError] [Pair Expr (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag identTag)
-        (\u : U8 =>
-          Ok [ParseError] [Pair Expr (List Token)]
-            (MkPair [Expr] [List Token] (E_Var (tokenText h)) t))
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-            (eqU8 tag natTag)
-            (\u : U8 =>
-              Ok [ParseError] [Pair Expr (List Token)]
-                (MkPair [Expr] [List Token] (E_Nat (tokenNatValue h)) t))
-            (\u : U8 =>
-              if [Result ParseError (Pair Expr (List Token))]
-                (eqU8 tag lParenTag)
-                (\u : U8 =>
-                  match (recurse t) [Result ParseError (Pair Expr (List Token))] {
-                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok res =>
-                      let inner = fstExprToken res in
-                      let rest = sndExprToken res in
-                      match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok final =>
-                          Ok [ParseError] [Pair Expr (List Token)]
-                            (MkPair [Expr] [List Token] inner final)
-                      }
-                  })
-                (\u : U8 =>
-                  if [Result ParseError (Pair Expr (List Token))]
-                    (eqU8 tag commaTag)
-                    (\u : U8 =>
-                      Ok [ParseError] [Pair Expr (List Token)]
-                        (MkPair [Expr] [List Token] (E_Var ",") t))
-                    (\u : U8 =>
-                      if [Result ParseError (Pair Expr (List Token))]
-                        (eqU8 tag dotTag)
-                        (\u : U8 =>
-                          Ok [ParseError] [Pair Expr (List Token)]
-                            (MkPair [Expr] [List Token] (E_Var ".") t))
-                        (\u : U8 =>
-                          if [Result ParseError (Pair Expr (List Token))]
-                            (eqU8 tag hashTag)
-                            (\u : U8 =>
-                              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                | Ok tvRes =>
-                                  match tvRes [Result ParseError (Pair Expr (List Token))] {
-                                    | MkPair tyVar afterTyVar =>
-                                      if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                                        (\u : U8 =>
-                                          match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                            | Ok afterOpen =>
-                                              matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen
-                                                (Err [ParseError] [Pair Expr (List Token)] parseError)
-                                                (\natTok : Token => \afterNat : List Token =>
-                                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                                    (\u : U8 =>
-                                                      match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                        | Ok rest =>
-                                                          Ok [ParseError] [Pair Expr (List Token)]
-                                                            (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)
-                                                      })
-                                                    (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
-                                          })
-                                        (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)
-                                  }
-                              })
-                            (\u : U8 =>
-                              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
-                                (\u : U8 => parseBraceBodyWith recurse t)
-                                (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)))
+                        }
                     )
-                )
+                    (
+                      \u : U8 =>
+                        match (expect afterType1 pipeTag) [Result ParseError (Pair Expr (List Token))] {
+                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                          | Ok afterPipe =>
+                            match (parseListElements recurse afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
+                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                              | Ok listRes =>
+                                let elements = fst [List Expr] [List Token] listRes in
+                                let rest = snd [List Expr] [List Token] listRes in
+                                Ok
+                                  [ParseError]
+                                  [Pair Expr (List Token)]
+                                  (
+                                    MkPair
+                                      [Expr]
+                                      [List Token]
+                                      (buildListExpr elements)
+                                      rest
+                                  )
+                            }
+                        }
+                    )
             )
+      }
+
+poly parseAtomWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      matchList
+        [Token]
+        [Result ParseError (Pair Expr (List Token))]
+        toks
+        (Err [ParseError] [Pair Expr (List Token)] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag identTag)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair Expr (List Token)]
+                      (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)
+                )
+                (
+                  \u : U8 =>
+                    if [Result ParseError (Pair Expr (List Token))] (eqU8 tag natTag)
+                      (
+                        \u : U8 =>
+                          Ok
+                            [ParseError]
+                            [Pair Expr (List Token)]
+                            (
+                              MkPair
+                                [Expr]
+                                [List Token]
+                                (E_Nat (tokenNatValue h))
+                                t
+                            )
+                      )
+                      (
+                        \u : U8 =>
+                          if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lParenTag)
+                            (
+                              \u : U8 =>
+                                match (recurse t) [Result ParseError (Pair Expr (List Token))] {
+                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                  | Ok res =>
+                                    let inner = fstExprToken res in
+                                    let rest = sndExprToken res in
+                                    match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                      | Ok final =>
+                                        Ok
+                                          [ParseError]
+                                          [Pair Expr (List Token)]
+                                          (
+                                            MkPair
+                                              [Expr]
+                                              [List Token]
+                                              inner
+                                              final
+                                          )
+                                    }
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag commaTag)
+                                  (
+                                    \u : U8 =>
+                                      Ok
+                                        [ParseError]
+                                        [Pair Expr (List Token)]
+                                        (
+                                          MkPair
+                                            [Expr]
+                                            [List Token]
+                                            (E_Var ",")
+                                            t
+                                        )
+                                  )
+                                  (
+                                    \u : U8 =>
+                                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag dotTag)
+                                        (
+                                          \u : U8 =>
+                                            Ok
+                                              [ParseError]
+                                              [Pair Expr (List Token)]
+                                              (
+                                                MkPair
+                                                  [Expr]
+                                                  [List Token]
+                                                  (E_Var ".")
+                                                  t
+                                              )
+                                        )
+                                        (
+                                          \u : U8 =>
+                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
+                                              (
+                                                \u : U8 =>
+                                                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
+                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                    | Ok tvRes =>
+                                                      match tvRes [Result ParseError (Pair Expr (List Token))] {
+                                                        | MkPair tyVar afterTyVar =>
+                                                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
+                                                            (
+                                                              \u : U8 =>
+                                                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                                  | Ok afterOpen =>
+                                                                    matchList
+                                                                      [Token]
+                                                                      [Result ParseError (Pair Expr (List Token))]
+                                                                      afterOpen
+                                                                      (
+                                                                        Err
+                                                                          [ParseError]
+                                                                          [Pair Expr (List Token)]
+                                                                          parseError
+                                                                      )
+                                                                      (
+                                                                        \natTok : Token =>
+                                                                          \afterNat : List Token =>
+                                                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
+                                                                              (
+                                                                                \u : U8 =>
+                                                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                                                    | Ok rest =>
+                                                                                      Ok
+                                                                                        [ParseError]
+                                                                                        [Pair Expr (List Token)]
+                                                                                        (
+                                                                                          MkPair
+                                                                                            [Expr]
+                                                                                            [List Token]
+                                                                                            (
+                                                                                              E_Nat
+                                                                                                (
+                                                                                                  tokenNatValue
+                                                                                                    natTok
+                                                                                                )
+                                                                                            )
+                                                                                            rest
+                                                                                        )
+                                                                                  }
+                                                                              )
+                                                                              (
+                                                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                                                              )
+                                                                      )
+                                                                }
+                                                            )
+                                                            (
+                                                              \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                                            )
+                                                      }
+                                                  }
+                                              )
+                                              (
+                                                \u : U8 =>
+                                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
+                                                    (
+                                                      \u : U8 => parseBraceBodyWith recurse t
+                                                    )
+                                                    (
+                                                      \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                                    )
+                                              )
+                                        )
+                                  )
+                            )
+                      )
+                )
         )
-    )
-poly skipTypeArg = \toks : List Token =>
-  match (expect toks lBracketTag) [Result ParseError (List Token)] {
-    | Err e => Err [ParseError] [List Token] e
-    | Ok afterOpen =>
-      skipAfter afterOpen rBracketTag
-  }
 
-poly parseSimpleTypeWith = \recurse : (List Token -> Result ParseError (Pair Type (List Token))) => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Type (List Token))] toks
-    (Err [ParseError] [Pair Type (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Type (List Token))]
-        (eqU8 tag lParenTag)
-        (\u : U8 =>
-          match (recurse t) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair Type (List Token)] e
-            | Ok res =>
-              let inner = fstTypeToken res in
-              let afterInner = sndTypeToken res in
-              matchList [Token] [Result ParseError (Pair Type (List Token))] afterInner
-                (Err [ParseError] [Pair Type (List Token)] parseError)
-                (\h2 : Token => \t2 : List Token =>
-                  if [Result ParseError (Pair Type (List Token))]
-                    (eqU8 (tokenTag h2) commaTag)
-                    (\u : U8 =>
-                      match (recurse t2) [Result ParseError (Pair Type (List Token))] {
-                        | Err e => Err [ParseError] [Pair Type (List Token)] e
-                        | Ok res2 =>
-                          let second = fstTypeToken res2 in
-                          let afterSecond = sndTypeToken res2 in
-                          match (expect afterSecond rParenTag) [Result ParseError (Pair Type (List Token))] {
-                            | Err e => Err [ParseError] [Pair Type (List Token)] e
-                            | Ok final =>
-                              Ok [ParseError] [Pair Type (List Token)]
-                                (MkPair [Type] [List Token]
-                                  (Ty_App (Ty_App (Ty_Var "Pair") inner) second)
-                                  final)
-                          }
-                      })
-                    (\u : U8 =>
-                      match (expect afterInner rParenTag) [Result ParseError (Pair Type (List Token))] {
-                        | Err e => Err [ParseError] [Pair Type (List Token)] e
-                        | Ok final => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] inner final)
-                      }))
-          })
-        (\u : U8 =>
-          if [Result ParseError (Pair Type (List Token))]
-            (eqU8 tag identTag)
-            (\u : U8 => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] (Ty_Var (tokenText h)) t))
-            (\u : U8 => Err [ParseError] [Pair Type (List Token)] parseError)
+poly skipTypeArg =
+  \toks : List Token =>
+    match (expect toks lBracketTag) [Result ParseError (List Token)] {
+      | Err e => Err [ParseError] [List Token] e
+      | Ok afterOpen => skipAfter afterOpen rBracketTag
+    }
+
+poly parseSimpleTypeWith =
+  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+    \toks : List Token =>
+      matchList
+        [Token]
+        [Result ParseError (Pair Type (List Token))]
+        toks
+        (Err [ParseError] [Pair Type (List Token)] parseError)
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair Type (List Token))] (eqU8 tag lParenTag)
+                (
+                  \u : U8 =>
+                    match (recurse t) [Result ParseError (Pair Type (List Token))] {
+                      | Err e => Err [ParseError] [Pair Type (List Token)] e
+                      | Ok res =>
+                        let inner = fstTypeToken res in
+                        let afterInner = sndTypeToken res in
+                        matchList
+                          [Token]
+                          [Result ParseError (Pair Type (List Token))]
+                          afterInner
+                          (Err [ParseError] [Pair Type (List Token)] parseError)
+                          (
+                            \h2 : Token =>
+                              \t2 : List Token =>
+                                if [Result ParseError (Pair Type (List Token))] (eqU8 (tokenTag h2) commaTag)
+                                  (
+                                    \u : U8 =>
+                                      match (recurse t2) [Result ParseError (Pair Type (List Token))] {
+                                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                                        | Ok res2 =>
+                                          let second = fstTypeToken res2 in
+                                          let afterSecond = sndTypeToken res2 in
+                                          match (expect afterSecond rParenTag) [Result ParseError (Pair Type (List Token))] {
+                                            | Err e => Err [ParseError] [Pair Type (List Token)] e
+                                            | Ok final =>
+                                              Ok
+                                                [ParseError]
+                                                [Pair Type (List Token)]
+                                                (
+                                                  MkPair
+                                                    [Type]
+                                                    [List Token]
+                                                    (
+                                                      Ty_App
+                                                        (
+                                                          Ty_App
+                                                            (Ty_Var "Pair")
+                                                            inner
+                                                        )
+                                                        second
+                                                    )
+                                                    final
+                                                )
+                                          }
+                                      }
+                                  )
+                                  (
+                                    \u : U8 =>
+                                      match (expect afterInner rParenTag) [Result ParseError (Pair Type (List Token))] {
+                                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                                        | Ok final =>
+                                          Ok
+                                            [ParseError]
+                                            [Pair Type (List Token)]
+                                            (
+                                              MkPair
+                                                [Type]
+                                                [List Token]
+                                                inner
+                                                final
+                                            )
+                                      }
+                                  )
+                          )
+                    }
+                )
+                (
+                  \u : U8 =>
+                    if [Result ParseError (Pair Type (List Token))] (eqU8 tag identTag)
+                      (
+                        \u : U8 =>
+                          Ok
+                            [ParseError]
+                            [Pair Type (List Token)]
+                            (
+                              MkPair
+                                [Type]
+                                [List Token]
+                                (Ty_Var (tokenText h))
+                                t
+                            )
+                      )
+                      (
+                        \u : U8 => Err [ParseError] [Pair Type (List Token)] parseError
+                      )
+                )
         )
-    )
 
-poly isTypeAtomStartTag = \tag : U8 =>
-  if [Bool] (eqU8 tag identTag)
-    (\u : U8 => true)
-    (\u : U8 => eqU8 tag lParenTag)
+poly isTypeAtomStartTag =
+  \tag : U8 =>
+    if [Bool] (eqU8 tag identTag)
+      (\u : U8 => true)
+      (\u : U8 => eqU8 tag lParenTag)
 
-poly rec parseTypeAppLoopWith = \recurse : (List Token -> Result ParseError (Pair Type (List Token))) => \lhs : Type => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Type (List Token))] toks
-    (Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] lhs toks))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Type (List Token))]
-        (isTypeAtomStartTag tag)
-        (\u : U8 =>
-          match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair Type (List Token)] e
-            | Ok rhsRes =>
-              let rhs = fstTypeToken rhsRes in
-              let rest = sndTypeToken rhsRes in
-              parseTypeAppLoopWith recurse (Ty_App lhs rhs) rest
-          })
-        (\u : U8 => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] lhs toks))
-    )
-
-poly parseTypeApplicationWith = \recurse : (List Token -> Result ParseError (Pair Type (List Token))) => \toks : List Token =>
-  match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
-    | Err e => Err [ParseError] [Pair Type (List Token)] e
-    | Ok headRes =>
-      let head = fstTypeToken headRes in
-      let rest = sndTypeToken headRes in
-      parseTypeAppLoopWith recurse head rest
-  }
-
-poly rec parseType = \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Type (List Token))] toks
-    (Err [ParseError] [Pair Type (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Type (List Token))]
-        (eqU8 tag hashTag)
-        (\u : U8 =>
-          match (expectIdent t) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair Type (List Token)] e
-            | Ok idRes =>
-              let tyVar = fstNameToken idRes in
-              let afterVar = sndNameToken idRes in
-              match (expect afterVar arrowTag) [Result ParseError (Pair Type (List Token))] {
-                | Err e => Err [ParseError] [Pair Type (List Token)] e
-                | Ok afterArrow =>
-                  match (parseType afterArrow) [Result ParseError (Pair Type (List Token))] {
-                    | Err e => Err [ParseError] [Pair Type (List Token)] e
-                    | Ok bodyRes =>
-                      let bodyTy = fstTypeToken bodyRes in
-                      let rest = sndTypeToken bodyRes in
-                      Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] (Ty_Forall tyVar bodyTy) rest)
-                  }
-              }
-          })
-        (\u : U8 =>
-          match (parseTypeApplicationWith parseType toks) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair Type (List Token)] e
-            | Ok appRes =>
-              let lhs = fstTypeToken appRes in
-              let rest = sndTypeToken appRes in
-              matchList [Token] [Result ParseError (Pair Type (List Token))] rest
-                (Ok [ParseError] [Pair Type (List Token)] appRes)
-                (\h2 : Token => \t2 : List Token =>
-                  if [Result ParseError (Pair Type (List Token))]
-                    (eqU8 (tokenTag h2) arrowTag)
-                    (\u : U8 =>
-                      match (parseType t2) [Result ParseError (Pair Type (List Token))] {
+poly rec parseTypeAppLoopWith =
+  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+    \lhs : Type =>
+      \toks : List Token =>
+        matchList
+          [Token]
+          [Result ParseError (Pair Type (List Token))]
+          toks
+          (
+            Ok
+              [ParseError]
+              [Pair Type (List Token)]
+              (MkPair [Type] [List Token] lhs toks)
+          )
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                if [Result ParseError (Pair Type (List Token))] (isTypeAtomStartTag tag)
+                  (
+                    \u : U8 =>
+                      match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
                         | Err e => Err [ParseError] [Pair Type (List Token)] e
                         | Ok rhsRes =>
                           let rhs = fstTypeToken rhsRes in
-                          let finalRest = sndTypeToken rhsRes in
-                          Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] (Ty_Arrow lhs rhs) finalRest)
-                      })
-                    (\u : U8 => Ok [ParseError] [Pair Type (List Token)] appRes)
-                )
-          }
-        )
-    )
+                          let rest = sndTypeToken rhsRes in
+                          parseTypeAppLoopWith recurse (Ty_App lhs rhs) rest
+                      }
+                  )
+                  (
+                    \u : U8 =>
+                      Ok
+                        [ParseError]
+                        [Pair Type (List Token)]
+                        (MkPair [Type] [List Token] lhs toks)
+                  )
+          )
 
-poly parseSimpleType = \toks : List Token =>
-  parseSimpleTypeWith parseType toks
+poly parseTypeApplicationWith =
+  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+    \toks : List Token =>
+      match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
+        | Err e => Err [ParseError] [Pair Type (List Token)] e
+        | Ok headRes =>
+          let head = fstTypeToken headRes in
+          let rest = sndTypeToken headRes in
+          parseTypeAppLoopWith recurse head rest
+      }
 
-poly parseTypeApplication = \toks : List Token =>
-  parseTypeApplicationWith parseType toks
+poly rec parseType =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (Pair Type (List Token))]
+      toks
+      (Err [ParseError] [Pair Type (List Token)] parseError)
+      (
+        \h : Token =>
+          \t : List Token =>
+            let tag = tokenTag h in
+            if [Result ParseError (Pair Type (List Token))] (eqU8 tag hashTag)
+              (
+                \u : U8 =>
+                  match (expectIdent t) [Result ParseError (Pair Type (List Token))] {
+                    | Err e => Err [ParseError] [Pair Type (List Token)] e
+                    | Ok idRes =>
+                      let tyVar = fstNameToken idRes in
+                      let afterVar = sndNameToken idRes in
+                      match (expect afterVar arrowTag) [Result ParseError (Pair Type (List Token))] {
+                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                        | Ok afterArrow =>
+                          match (parseType afterArrow) [Result ParseError (Pair Type (List Token))] {
+                            | Err e => Err [ParseError] [Pair Type (List Token)] e
+                            | Ok bodyRes =>
+                              let bodyTy = fstTypeToken bodyRes in
+                              let rest = sndTypeToken bodyRes in
+                              Ok
+                                [ParseError]
+                                [Pair Type (List Token)]
+                                (
+                                  MkPair
+                                    [Type]
+                                    [List Token]
+                                    (Ty_Forall tyVar bodyTy)
+                                    rest
+                                )
+                          }
+                      }
+                  }
+              )
+              (
+                \u : U8 =>
+                  match (parseTypeApplicationWith parseType toks) [Result ParseError (Pair Type (List Token))] {
+                    | Err e => Err [ParseError] [Pair Type (List Token)] e
+                    | Ok appRes =>
+                      let lhs = fstTypeToken appRes in
+                      let rest = sndTypeToken appRes in
+                      matchList
+                        [Token]
+                        [Result ParseError (Pair Type (List Token))]
+                        rest
+                        (Ok [ParseError] [Pair Type (List Token)] appRes)
+                        (
+                          \h2 : Token =>
+                            \t2 : List Token =>
+                              if [Result ParseError (Pair Type (List Token))] (eqU8 (tokenTag h2) arrowTag)
+                                (
+                                  \u : U8 =>
+                                    match (parseType t2) [Result ParseError (Pair Type (List Token))] {
+                                      | Err e => Err [ParseError] [Pair Type (List Token)] e
+                                      | Ok rhsRes =>
+                                        let rhs = fstTypeToken rhsRes in
+                                        let finalRest = sndTypeToken rhsRes in
+                                        Ok
+                                          [ParseError]
+                                          [Pair Type (List Token)]
+                                          (
+                                            MkPair
+                                              [Type]
+                                              [List Token]
+                                              (Ty_Arrow lhs rhs)
+                                              finalRest
+                                          )
+                                    }
+                                )
+                                (
+                                  \u : U8 => Ok [ParseError] [Pair Type (List Token)] appRes
+                                )
+                        )
+                  }
+              )
+      )
 
-poly rec parseAppLoopWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \lhs : Expr => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
-    (Ok [ParseError] [Pair Expr (List Token)]
-      (MkPair [Expr] [List Token] lhs toks))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag lBracketTag)
-        (\u : U8 =>
-          match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
-            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-            | Ok afterType => parseAppLoopWith recurse lhs afterType
-          })
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-            (isAtomStartTag tag)
-            (\u : U8 =>
-              match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                | Ok rhsRes =>
-                  let rhs = fstExprToken rhsRes in
-                  let rest = sndExprToken rhsRes in
-                  parseAppLoopWith recurse (E_App lhs rhs) rest
-              })
-            (\u : U8 =>
-              Ok [ParseError] [Pair Expr (List Token)]
-                (MkPair [Expr] [List Token] lhs toks))
-        )
-    )
+poly parseSimpleType =
+  \toks : List Token => parseSimpleTypeWith parseType toks
 
-poly rec parseAppLoopNoBraceWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \lhs : Expr => \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
-    (Ok [ParseError] [Pair Expr (List Token)]
-      (MkPair [Expr] [List Token] lhs toks))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag lBraceTag)
-        (\u : U8 => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] lhs toks))
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-            (eqU8 tag lBracketTag)
-            (\u : U8 =>
-              match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
-                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                | Ok afterType => parseAppLoopNoBraceWith recurse lhs afterType
-              })
-            (\u : U8 =>
-              if [Result ParseError (Pair Expr (List Token))]
-                (isAtomStartTag tag)
-                (\u : U8 =>
-                  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+poly parseTypeApplication =
+  \toks : List Token => parseTypeApplicationWith parseType toks
+
+poly rec parseAppLoopWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \lhs : Expr =>
+      \toks : List Token =>
+        matchList
+          [Token]
+          [Result ParseError (Pair Expr (List Token))]
+          toks
+          (
+            Ok
+              [ParseError]
+              [Pair Expr (List Token)]
+              (MkPair [Expr] [List Token] lhs toks)
+          )
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBracketTag)
+                  (
+                    \u : U8 =>
+                      match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
+                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        | Ok afterType => parseAppLoopWith recurse lhs afterType
+                      }
+                  )
+                  (
+                    \u : U8 =>
+                      if [Result ParseError (Pair Expr (List Token))] (isAtomStartTag tag)
+                        (
+                          \u : U8 =>
+                            match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                              | Ok rhsRes =>
+                                let rhs = fstExprToken rhsRes in
+                                let rest = sndExprToken rhsRes in
+                                parseAppLoopWith recurse (E_App lhs rhs) rest
+                            }
+                        )
+                        (
+                          \u : U8 =>
+                            Ok
+                              [ParseError]
+                              [Pair Expr (List Token)]
+                              (MkPair [Expr] [List Token] lhs toks)
+                        )
+                  )
+          )
+
+poly rec parseAppLoopNoBraceWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \lhs : Expr =>
+      \toks : List Token =>
+        matchList
+          [Token]
+          [Result ParseError (Pair Expr (List Token))]
+          toks
+          (
+            Ok
+              [ParseError]
+              [Pair Expr (List Token)]
+              (MkPair [Expr] [List Token] lhs toks)
+          )
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
+                  (
+                    \u : U8 =>
+                      Ok
+                        [ParseError]
+                        [Pair Expr (List Token)]
+                        (MkPair [Expr] [List Token] lhs toks)
+                  )
+                  (
+                    \u : U8 =>
+                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBracketTag)
+                        (
+                          \u : U8 =>
+                            match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
+                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                              | Ok afterType => parseAppLoopNoBraceWith recurse lhs afterType
+                            }
+                        )
+                        (
+                          \u : U8 =>
+                            if [Result ParseError (Pair Expr (List Token))] (isAtomStartTag tag)
+                              (
+                                \u : U8 =>
+                                  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                    | Ok rhsRes =>
+                                      let rhs = fstExprToken rhsRes in
+                                      let rest = sndExprToken rhsRes in
+                                      parseAppLoopNoBraceWith
+                                        recurse
+                                        (E_App lhs rhs)
+                                        rest
+                                  }
+                              )
+                              (
+                                \u : U8 =>
+                                  Ok
+                                    [ParseError]
+                                    [Pair Expr (List Token)]
+                                    (MkPair [Expr] [List Token] lhs toks)
+                              )
+                        )
+                  )
+          )
+
+poly parseAppNoBraceWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+        | Ok headRes =>
+          let head = fstExprToken headRes in
+          let rest = sndExprToken headRes in
+          parseAppLoopNoBraceWith recurse head rest
+      }
+
+poly parseAppWith =
+  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+    \toks : List Token =>
+      match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
+        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+        | Ok headRes =>
+          let head = fstExprToken headRes in
+          let rest = sndExprToken headRes in
+          parseAppLoopWith recurse head rest
+      }
+
+poly parseAtom =
+  \toks : List Token => parseAtomWith parseExpr toks
+
+poly parseApp =
+  \toks : List Token => parseAppWith parseExpr toks
+
+poly parseMatchArm =
+  \toks : List Token => parseMatchArmWith parseExpr toks
+
+poly parseMatchArms =
+  \toks : List Token => parseMatchArmsWith parseExpr toks (nil [Pair Pattern Expr])
+
+poly rec parseExpr =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (Pair Expr (List Token))]
+      toks
+      (Err [ParseError] [Pair Expr (List Token)] parseError)
+      (
+        \h : Token =>
+          \t : List Token =>
+            let tag = tokenTag h in
+            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
+              (
+                \u : U8 =>
+                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
                     | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok rhsRes =>
-                      let rhs = fstExprToken rhsRes in
-                      let rest = sndExprToken rhsRes in
-                      parseAppLoopNoBraceWith recurse (E_App lhs rhs) rest
-                  })
-                (\u : U8 =>
-                  Ok [ParseError] [Pair Expr (List Token)]
-                    (MkPair [Expr] [List Token] lhs toks))
-            )
-        )
-    )
-
-poly parseAppNoBraceWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
-  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-    | Ok headRes =>
-      let head = fstExprToken headRes in
-      let rest = sndExprToken headRes in
-      parseAppLoopNoBraceWith recurse head rest
-  }
-
-poly parseAppWith = \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) => \toks : List Token =>
-  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-    | Ok headRes =>
-      let head = fstExprToken headRes in
-      let rest = sndExprToken headRes in
-      parseAppLoopWith recurse head rest
-  }
-
-poly parseAtom = \toks : List Token =>
-  parseAtomWith parseExpr toks
-
-poly parseApp = \toks : List Token =>
-  parseAppWith parseExpr toks
-
-poly parseMatchArm = \toks : List Token =>
-  parseMatchArmWith parseExpr toks
-
-poly parseMatchArms = \toks : List Token =>
-  parseMatchArmsWith parseExpr toks (nil [Pair Pattern Expr])
-
-poly rec parseExpr = \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Expr (List Token))] toks
-    (Err [ParseError] [Pair Expr (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag hashTag)
-        (\u : U8 =>
-          match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-            | Ok tvRes =>
-              match tvRes [Result ParseError (Pair Expr (List Token))] {
-                | MkPair tyVar afterTyVar =>
-                    if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                      (\u : U8 =>
-                        match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
+                    | Ok tvRes =>
+                      match tvRes [Result ParseError (Pair Expr (List Token))] {
+                        | MkPair tyVar afterTyVar =>
+                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
+                            (
+                              \u : U8 =>
+                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                  | Ok afterOpen =>
+                                    matchList
+                                      [Token]
+                                      [Result ParseError (Pair Expr (List Token))]
+                                      afterOpen
+                                      (
+                                        Err
+                                          [ParseError]
+                                          [Pair Expr (List Token)]
+                                          parseError
+                                      )
+                                      (
+                                        \natTok : Token =>
+                                          \afterNat : List Token =>
+                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
+                                              (
+                                                \u : U8 =>
+                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
+                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                    | Ok rest =>
+                                                      Ok
+                                                        [ParseError]
+                                                        [Pair Expr (List Token)]
+                                                        (
+                                                          MkPair
+                                                            [Expr]
+                                                            [List Token]
+                                                            (
+                                                              E_Nat
+                                                                (
+                                                                  tokenNatValue
+                                                                    natTok
+                                                                )
+                                                            )
+                                                            rest
+                                                        )
+                                                  }
+                                              )
+                                              (
+                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
+                                              )
+                                      )
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                match (expect afterTyVar fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
+                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                  | Ok bodyToks => parseExpr bodyToks
+                                }
+                            )
+                      }
+                  }
+              )
+              (
+                \u : U8 =>
+                  if [Result ParseError (Pair Expr (List Token))] (eqU8 tag backslashTag)
+                    (
+                      \u : U8 =>
+                        match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
                           | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                          | Ok afterOpen =>
-                              matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen
-                                (Err [ParseError] [Pair Expr (List Token)] parseError)
-                                (\natTok : Token => \afterNat : List Token =>
-                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                    (\u : U8 =>
-                                      match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                        | Ok rest =>
-                                            Ok [ParseError] [Pair Expr (List Token)]
-                                              (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)
-                                      })
-                                    (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))
-                        })
-                      (\u : U8 =>
-                        match (expect afterTyVar fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
-                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                          | Ok bodyToks => parseExpr bodyToks
-                        })
-              }
-          })
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-        (eqU8 tag backslashTag)
-        (\u : U8 =>
-          match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-            | Ok idRes =>
-              let name = fstNameToken idRes in
-              let afterName = sndNameToken idRes in
-              match (skipAfter afterName fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
-                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                | Ok bodyToks =>
-                    match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {
-                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                      | Ok bodyRes =>
-                        let body = fstExprToken bodyRes in
-                        let rest = sndExprToken bodyRes in
-                        Ok [ParseError] [Pair Expr (List Token)]
-                          (MkPair [Expr] [List Token] (E_Lam name body) rest)
-                    }
-              }
-          })
-        (\u : U8 =>
-          if [Result ParseError (Pair Expr (List Token))]
-            (eqU8 tag kwLetTag)
-            (\u : U8 =>
-              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                | Ok idRes =>
-                  let name = fstNameToken idRes in
-                  let afterName = sndNameToken idRes in
-                  match (skipAfter afterName eqTag) [Result ParseError (Pair Expr (List Token))] {
-                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok valToks =>
-                        match (parseExpr valToks) [Result ParseError (Pair Expr (List Token))] {
-                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                          | Ok valRes =>
-                            let valExpr = fstExprToken valRes in
-                            let afterVal = sndExprToken valRes in
-                            match (expect afterVal kwInTag) [Result ParseError (Pair Expr (List Token))] {
+                          | Ok idRes =>
+                            let name = fstNameToken idRes in
+                            let afterName = sndNameToken idRes in
+                            match (skipAfter afterName fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
                               | Err e => Err [ParseError] [Pair Expr (List Token)] e
                               | Ok bodyToks =>
                                 match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {
                                   | Err e => Err [ParseError] [Pair Expr (List Token)] e
                                   | Ok bodyRes =>
-                                    let bodyExpr = fstExprToken bodyRes in
+                                    let body = fstExprToken bodyRes in
                                     let rest = sndExprToken bodyRes in
-                                    Ok [ParseError] [Pair Expr (List Token)]
-                                      (MkPair [Expr] [List Token] (E_Let name valExpr bodyExpr) rest)
+                                    Ok
+                                      [ParseError]
+                                      [Pair Expr (List Token)]
+                                      (
+                                        MkPair
+                                          [Expr]
+                                          [List Token]
+                                          (E_Lam name body)
+                                          rest
+                                      )
                                 }
                             }
                         }
-                  }
-              })
-            (\u : U8 =>
-              if [Result ParseError (Pair Expr (List Token))]
-                (eqU8 tag kwMatchTag)
-                (\u : U8 =>
-                  match (parseAppNoBraceWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
-                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok scrutRes =>
-                      let scrutinee = fstExprToken scrutRes in
-                      let afterScrut = sndExprToken scrutRes in
-                      match (skipAfter afterScrut lBraceTag) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok inside =>
-                            match (parseMatchArmsWith parseExpr inside (nil [Pair Pattern Expr])) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                              | Ok armsRes =>
-                                let arms = fstArmsToken armsRes in
-                                let rest = sndArmsToken armsRes in
-                                Ok [ParseError] [Pair Expr (List Token)]
-                                  (MkPair [Expr] [List Token] (E_Match scrutinee arms) rest)
-                            }
-                      }
-                  })
-                (\u : U8 => parseAppWith parseExpr toks))))
-    )
+                    )
+                    (
+                      \u : U8 =>
+                        if [Result ParseError (Pair Expr (List Token))] (eqU8 tag kwLetTag)
+                          (
+                            \u : U8 =>
+                              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
+                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                | Ok idRes =>
+                                  let name = fstNameToken idRes in
+                                  let afterName = sndNameToken idRes in
+                                  match (skipAfter afterName eqTag) [Result ParseError (Pair Expr (List Token))] {
+                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                    | Ok valToks =>
+                                      match (parseExpr valToks) [Result ParseError (Pair Expr (List Token))] {
+                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                        | Ok valRes =>
+                                          let valExpr = fstExprToken valRes in
+                                          let afterVal = sndExprToken valRes in
+                                          match (expect afterVal kwInTag) [Result ParseError (Pair Expr (List Token))] {
+                                            | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                            | Ok bodyToks =>
+                                              match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {
+                                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                                | Ok bodyRes =>
+                                                  let bodyExpr = fstExprToken bodyRes in
+                                                  let rest = sndExprToken bodyRes in
+                                                  Ok
+                                                    [ParseError]
+                                                    [Pair Expr (List Token)]
+                                                    (
+                                                      MkPair
+                                                        [Expr]
+                                                        [List Token]
+                                                        (
+                                                          E_Let
+                                                            name
+                                                            valExpr
+                                                            bodyExpr
+                                                        )
+                                                        rest
+                                                    )
+                                              }
+                                          }
+                                      }
+                                  }
+                              }
+                          )
+                          (
+                            \u : U8 =>
+                              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag kwMatchTag)
+                                (
+                                  \u : U8 =>
+                                    match (parseAppNoBraceWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
+                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                      | Ok scrutRes =>
+                                        let scrutinee = fstExprToken scrutRes in
+                                        let afterScrut = sndExprToken scrutRes in
+                                        match (skipAfter afterScrut lBraceTag) [Result ParseError (Pair Expr (List Token))] {
+                                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                          | Ok inside =>
+                                            match (parseMatchArmsWith parseExpr inside (nil [Pair Pattern Expr])) [Result ParseError (Pair Expr (List Token))] {
+                                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                              | Ok armsRes =>
+                                                let arms = fstArmsToken armsRes in
+                                                let rest = sndArmsToken armsRes in
+                                                Ok
+                                                  [ParseError]
+                                                  [Pair Expr (List Token)]
+                                                  (
+                                                    MkPair
+                                                      [Expr]
+                                                      [List Token]
+                                                      (E_Match scrutinee arms)
+                                                      rest
+                                                  )
+                                            }
+                                        }
+                                    }
+                                )
+                                (\u : U8 => parseAppWith parseExpr toks)
+                          )
+                    )
+              )
+      )
 
-poly parseNamedDef = \defKind : DefKind => \isRecursive : Bool => \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok nameRes =>
-      let name = fstNameToken nameRes in
-      let afterName = sndNameToken nameRes in
-      match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok bodyToks =>
-            match (parseExpr bodyToks) [Result ParseError (Pair Decl (List Token))] {
+poly parseNamedDef =
+  \defKind : DefKind =>
+    \isRecursive : Bool =>
+      \toks : List Token =>
+        match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok nameRes =>
+            let name = fstNameToken nameRes in
+            let afterName = sndNameToken nameRes in
+            match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
               | Err e => Err [ParseError] [Pair Decl (List Token)] e
-              | Ok bodyRes =>
-                let body = fstExprToken bodyRes in
-                let rest = sndExprToken bodyRes in
-                Ok [ParseError] [Pair Decl (List Token)]
-                  (MkPair [Decl] [List Token] (D_Def defKind isRecursive name body) rest)
-            }
-      }
-  }
-
-poly rec parseCtorArity = \toks : List Token => \acc : U8 =>
-  matchList [Token] [Result ParseError (Pair U8 (List Token))] toks
-    (Ok [ParseError] [Pair U8 (List Token)] (MkPair [U8] [List Token] acc toks))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair U8 (List Token))]
-        (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
-        (\u : U8 => Ok [ParseError] [Pair U8 (List Token)] (MkPair [U8] [List Token] acc toks))
-        (\u : U8 =>
-          match (parseSimpleType toks) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair U8 (List Token)] e
-            | Ok res =>
-                let rest = sndTypeToken res in
-                match (checkedIncrementU8 acc) [Result ParseError (Pair U8 (List Token))] {
-                  | Err e => Err [ParseError] [Pair U8 (List Token)] e
-                  | Ok nextAcc => parseCtorArity rest nextAcc
+              | Ok bodyToks =>
+                match (parseExpr bodyToks) [Result ParseError (Pair Decl (List Token))] {
+                  | Err e => Err [ParseError] [Pair Decl (List Token)] e
+                  | Ok bodyRes =>
+                    let body = fstExprToken bodyRes in
+                    let rest = sndExprToken bodyRes in
+                    Ok
+                      [ParseError]
+                      [Pair Decl (List Token)]
+                      (
+                        MkPair
+                          [Decl]
+                          [List Token]
+                          (D_Def defKind isRecursive name body)
+                          rest
+                      )
                 }
-          }
-        )
-    )
+            }
+        }
 
-poly rec parseDataCtors = \toks : List Token => \acc : List (Pair (List U8) U8) =>
-  matchList [Token] [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] toks
-    (Ok [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] (MkPair [List (Pair (List U8) U8)] [List Token] (reverse [Pair (List U8) U8] acc) toks))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (isTopLevelStartTag tag)
-        (\u : U8 => Ok [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] (MkPair [List (Pair (List U8) U8)] [List Token] (reverse [Pair (List U8) U8] acc) toks))
-        (\u : U8 =>
-          if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag pipeTag)
-            (\u : U8 =>
-              match (expectIdent t) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                | Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e
-                | Ok ctorRes =>
-                  let ctorName = fstNameToken ctorRes in
-                  let afterCtor = sndNameToken ctorRes in
-                  match (parseCtorArity afterCtor #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                    | Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e
-                    | Ok arityRes =>
-                      let arity = fst [U8] [List Token] arityRes in
-                      let rest = snd [U8] [List Token] arityRes in
-                      parseDataCtors rest (cons [Pair (List U8) U8] (MkPair [List U8] [U8] ctorName arity) acc)
-                  }
-              })
-            (\u : U8 =>
-              if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag identTag)
-                (\u : U8 =>
-                  let ctorName = tokenText h in
-                  match (parseCtorArity t #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                    | Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e
-                    | Ok arityRes =>
-                      let arity = fst [U8] [List Token] arityRes in
-                      let rest = snd [U8] [List Token] arityRes in
-                      parseDataCtors rest (cons [Pair (List U8) U8] (MkPair [List U8] [U8] ctorName arity) acc)
-                  }
+poly rec parseCtorArity =
+  \toks : List Token =>
+    \acc : U8 =>
+      matchList
+        [Token]
+        [Result ParseError (Pair U8 (List Token))]
+        toks
+        (
+          Ok
+            [ParseError]
+            [Pair U8 (List Token)]
+            (MkPair [U8] [List Token] acc toks)
+        )
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair U8 (List Token))] (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair U8 (List Token)]
+                      (MkPair [U8] [List Token] acc toks)
                 )
-                (\u : U8 => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] parseError)
+                (
+                  \u : U8 =>
+                    match (parseSimpleType toks) [Result ParseError (Pair Type (List Token))] {
+                      | Err e => Err [ParseError] [Pair U8 (List Token)] e
+                      | Ok res =>
+                        let rest = sndTypeToken res in
+                        match (checkedIncrementU8 acc) [Result ParseError (Pair U8 (List Token))] {
+                          | Err e => Err [ParseError] [Pair U8 (List Token)] e
+                          | Ok nextAcc => parseCtorArity rest nextAcc
+                        }
+                    }
+                )
+        )
+
+poly rec parseDataCtors =
+  \toks : List Token =>
+    \acc : List (Pair (List U8) U8) =>
+      matchList
+        [Token]
+        [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))]
+        toks
+        (
+          Ok
+            [ParseError]
+            [Pair (List (Pair (List U8) U8)) (List Token)]
+            (
+              MkPair
+                [List (Pair (List U8) U8)]
+                [List Token]
+                (reverse [Pair (List U8) U8] acc)
+                toks
             )
         )
-    )
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (isTopLevelStartTag tag)
+                (
+                  \u : U8 =>
+                    Ok
+                      [ParseError]
+                      [Pair (List (Pair (List U8) U8)) (List Token)]
+                      (
+                        MkPair
+                          [List (Pair (List U8) U8)]
+                          [List Token]
+                          (reverse [Pair (List U8) U8] acc)
+                          toks
+                      )
+                )
+                (
+                  \u : U8 =>
+                    if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag pipeTag)
+                      (
+                        \u : U8 =>
+                          match (expectIdent t) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
+                            | Err e =>
+                              Err
+                                [ParseError]
+                                [Pair (List (Pair (List U8) U8)) (List Token)]
+                                e
+                            | Ok ctorRes =>
+                              let ctorName = fstNameToken ctorRes in
+                              let afterCtor = sndNameToken ctorRes in
+                              match (parseCtorArity afterCtor #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
+                                | Err e =>
+                                  Err
+                                    [ParseError]
+                                    [Pair (List (Pair (List U8) U8)) (List Token)]
+                                    e
+                                | Ok arityRes =>
+                                  let arity = fst [U8] [List Token] arityRes in
+                                  let rest = snd [U8] [List Token] arityRes in
+                                  parseDataCtors
+                                    rest
+                                    (
+                                      cons
+                                        [Pair (List U8) U8]
+                                        (MkPair [List U8] [U8] ctorName arity)
+                                        acc
+                                    )
+                              }
+                          }
+                      )
+                      (
+                        \u : U8 =>
+                          if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag identTag)
+                            (
+                              \u : U8 =>
+                                let ctorName = tokenText h in
+                                match (parseCtorArity t #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
+                                  | Err e =>
+                                    Err
+                                      [ParseError]
+                                      [Pair (List (Pair (List U8) U8)) (List Token)]
+                                      e
+                                  | Ok arityRes =>
+                                    let arity = fst [U8] [List Token] arityRes in
+                                    let rest = snd [U8] [List Token] arityRes in
+                                    parseDataCtors
+                                      rest
+                                      (
+                                        cons
+                                          [Pair (List U8) U8]
+                                          (MkPair [List U8] [U8] ctorName arity)
+                                          acc
+                                      )
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                Err
+                                  [ParseError]
+                                  [Pair (List (Pair (List U8) U8)) (List Token)]
+                                  parseError
+                            )
+                      )
+                )
+        )
 
-poly parseModuleDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok modRes =>
-      let name = fstNameToken modRes in
-      let rest = sndNameToken modRes in
-      Ok [ParseError] [Pair Decl (List Token)]
-        (MkPair [Decl] [List Token] (D_Module name) rest)
-  }
+poly parseModuleDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok modRes =>
+        let name = fstNameToken modRes in
+        let rest = sndNameToken modRes in
+        Ok
+          [ParseError]
+          [Pair Decl (List Token)]
+          (MkPair [Decl] [List Token] (D_Module name) rest)
+    }
 
-poly parseImportDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok modRes =>
-      let modName = fstNameToken modRes in
-      let afterMod = sndNameToken modRes in
-      match (expectIdent afterMod) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok symRes =>
-          let sym = fstNameToken symRes in
-          let rest = sndNameToken symRes in
-          Ok [ParseError] [Pair Decl (List Token)]
-            (MkPair [Decl] [List Token] (D_Import modName sym) rest)
-      }
-  }
+poly parseImportDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok modRes =>
+        let modName = fstNameToken modRes in
+        let afterMod = sndNameToken modRes in
+        match (expectIdent afterMod) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok symRes =>
+            let sym = fstNameToken symRes in
+            let rest = sndNameToken symRes in
+            Ok
+              [ParseError]
+              [Pair Decl (List Token)]
+              (MkPair [Decl] [List Token] (D_Import modName sym) rest)
+        }
+    }
 
-poly parseExportDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok expRes =>
-      let name = fstNameToken expRes in
-      let rest = sndNameToken expRes in
-      Ok [ParseError] [Pair Decl (List Token)]
-        (MkPair [Decl] [List Token] (D_Export name) rest)
-  }
+poly parseExportDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok expRes =>
+        let name = fstNameToken expRes in
+        let rest = sndNameToken expRes in
+        Ok
+          [ParseError]
+          [Pair Decl (List Token)]
+          (MkPair [Decl] [List Token] (D_Export name) rest)
+    }
 
-poly parseOpaqueDecl = \toks : List Token =>
-  match (expect toks kwTypeTag) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok afterType =>
-      match (expectIdent afterType) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok opqRes =>
-          let name = fstNameToken opqRes in
-          let afterName = sndNameToken opqRes in
-          Ok [ParseError] [Pair Decl (List Token)]
-            (MkPair [Decl] [List Token] (D_Opaque name) afterName)
-      }
-  }
+poly parseOpaqueDecl =
+  \toks : List Token =>
+    match (expect toks kwTypeTag) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok afterType =>
+        match (expectIdent afterType) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok opqRes =>
+            let name = fstNameToken opqRes in
+            let afterName = sndNameToken opqRes in
+            Ok
+              [ParseError]
+              [Pair Decl (List Token)]
+              (MkPair [Decl] [List Token] (D_Opaque name) afterName)
+        }
+    }
 
-poly parseNativeDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok natRes =>
-      let name = fstNameToken natRes in
-      let afterName = sndNameToken natRes in
-      match (expect afterName colonTag) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok afterColon =>
-          match (parseType afterColon) [Result ParseError (Pair Type (List Token))] {
-            | Err e => Err [ParseError] [Pair Decl (List Token)] e
-            | Ok tyRes =>
-              let rest = sndTypeToken tyRes in
-              Ok [ParseError] [Pair Decl (List Token)]
-                (MkPair [Decl] [List Token] (D_Native name) rest)
-          }
-      }
-  }
+poly parseNativeDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok natRes =>
+        let name = fstNameToken natRes in
+        let afterName = sndNameToken natRes in
+        match (expect afterName colonTag) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok afterColon =>
+            match (parseType afterColon) [Result ParseError (Pair Type (List Token))] {
+              | Err e => Err [ParseError] [Pair Decl (List Token)] e
+              | Ok tyRes =>
+                let rest = sndTypeToken tyRes in
+                Ok
+                  [ParseError]
+                  [Pair Decl (List Token)]
+                  (MkPair [Decl] [List Token] (D_Native name) rest)
+            }
+        }
+    }
 
-poly parseTypeDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok tyRes =>
-      let name = fstNameToken tyRes in
-      let afterName = sndNameToken tyRes in
-      match (skipToTopLevelDecl afterName) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok rest =>
-          Ok [ParseError] [Pair Decl (List Token)]
-            (MkPair [Decl] [List Token] (D_Type name) rest)
-      }
-  }
+poly parseTypeDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok tyRes =>
+        let name = fstNameToken tyRes in
+        let afterName = sndNameToken tyRes in
+        match (skipToTopLevelDecl afterName) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok rest =>
+            Ok
+              [ParseError]
+              [Pair Decl (List Token)]
+              (MkPair [Decl] [List Token] (D_Type name) rest)
+        }
+    }
 
-poly parseDataDecl = \toks : List Token =>
-  match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-    | Err e => Err [ParseError] [Pair Decl (List Token)] e
-    | Ok datRes =>
-      let name = fstNameToken datRes in
-      let afterName = sndNameToken datRes in
-      match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
-        | Err e => Err [ParseError] [Pair Decl (List Token)] e
-        | Ok afterEq =>
-          match (parseDataCtors afterEq (nil [Pair (List U8) U8])) [Result ParseError (Pair Decl (List Token))] {
-            | Err e => Err [ParseError] [Pair Decl (List Token)] e
-            | Ok ctorsRes =>
-              let ctors = fst [List (Pair (List U8) U8)] [List Token] ctorsRes in
-              let rest = snd [List (Pair (List U8) U8)] [List Token] ctorsRes in
-              Ok [ParseError] [Pair Decl (List Token)]
-                (MkPair [Decl] [List Token] (D_Data name ctors) rest)
-          }
-      }
-  }
+poly parseDataDecl =
+  \toks : List Token =>
+    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
+      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+      | Ok datRes =>
+        let name = fstNameToken datRes in
+        let afterName = sndNameToken datRes in
+        match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
+          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+          | Ok afterEq =>
+            match (parseDataCtors afterEq (nil [Pair (List U8) U8])) [Result ParseError (Pair Decl (List Token))] {
+              | Err e => Err [ParseError] [Pair Decl (List Token)] e
+              | Ok ctorsRes =>
+                let ctors = fst [List (Pair (List U8) U8)] [List Token] ctorsRes in
+                let rest = snd [List (Pair (List U8) U8)] [List Token] ctorsRes in
+                Ok
+                  [ParseError]
+                  [Pair Decl (List Token)]
+                  (MkPair [Decl] [List Token] (D_Data name ctors) rest)
+            }
+        }
+    }
 
-poly parsePolyDecl = \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Decl (List Token))] toks
-    (Err [ParseError] [Pair Decl (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      if [Result ParseError (Pair Decl (List Token))]
-        (eqU8 (tokenTag h) kwRecTag)
-        (\u : U8 => parseNamedDef K_Poly true t)
-        (\u : U8 => parseNamedDef K_Poly false toks))
+poly parsePolyDecl =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (Pair Decl (List Token))]
+      toks
+      (Err [ParseError] [Pair Decl (List Token)] parseError)
+      (
+        \h : Token =>
+          \t : List Token =>
+            if [Result ParseError (Pair Decl (List Token))] (eqU8 (tokenTag h) kwRecTag)
+              (\u : U8 => parseNamedDef K_Poly true t)
+              (\u : U8 => parseNamedDef K_Poly false toks)
+      )
 
-poly parseDecl = \toks : List Token =>
-  matchList [Token] [Result ParseError (Pair Decl (List Token))] toks
-    (Err [ParseError] [Pair Decl (List Token)] parseError)
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwModuleTag)
-        (\u : U8 => parseModuleDecl t)
-        (\u : U8 =>
-          if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwImportTag)
-            (\u : U8 => parseImportDecl t)
-            (\u : U8 =>
-              if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwExportTag)
-                (\u : U8 => parseExportDecl t)
-                (\u : U8 =>
-                  if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwOpaqueTag)
-                    (\u : U8 => parseOpaqueDecl t)
-                    (\u : U8 =>
-                      if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwNativeTag)
-                        (\u : U8 => parseNativeDecl t)
-                        (\u : U8 =>
-                          if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwTypeTag)
-                            (\u : U8 => parseTypeDecl t)
-                            (\u : U8 =>
-                              if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwDataTag)
-                                (\u : U8 => parseDataDecl t)
-                                (\u : U8 =>
-                                  if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwPolyTag)
-                                    (\u : U8 => parsePolyDecl t)
-                                    (\u : U8 =>
-                                      if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwCombinatorTag)
-                                        (\u : U8 => parseNamedDef K_Combinator false t)
-                                        (\u : U8 => Err [ParseError] [Pair Decl (List Token)] parseError))))))))))
+poly parseDecl =
+  \toks : List Token =>
+    matchList
+      [Token]
+      [Result ParseError (Pair Decl (List Token))]
+      toks
+      (Err [ParseError] [Pair Decl (List Token)] parseError)
+      (
+        \h : Token =>
+          \t : List Token =>
+            let tag = tokenTag h in
+            if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwModuleTag)
+              (\u : U8 => parseModuleDecl t)
+              (
+                \u : U8 =>
+                  if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwImportTag)
+                    (\u : U8 => parseImportDecl t)
+                    (
+                      \u : U8 =>
+                        if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwExportTag)
+                          (\u : U8 => parseExportDecl t)
+                          (
+                            \u : U8 =>
+                              if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwOpaqueTag)
+                                (\u : U8 => parseOpaqueDecl t)
+                                (
+                                  \u : U8 =>
+                                    if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwNativeTag)
+                                      (\u : U8 => parseNativeDecl t)
+                                      (
+                                        \u : U8 =>
+                                          if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwTypeTag)
+                                            (\u : U8 => parseTypeDecl t)
+                                            (
+                                              \u : U8 =>
+                                                if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwDataTag)
+                                                  (\u : U8 => parseDataDecl t)
+                                                  (
+                                                    \u : U8 =>
+                                                      if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwPolyTag)
+                                                        (
+                                                          \u : U8 => parsePolyDecl t
+                                                        )
+                                                        (
+                                                          \u : U8 =>
+                                                            if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwCombinatorTag)
+                                                              (
+                                                                \u : U8 => parseNamedDef K_Combinator false t
+                                                              )
+                                                              (
+                                                                \u : U8 => Err [ParseError] [Pair Decl (List Token)] parseError
+                                                              )
+                                                        )
+                                                  )
+                                            )
+                                      )
+                                )
+                          )
+                    )
+              )
+      )
 
-poly rec parseProgramAcc = \toks : List Token => \acc : List Decl =>
-  matchList [Token] [Result ParseError (List Decl)] toks
-    (Ok [ParseError] [List Decl] (reverse [Decl] acc))
-    (\h : Token => \t : List Token =>
-      let tag = tokenTag h in
-      if [Result ParseError (List Decl)] (eqU8 tag eofTag)
-        (\u : U8 => Ok [ParseError] [List Decl] (reverse [Decl] acc))
-        (\u : U8 =>
-          match (parseDecl toks) [Result ParseError (List Decl)] {
-            | Err e => Err [ParseError] [List Decl] e
-            | Ok declRes =>
-              let decl = fstDeclToken declRes in
-              let rest = sndDeclToken declRes in
-              parseProgramAcc rest (cons [Decl] decl acc)
-          })
-    )
+poly rec parseProgramAcc =
+  \toks : List Token =>
+    \acc : List Decl =>
+      matchList
+        [Token]
+        [Result ParseError (List Decl)]
+        toks
+        (Ok [ParseError] [List Decl] (reverse [Decl] acc))
+        (
+          \h : Token =>
+            \t : List Token =>
+              let tag = tokenTag h in
+              if [Result ParseError (List Decl)] (eqU8 tag eofTag)
+                (\u : U8 => Ok [ParseError] [List Decl] (reverse [Decl] acc))
+                (
+                  \u : U8 =>
+                    match (parseDecl toks) [Result ParseError (List Decl)] {
+                      | Err e => Err [ParseError] [List Decl] e
+                      | Ok declRes =>
+                        let decl = fstDeclToken declRes in
+                        let rest = sndDeclToken declRes in
+                        parseProgramAcc rest (cons [Decl] decl acc)
+                    }
+                )
+        )
 
-poly parseProgram = \toks : List Token =>
-  parseProgramAcc toks (nil [Decl])
+poly parseProgram =
+  \toks : List Token => parseProgramAcc toks (nil [Decl])

--- a/bootstrap/src/telemetry.trip
+++ b/bootstrap/src/telemetry.trip
@@ -1,59 +1,96 @@
 module Telemetry
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude map
+
 import Prelude matchList
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Parser parseProgram
+
 import Parser D_Def
+
 import Parser Decl
+
 import Avl Avl
+
 import Avl empty
+
 import Avl lookup
+
 import Avl toListEntries
+
 import Bridge elaborateProgram
+
 import Lowering Lower
+
 import Lowering lowerToComb
+
 import Unparse Comb
 
 export phase1
+
 export phase2
+
 export phase3
+
 export phase4
 
-poly phase1 = \source : List U8 =>
-  match (tokenize source) [List Token] {
-    | Err e => nil [Token]
-    | Ok toks => toks
-  }
+poly phase1 =
+  \source : List U8 =>
+    match (tokenize source) [List Token] {
+      | Err e => nil [Token]
+      | Ok toks => toks
+    }
 
-poly phase2 = \toks : List Token =>
-  match (parseProgram toks) [List Decl] {
-    | Err e => nil [Decl]
-    | Ok decls => decls
-  }
+poly phase2 =
+  \toks : List Token =>
+    match (parseProgram toks) [List Decl] {
+      | Err e => nil [Decl]
+      | Ok decls => decls
+    }
 
-poly phase3 = \decls : List Decl =>
-  match (elaborateProgram (empty [List U8] [Lower]) decls) [Avl (List U8) Lower] {
-    | Err e => empty [List U8] [Lower]
-    | Ok globals => globals
-  }
+poly phase3 =
+  \decls : List Decl =>
+    match (elaborateProgram (empty [List U8] [Lower]) decls) [Avl (List U8) Lower] {
+      | Err e => empty [List U8] [Lower]
+      | Ok globals => globals
+    }
 
-poly phase4 = \globals : Avl (List U8) Lower =>
+poly phase4 =
+  \globals : Avl (List U8) Lower =>
     let entries = toListEntries [List U8] [Lower] globals in
-    map [Pair (List U8) Lower] [Pair (List U8) Comb]
-      (\entry : Pair (List U8) Lower =>
-        MkPair [List U8] [Comb]
-          (fst [List U8] [Lower] entry)
-          (lowerToComb (snd [List U8] [Lower] entry)))
+    map
+      [Pair (List U8) Lower]
+      [Pair (List U8) Comb]
+      (
+        \entry : Pair (List U8) Lower =>
+          MkPair
+            [List U8]
+            [Comb]
+            (fst [List U8] [Lower] entry)
+            (lowerToComb (snd [List U8] [Lower] entry))
+      )
       entries

--- a/bootstrap/src/unparse.trip
+++ b/bootstrap/src/unparse.trip
@@ -1,39 +1,71 @@
 module Unparse
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude append
+
 import Prelude addU8
+
 import Prelude divU8
+
 import Prelude modU8
+
 import Prelude ltU8
+
 import Prelude U8
 
 export Terminal
+
 export T_S
+
 export T_K
+
 export T_I
+
 export T_B
+
 export T_C
+
 export T_SPrime
+
 export T_BPrime
+
 export T_CPrime
+
 export T_WriteOne
+
 export T_ReadOne
+
 export T_EqU8
+
 export T_LtU8
+
 export T_DivU8
+
 export T_ModU8
+
 export T_AddU8
+
 export T_SubU8
+
 export T_Byte
+
 export Comb
+
 export C_Term
+
 export C_App
+
 export terminalBytes
+
 export unparseCombinator
+
 export terminalTag
+
 export terminalByteValue
 
 data Terminal =
@@ -59,98 +91,122 @@ data Comb =
   | C_Term Terminal
   | C_App Comb Comb
 
-poly terminalBytes = \t : Terminal =>
-  match t [List U8] {
-    | T_S => "S"
-    | T_K => "K"
-    | T_I => "I"
-    | T_B => "B"
-    | T_C => "C"
-    | T_SPrime => "P"
-    | T_BPrime => "Q"
-    | T_CPrime => "R"
-    | T_WriteOne => "."
-    | T_ReadOne => ","
-    | T_EqU8 => "E"
-    | T_LtU8 => "L"
-    | T_DivU8 => "D"
-    | T_ModU8 => "M"
-    | T_AddU8 => "A"
-    | T_SubU8 => "O"
-    | T_Byte b => append [U8] "#u8(" (append [U8] (u8ToDigits b) ")")
-  }
+poly terminalBytes =
+  \t : Terminal =>
+    match t [List U8] {
+      | T_S => "S"
+      | T_K => "K"
+      | T_I => "I"
+      | T_B => "B"
+      | T_C => "C"
+      | T_SPrime => "P"
+      | T_BPrime => "Q"
+      | T_CPrime => "R"
+      | T_WriteOne => "."
+      | T_ReadOne => ","
+      | T_EqU8 => "E"
+      | T_LtU8 => "L"
+      | T_DivU8 => "D"
+      | T_ModU8 => "M"
+      | T_AddU8 => "A"
+      | T_SubU8 => "O"
+      | T_Byte b =>
+        append [U8] "#u8(" (append [U8] (u8ToDigits b) ")")
+    }
 
-poly rec unparseCombinator = \c : Comb =>
-  match c [List U8] {
-    | C_Term t => terminalBytes t
-    | C_App l r =>
-        append [U8] "(" (append [U8] (unparseCombinator l) (append [U8] " " (append [U8] (unparseCombinator r) ")")))
-  }
+poly rec unparseCombinator =
+  \c : Comb =>
+    match c [List U8] {
+      | C_Term t => terminalBytes t
+      | C_App l r =>
+        append
+          [U8]
+          "("
+          (
+            append
+              [U8]
+              (unparseCombinator l)
+              (append [U8] " " (append [U8] (unparseCombinator r) ")"))
+          )
+    }
 
-poly digitToAscii = \d : U8 =>
-  addU8 d #u8(48)
+poly digitToAscii =
+  \d : U8 => addU8 d #u8(48)
 
-poly singletonU8 = \b : U8 =>
-  cons [U8] b (nil [U8])
+poly singletonU8 =
+  \b : U8 => {U8 | b}
 
-poly u8ToDigits = \n : U8 =>
-  if [List U8] (ltU8 n #u8(10))
-    (\u : U8 => singletonU8 (digitToAscii n))
-    (\u : U8 =>
-      if [List U8] (ltU8 n #u8(100))
-        (\u : U8 =>
-          cons [U8]
-            (digitToAscii (divU8 n #u8(10)))
-            (singletonU8 (digitToAscii (modU8 n #u8(10)))))
-        (\u : U8 =>
-          let hundreds = divU8 n #u8(100) in
-          let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-          let ones = modU8 n #u8(10) in
-          cons [U8]
-            (digitToAscii hundreds)
-            (cons [U8]
-              (digitToAscii tens)
-              (singletonU8 (digitToAscii ones))))
-    )
+poly u8ToDigits =
+  \n : U8 =>
+    if [List U8] (ltU8 n #u8(10))
+      (\u : U8 => singletonU8 (digitToAscii n))
+      (
+        \u : U8 =>
+          if [List U8] (ltU8 n #u8(100))
+            (
+              \u : U8 =>
+                cons
+                  [U8]
+                  (digitToAscii (divU8 n #u8(10)))
+                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
+            )
+            (
+              \u : U8 =>
+                let hundreds = divU8 n #u8(100) in
+                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
+                let ones = modU8 n #u8(10) in
+                cons
+                  [U8]
+                  (digitToAscii hundreds)
+                  (
+                    cons
+                      [U8]
+                      (digitToAscii tens)
+                      (singletonU8 (digitToAscii ones))
+                  )
+            )
+      )
 
-poly terminalTag = \t : Terminal =>
-  match t [U8] {
-    | T_S => #u8(0)
-    | T_K => #u8(1)
-    | T_I => #u8(2)
-    | T_B => #u8(3)
-    | T_C => #u8(4)
-    | T_SPrime => #u8(5)
-    | T_BPrime => #u8(6)
-    | T_CPrime => #u8(7)
-    | T_WriteOne => #u8(8)
-    | T_ReadOne => #u8(9)
-    | T_EqU8 => #u8(10)
-    | T_LtU8 => #u8(11)
-    | T_DivU8 => #u8(12)
-    | T_ModU8 => #u8(13)
-    | T_AddU8 => #u8(14)
-    | T_SubU8 => #u8(15)
-    | T_Byte _ => #u8(16)
-  }
+poly terminalTag =
+  \t : Terminal =>
+    match t [U8] {
+      | T_S => #u8(0)
+      | T_K => #u8(1)
+      | T_I => #u8(2)
+      | T_B => #u8(3)
+      | T_C => #u8(4)
+      | T_SPrime => #u8(5)
+      | T_BPrime => #u8(6)
+      | T_CPrime => #u8(7)
+      | T_WriteOne => #u8(8)
+      | T_ReadOne => #u8(9)
+      | T_EqU8 => #u8(10)
+      | T_LtU8 => #u8(11)
+      | T_DivU8 => #u8(12)
+      | T_ModU8 => #u8(13)
+      | T_AddU8 => #u8(14)
+      | T_SubU8 => #u8(15)
+      | T_Byte _ => #u8(16)
+    }
 
-poly terminalByteValue = \t : Terminal =>
-  match t [U8] {
-    | T_S => #u8(0)
-    | T_K => #u8(0)
-    | T_I => #u8(0)
-    | T_B => #u8(0)
-    | T_C => #u8(0)
-    | T_SPrime => #u8(0)
-    | T_BPrime => #u8(0)
-    | T_CPrime => #u8(0)
-    | T_WriteOne => #u8(0)
-    | T_ReadOne => #u8(0)
-    | T_EqU8 => #u8(0)
-    | T_LtU8 => #u8(0)
-    | T_DivU8 => #u8(0)
-    | T_ModU8 => #u8(0)
-    | T_AddU8 => #u8(0)
-    | T_SubU8 => #u8(0)
-    | T_Byte b => b
-  }
+poly terminalByteValue =
+  \t : Terminal =>
+    match t [U8] {
+      | T_S => #u8(0)
+      | T_K => #u8(0)
+      | T_I => #u8(0)
+      | T_B => #u8(0)
+      | T_C => #u8(0)
+      | T_SPrime => #u8(0)
+      | T_BPrime => #u8(0)
+      | T_CPrime => #u8(0)
+      | T_WriteOne => #u8(0)
+      | T_ReadOne => #u8(0)
+      | T_EqU8 => #u8(0)
+      | T_LtU8 => #u8(0)
+      | T_DivU8 => #u8(0)
+      | T_ModU8 => #u8(0)
+      | T_AddU8 => #u8(0)
+      | T_SubU8 => #u8(0)
+      | T_Byte b => b
+    }

--- a/lib/avl.trip
+++ b/lib/avl.trip
@@ -1,248 +1,443 @@
 module Avl
 
 import Prelude Bool
+
 import Prelude Bin
+
 import Prelude true
+
 import Prelude false
+
 import Prelude and
+
 import Prelude not
+
 import Prelude if
+
 import Prelude List
+
 import Prelude Pair
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude MkPair
+
 import Prelude matchList
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude append
+
 import Prelude error
+
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat lte
 
 export Avl
+
 export Empty
+
 export Node
+
 export empty
+
 export height
+
 export size
+
 export lookup
+
 export insert
+
 export delete
+
 export toListKeys
+
 export toListEntries
+
 export fromList
+
 export maxNat
+
 export gtNat
+
 export mkNode
+
 export rotateLeft
+
 export rotateRight
+
 export balance
+
 export extractMin
+
 export deleteRoot
 
-data Avl K V = Empty | Node (Avl K V) K V Nat (Avl K V)
+data Avl K V =
+  | Empty
+  | Node (Avl K V) K V Nat (Avl K V)
 
-poly empty = #K => #V => Empty [K] [V]
+poly empty =
+  #K => #V => Empty [K] [V]
 
-poly height = #K => #V => \t : Avl K V =>
-  match t [Nat] {
-    | Empty => zero
-    | Node _ _ _ h _ => h
-  }
-
-poly rec size = #K => #V => \t : Avl K V =>
-  match t [Nat] {
-    | Empty => zero
-    | Node l _ _ _ r =>
-        succ (add (size [K] [V] l) (size [K] [V] r))
-  }
-
-poly maxNat = \a : Nat => \b : Nat =>
-  (lte a b) [Nat] b a
-
-poly gtNat = \a : Nat => \b : Nat =>
-  and (lte b a) (not (lte a b))
-
-poly mkNode = #K => #V => \l : Avl K V => \k : K => \v : V => \r : Avl K V =>
-  Node [K] [V] l k v
-    (succ (maxNat (height [K] [V] l) (height [K] [V] r)))
-    r
-
-poly rotateLeft = #K => #V => \t : Avl K V =>
-  match t [Avl K V] {
-    | Empty => Empty [K] [V]
-    | Node l k v _ r =>
-        match r [Avl K V] {
-          | Empty => mkNode [K] [V] l k v r
-          | Node rl rk rv _ rr =>
-              mkNode [K] [V]
-                (mkNode [K] [V] l k v rl)
-                rk
-                rv
-                rr
+poly height =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Nat] {
+          | Empty => zero
+          | Node _ _ _ h _ => h
         }
-  }
 
-poly rotateRight = #K => #V => \t : Avl K V =>
-  match t [Avl K V] {
-    | Empty => Empty [K] [V]
-    | Node l k v _ r =>
-        match l [Avl K V] {
-          | Empty => mkNode [K] [V] l k v r
-          | Node ll lk lv _ lr =>
-              mkNode [K] [V]
-                ll
-                lk
-                lv
-                (mkNode [K] [V] lr k v r)
+poly rec size =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Nat] {
+          | Empty => zero
+          | Node l _ _ _ r => succ (add (size [K] [V] l) (size [K] [V] r))
         }
-  }
 
-poly balance = #K => #V => \t : Avl K V =>
-  match t [Avl K V] {
-    | Empty => Empty [K] [V]
-    | Node l k v _ r =>
-        let hl = height [K] [V] l in
-        let hr = height [K] [V] r in
-        if [Avl K V] (gtNat hl (succ hr))
-          (\u : Bin =>
+poly maxNat =
+  \a : Nat => \b : Nat => (lte a b) [Nat] b a
+
+poly gtNat =
+  \a : Nat => \b : Nat => and (lte b a) (not (lte a b))
+
+poly mkNode =
+  #K =>
+    #V =>
+      \l : Avl K V =>
+        \k : K =>
+          \v : V =>
+            \r : Avl K V =>
+              Node
+                [K]
+                [V]
+                l
+                k
+                v
+                (succ (maxNat (height [K] [V] l) (height [K] [V] r)))
+                r
+
+poly rotateLeft =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Avl K V] {
+          | Empty => Empty [K] [V]
+          | Node l k v _ r =>
+            match r [Avl K V] {
+              | Empty => mkNode [K] [V] l k v r
+              | Node rl rk rv _ rr => mkNode [K] [V] (mkNode [K] [V] l k v rl) rk rv rr
+            }
+        }
+
+poly rotateRight =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Avl K V] {
+          | Empty => Empty [K] [V]
+          | Node l k v _ r =>
             match l [Avl K V] {
               | Empty => mkNode [K] [V] l k v r
-              | Node ll _ _ _ lr =>
-                  if [Avl K V] (lte (height [K] [V] lr) (height [K] [V] ll))
-                    (\u : Bin => rotateRight [K] [V] (mkNode [K] [V] l k v r))
-                    (\u : Bin =>
-                      rotateRight [K] [V]
-                        (mkNode [K] [V] (rotateLeft [K] [V] l) k v r))
-            })
-          (\u : Bin =>
-            if [Avl K V] (gtNat hr (succ hl))
-              (\u : Bin =>
-                match r [Avl K V] {
-                  | Empty => mkNode [K] [V] l k v r
-                  | Node rl _ _ _ rr =>
-                      if [Avl K V] (lte (height [K] [V] rl) (height [K] [V] rr))
-                        (\u : Bin => rotateLeft [K] [V] (mkNode [K] [V] l k v r))
-                        (\u : Bin =>
-                          rotateLeft [K] [V]
-                            (mkNode [K] [V] l k v (rotateRight [K] [V] r)))
-                })
-              (\u : Bin => mkNode [K] [V] l k v r))
-  }
+              | Node ll lk lv _ lr => mkNode [K] [V] ll lk lv (mkNode [K] [V] lr k v r)
+            }
+        }
 
-poly rec lookup = #K => #V => \lteKey : K -> K -> Bool => \key : K => \t : Avl K V =>
-  match t [Maybe V] {
-    | Empty => None [V]
-    | Node l nk nv _ r =>
-        let le = lteKey key nk in
-        let ge = lteKey nk key in
-        if [Maybe V] (and le ge)
-          (\u : Bin => Some [V] nv)
-          (\u : Bin =>
-            if [Maybe V] le
-              (\u : Bin => lookup [K] [V] lteKey key l)
-              (\u : Bin => lookup [K] [V] lteKey key r))
-  }
+poly balance =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Avl K V] {
+          | Empty => Empty [K] [V]
+          | Node l k v _ r =>
+            let hl = height [K] [V] l in
+            let hr = height [K] [V] r in
+            if [Avl K V] (gtNat hl (succ hr))
+              (
+                \u : Bin =>
+                  match l [Avl K V] {
+                    | Empty => mkNode [K] [V] l k v r
+                    | Node ll _ _ _ lr =>
+                      if [Avl K V] (lte (height [K] [V] lr) (height [K] [V] ll))
+                        (
+                          \u : Bin => rotateRight [K] [V] (mkNode [K] [V] l k v r)
+                        )
+                        (
+                          \u : Bin =>
+                            rotateRight
+                              [K]
+                              [V]
+                              (mkNode [K] [V] (rotateLeft [K] [V] l) k v r)
+                        )
+                  }
+              )
+              (
+                \u : Bin =>
+                  if [Avl K V] (gtNat hr (succ hl))
+                    (
+                      \u : Bin =>
+                        match r [Avl K V] {
+                          | Empty => mkNode [K] [V] l k v r
+                          | Node rl _ _ _ rr =>
+                            if [Avl K V] (lte (height [K] [V] rl) (height [K] [V] rr))
+                              (
+                                \u : Bin => rotateLeft [K] [V] (mkNode [K] [V] l k v r)
+                              )
+                              (
+                                \u : Bin =>
+                                  rotateLeft
+                                    [K]
+                                    [V]
+                                    (
+                                      mkNode
+                                        [K]
+                                        [V]
+                                        l
+                                        k
+                                        v
+                                        (rotateRight [K] [V] r)
+                                    )
+                              )
+                        }
+                    )
+                    (\u : Bin => mkNode [K] [V] l k v r)
+              )
+        }
 
-poly rec insert = #K => #V => \lteKey : K -> K -> Bool => \key : K => \value : V => \t : Avl K V =>
-  match t [Avl K V] {
-    | Empty =>
-        mkNode [K] [V]
-          (Empty [K] [V])
-          key
-          value
-          (Empty [K] [V])
-    | Node l nk nv _ r =>
-        let le = lteKey key nk in
-        let ge = lteKey nk key in
-        if [Avl K V] (and le ge)
-          (\u : Bin => mkNode [K] [V] l nk value r)
-          (\u : Bin =>
-            if [Avl K V] le
-              (\u : Bin =>
-                balance [K] [V]
-                  (mkNode [K] [V] (insert [K] [V] lteKey key value l) nk nv r))
-              (\u : Bin =>
-                balance [K] [V]
-                  (mkNode [K] [V] l nk nv (insert [K] [V] lteKey key value r))))
-  }
+poly rec lookup =
+  #K =>
+    #V =>
+      \lteKey : K -> K -> Bool =>
+        \key : K =>
+          \t : Avl K V =>
+            match t [Maybe V] {
+              | Empty => None [V]
+              | Node l nk nv _ r =>
+                let le = lteKey key nk in
+                let ge = lteKey nk key in
+                if [Maybe V] (and le ge)
+                  (\u : Bin => Some [V] nv)
+                  (
+                    \u : Bin =>
+                      if [Maybe V] le
+                        (\u : Bin => lookup [K] [V] lteKey key l)
+                        (\u : Bin => lookup [K] [V] lteKey key r)
+                  )
+            }
 
-poly rec extractMin = #K => #V => \t : Avl K V =>
-  match t [Pair K (Pair V (Avl K V))] {
-    | Empty => error [Pair K (Pair V (Avl K V))]
-    | Node l k v _ r =>
-        match l [Pair K (Pair V (Avl K V))] {
-          | Empty =>
-              MkPair [K] [Pair V (Avl K V)]
-                k
-                (MkPair [V] [Avl K V] v r)
-          | Node _ _ _ _ _ =>
-              match (extractMin [K] [V] l) [Pair K (Pair V (Avl K V))] {
-                | MkPair minK minRest =>
+poly rec insert =
+  #K =>
+    #V =>
+      \lteKey : K -> K -> Bool =>
+        \key : K =>
+          \value : V =>
+            \t : Avl K V =>
+              match t [Avl K V] {
+                | Empty =>
+                  mkNode [K] [V] (Empty [K] [V]) key value (Empty [K] [V])
+                | Node l nk nv _ r =>
+                  let le = lteKey key nk in
+                  let ge = lteKey nk key in
+                  if [Avl K V] (and le ge)
+                    (\u : Bin => mkNode [K] [V] l nk value r)
+                    (
+                      \u : Bin =>
+                        if [Avl K V] le
+                          (
+                            \u : Bin =>
+                              balance
+                                [K]
+                                [V]
+                                (
+                                  mkNode
+                                    [K]
+                                    [V]
+                                    (insert [K] [V] lteKey key value l)
+                                    nk
+                                    nv
+                                    r
+                                )
+                          )
+                          (
+                            \u : Bin =>
+                              balance
+                                [K]
+                                [V]
+                                (
+                                  mkNode
+                                    [K]
+                                    [V]
+                                    l
+                                    nk
+                                    nv
+                                    (insert [K] [V] lteKey key value r)
+                                )
+                          )
+                    )
+              }
+
+poly rec extractMin =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [Pair K (Pair V (Avl K V))] {
+          | Empty => error [Pair K (Pair V (Avl K V))]
+          | Node l k v _ r =>
+            match l [Pair K (Pair V (Avl K V))] {
+              | Empty =>
+                MkPair [K] [Pair V (Avl K V)] k (MkPair [V] [Avl K V] v r)
+              | Node _ _ _ _ _ =>
+                match (extractMin [K] [V] l) [Pair K (Pair V (Avl K V))] {
+                  | MkPair minK minRest =>
                     match minRest [Pair V (Avl K V)] {
                       | MkPair minV newLeft =>
-                          MkPair [K] [Pair V (Avl K V)]
-                            minK
-                            (MkPair [V] [Avl K V] minV (balance [K] [V] (mkNode [K] [V] newLeft k v r)))
+                        MkPair
+                          [K]
+                          [Pair V (Avl K V)]
+                          minK
+                          (
+                            MkPair
+                              [V]
+                              [Avl K V]
+                              minV
+                              (balance [K] [V] (mkNode [K] [V] newLeft k v r))
+                          )
                     }
-              }
+                }
+            }
         }
-  }
 
-poly deleteRoot = #K => #V => \l : Avl K V => \r : Avl K V =>
-  match r [Avl K V] {
-    | Empty => l
-    | Node _ _ _ _ _ =>
-        match (extractMin [K] [V] r) [Pair K (Pair V (Avl K V))] {
-          | MkPair minK minRest =>
-              match minRest [Pair V (Avl K V)] {
-                | MkPair minV newRight =>
-                    balance [K] [V] (mkNode [K] [V] l minK minV newRight)
+poly deleteRoot =
+  #K =>
+    #V =>
+      \l : Avl K V =>
+        \r : Avl K V =>
+          match r [Avl K V] {
+            | Empty => l
+            | Node _ _ _ _ _ =>
+              match (extractMin [K] [V] r) [Pair K (Pair V (Avl K V))] {
+                | MkPair minK minRest =>
+                  match minRest [Pair V (Avl K V)] {
+                    | MkPair minV newRight =>
+                      balance [K] [V] (mkNode [K] [V] l minK minV newRight)
+                  }
               }
+          }
+
+poly rec delete =
+  #K =>
+    #V =>
+      \lteKey : K -> K -> Bool =>
+        \key : K =>
+          \t : Avl K V =>
+            match t [Avl K V] {
+              | Empty => Empty [K] [V]
+              | Node l nk nv _ r =>
+                let le = lteKey key nk in
+                let ge = lteKey nk key in
+                if [Avl K V] (and le ge)
+                  (\u : Bin => deleteRoot [K] [V] l r)
+                  (
+                    \u : Bin =>
+                      if [Avl K V] le
+                        (
+                          \u : Bin =>
+                            balance
+                              [K]
+                              [V]
+                              (
+                                mkNode
+                                  [K]
+                                  [V]
+                                  (delete [K] [V] lteKey key l)
+                                  nk
+                                  nv
+                                  r
+                              )
+                        )
+                        (
+                          \u : Bin =>
+                            balance
+                              [K]
+                              [V]
+                              (
+                                mkNode
+                                  [K]
+                                  [V]
+                                  l
+                                  nk
+                                  nv
+                                  (delete [K] [V] lteKey key r)
+                              )
+                        )
+                  )
+            }
+
+poly rec toListKeys =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [List K] {
+          | Empty => nil [K]
+          | Node l k _ _ r =>
+            append
+              [K]
+              (toListKeys [K] [V] l)
+              (cons [K] k (toListKeys [K] [V] r))
         }
-  }
 
-poly rec delete = #K => #V => \lteKey : K -> K -> Bool => \key : K => \t : Avl K V =>
-  match t [Avl K V] {
-    | Empty => Empty [K] [V]
-    | Node l nk nv _ r =>
-        let le = lteKey key nk in
-        let ge = lteKey nk key in
-        if [Avl K V] (and le ge)
-          (\u : Bin => deleteRoot [K] [V] l r)
-          (\u : Bin =>
-            if [Avl K V] le
-              (\u : Bin => balance [K] [V] (mkNode [K] [V] (delete [K] [V] lteKey key l) nk nv r))
-              (\u : Bin => balance [K] [V] (mkNode [K] [V] l nk nv (delete [K] [V] lteKey key r))))
-  }
+poly rec toListEntries =
+  #K =>
+    #V =>
+      \t : Avl K V =>
+        match t [List (Pair K V)] {
+          | Empty => nil [Pair K V]
+          | Node l k v _ r =>
+            append
+              [Pair K V]
+              (toListEntries [K] [V] l)
+              (cons [Pair K V] (MkPair [K] [V] k v) (toListEntries [K] [V] r))
+        }
 
-poly rec toListKeys = #K => #V => \t : Avl K V =>
-  match t [List K] {
-    | Empty => nil [K]
-    | Node l k _ _ r =>
-        append [K]
-          (toListKeys [K] [V] l)
-          (cons [K] k (toListKeys [K] [V] r))
-  }
-
-poly rec toListEntries = #K => #V => \t : Avl K V =>
-  match t [List (Pair K V)] {
-    | Empty => nil [Pair K V]
-    | Node l k v _ r =>
-        append [Pair K V]
-          (toListEntries [K] [V] l)
-          (cons [Pair K V] (MkPair [K] [V] k v) (toListEntries [K] [V] r))
-  }
-
-poly rec fromList = #K => #V => \lteKey : K -> K -> Bool => \entries : List (Pair K V) =>
-  matchList [Pair K V] [Avl K V] entries (empty [K] [V])
-    (\entry : Pair K V => \rest : List (Pair K V) =>
-      let acc = fromList [K] [V] lteKey rest in
-      insert [K] [V] lteKey (fst [K] [V] entry) (snd [K] [V] entry) acc)
+poly rec fromList =
+  #K =>
+    #V =>
+      \lteKey : K -> K -> Bool =>
+        \entries : List (Pair K V) =>
+          matchList
+            [Pair K V]
+            [Avl K V]
+            entries
+            (empty [K] [V])
+            (
+              \entry : Pair K V =>
+                \rest : List (Pair K V) =>
+                  let acc = fromList [K] [V] lteKey rest in
+                  insert
+                    [K]
+                    [V]
+                    lteKey
+                    (fst [K] [V] entry)
+                    (snd [K] [V] entry)
+                    acc
+            )

--- a/lib/bin.trip
+++ b/lib/bin.trip
@@ -1,166 +1,215 @@
 module Bin
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude Pair
+
 import Prelude MkPair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude eqU8
+
 import Prelude addU8
+
 import Prelude not
+
 import Prelude digitToAscii
+
 import Prelude listIsEmpty
 
 export incBin
+
 export addBin
+
 export mulBin
+
 export subBin
+
 export predBin
+
 export isZeroBin
+
 export eqBin
+
 export ltBin
+
 export lteBin
+
 export gteBin
+
 export u8ToBin
+
 export binToDigits
 
-poly rec isZeroBin = \b : Bin =>
-  match b [Bool] {
-    | BZ => true
-    | B0 rest => isZeroBin rest
-    | B1 _ => false
-  }
+poly rec isZeroBin =
+  \b : Bin =>
+    match b [Bool] {
+      | BZ => true
+      | B0 rest => isZeroBin rest
+      | B1 _ => false
+    }
 
-poly rec incBin = \b : Bin =>
-  match b [Bin] {
-    | BZ => B1 BZ
-    | B0 rest => B1 rest
-    | B1 rest => B0 (incBin rest)
-  }
+poly rec incBin =
+  \b : Bin =>
+    match b [Bin] {
+      | BZ => B1 BZ
+      | B0 rest => B1 rest
+      | B1 rest => B0 (incBin rest)
+    }
 
-poly rec addBin = \a : Bin => \b : Bin =>
-  match a [Bin] {
-    | BZ => b
-    | B0 pa =>
-        match b [Bin] {
-          | BZ => a
-          | B0 pb => B0 (addBin pa pb)
-          | B1 pb => B1 (addBin pa pb)
-        }
-    | B1 pa =>
-        match b [Bin] {
-          | BZ => a
-          | B0 pb => B1 (addBin pa pb)
-          | B1 pb => B0 (incBin (addBin pa pb))
-        }
-  }
+poly rec addBin =
+  \a : Bin =>
+    \b : Bin =>
+      match a [Bin] {
+        | BZ => b
+        | B0 pa =>
+          match b [Bin] {
+            | BZ => a
+            | B0 pb => B0 (addBin pa pb)
+            | B1 pb => B1 (addBin pa pb)
+          }
+        | B1 pa =>
+          match b [Bin] {
+            | BZ => a
+            | B0 pb => B1 (addBin pa pb)
+            | B1 pb => B0 (incBin (addBin pa pb))
+          }
+      }
 
-poly rec mulBin = \a : Bin => \b : Bin =>
-  match b [Bin] {
-    | BZ => BZ
-    | B0 pb => B0 (mulBin a pb)
-    | B1 pb => addBin a (B0 (mulBin a pb))
-  }
+poly rec mulBin =
+  \a : Bin =>
+    \b : Bin =>
+      match b [Bin] {
+        | BZ => BZ
+        | B0 pb => B0 (mulBin a pb)
+        | B1 pb => addBin a (B0 (mulBin a pb))
+      }
 
-poly rec predBin = \b : Bin =>
-  match b [Bin] {
-    | BZ => BZ
-    | B0 rest => B1 (predBin rest)
-    | B1 rest => B0 rest
-  }
+poly rec predBin =
+  \b : Bin =>
+    match b [Bin] {
+      | BZ => BZ
+      | B0 rest => B1 (predBin rest)
+      | B1 rest => B0 rest
+    }
 
-poly rec subBin = \a : Bin => \b : Bin =>
-  match b [Bin] {
-    | BZ => a
-    | B0 pb =>
-        match a [Bin] {
-          | BZ => BZ
-          | B0 pa => B0 (subBin pa pb)
-          | B1 pa => B1 (subBin pa pb)
-        }
-    | B1 pb =>
-        match a [Bin] {
-          | BZ => BZ
-          | B0 pa => B1 (subBin (predBin pa) pb)
-          | B1 pa => B0 (subBin pa pb)
-        }
-  }
+poly rec subBin =
+  \a : Bin =>
+    \b : Bin =>
+      match b [Bin] {
+        | BZ => a
+        | B0 pb =>
+          match a [Bin] {
+            | BZ => BZ
+            | B0 pa => B0 (subBin pa pb)
+            | B1 pa => B1 (subBin pa pb)
+          }
+        | B1 pb =>
+          match a [Bin] {
+            | BZ => BZ
+            | B0 pa => B1 (subBin (predBin pa) pb)
+            | B1 pa => B0 (subBin pa pb)
+          }
+      }
 
-poly rec eqBin = \a : Bin => \b : Bin =>
-  match a [Bool] {
-    | BZ => isZeroBin b
-    | B0 pa =>
-        match b [Bool] {
-          | BZ => false
-          | B0 pb => eqBin pa pb
-          | B1 _ => false
-        }
-    | B1 pa =>
-        match b [Bool] {
-          | BZ => false
-          | B0 _ => false
-          | B1 pb => eqBin pa pb
-        }
-  }
+poly rec eqBin =
+  \a : Bin =>
+    \b : Bin =>
+      match a [Bool] {
+        | BZ => isZeroBin b
+        | B0 pa =>
+          match b [Bool] {
+            | BZ => false
+            | B0 pb => eqBin pa pb
+            | B1 _ => false
+          }
+        | B1 pa =>
+          match b [Bool] {
+            | BZ => false
+            | B0 _ => false
+            | B1 pb => eqBin pa pb
+          }
+      }
 
-poly rec ltBin = \a : Bin => \b : Bin =>
-  not (isZeroBin (subBin b a))
+poly rec ltBin =
+  \a : Bin => \b : Bin => not (isZeroBin (subBin b a))
 
-poly lteBin = \a : Bin => \b : Bin =>
-  isZeroBin (subBin a b)
+poly lteBin =
+  \a : Bin => \b : Bin => isZeroBin (subBin a b)
 
-poly gteBin = \a : Bin => \b : Bin =>
-  lteBin b a
+poly gteBin =
+  \a : Bin => \b : Bin => lteBin b a
 
-poly rec u8ToBinAcc = \count : U8 => \n : U8 => \acc : Bin =>
-  if [Bin] (eqU8 count n)
-    (\u : U8 => acc)
-    (\u : U8 => u8ToBinAcc (addU8 count #u8(1)) n (incBin acc))
+poly rec u8ToBinAcc =
+  \count : U8 =>
+    \n : U8 =>
+      \acc : Bin =>
+        if [Bin] (eqU8 count n)
+          (\u : U8 => acc)
+          (\u : U8 => u8ToBinAcc (addU8 count #u8(1)) n (incBin acc))
 
-poly u8ToBin = \n : U8 =>
-  u8ToBinAcc #u8(0) n BZ
+poly u8ToBin =
+  \n : U8 => u8ToBinAcc #u8(0) n BZ
 
-poly rec divModBinAcc = \n : Bin => \d : Bin => \q : Bin =>
-  if [Pair Bin Bin] (ltBin n d)
-    (\u : U8 => MkPair [Bin] [Bin] q n)
-    (\u : U8 => divModBinAcc (subBin n d) d (incBin q))
+poly rec divModBinAcc =
+  \n : Bin =>
+    \d : Bin =>
+      \q : Bin =>
+        if [Pair Bin Bin] (ltBin n d)
+          (\u : U8 => MkPair [Bin] [Bin] q n)
+          (\u : U8 => divModBinAcc (subBin n d) d (incBin q))
 
-poly divModBin = \n : Bin => \d : Bin =>
-  divModBinAcc n d BZ
+poly divModBin =
+  \n : Bin => \d : Bin => divModBinAcc n d BZ
 
-poly rec binToDigitsAcc = \val : Bin => \acc : List U8 =>
-  let ten = u8ToBin #u8(10) in
-  if [List U8] (isZeroBin val)
-    (\u : U8 => if [List U8] (listIsEmpty [U8] acc) (\u : U8 => "0") (\u : U8 => acc))
-    (\u : U8 =>
-      let res = divModBin val ten in
-      let q = fst [Bin] [Bin] res in
-      let r = snd [Bin] [Bin] res in
-      let digit = 
-        if [U8] (isZeroBin r) (\u : U8 => '0')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(1))) (\u : U8 => '1')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(2))) (\u : U8 => '2')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(3))) (\u : U8 => '3')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(4))) (\u : U8 => '4')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(5))) (\u : U8 => '5')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(6))) (\u : U8 => '6')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(7))) (\u : U8 => '7')
-        (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(8))) (\u : U8 => '8')
-        (\u : U8 => '9'))))))))) in
-      binToDigitsAcc q (cons [U8] digit acc))
+poly rec binToDigitsAcc =
+  \val : Bin =>
+    \acc : List U8 =>
+      let ten = u8ToBin #u8(10) in
+      if [List U8] (isZeroBin val)
+        (
+          \u : U8 =>
+            if [List U8] (listIsEmpty [U8] acc)
+              (\u : U8 => "0")
+              (\u : U8 => acc)
+        )
+        (
+          \u : U8 =>
+            let res = divModBin val ten in
+            let q = fst [Bin] [Bin] res in
+            let r = snd [Bin] [Bin] res in
+            let digit = if [U8] (isZeroBin r) (\u : U8 => '0') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(1))) (\u : U8 => '1') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(2))) (\u : U8 => '2') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(3))) (\u : U8 => '3') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(4))) (\u : U8 => '4') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(5))) (\u : U8 => '5') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(6))) (\u : U8 => '6') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(7))) (\u : U8 => '7') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(8))) (\u : U8 => '8') (\u : U8 => '9'))))))))) in
+            binToDigitsAcc q (cons [U8] digit acc)
+        )
 
-poly binToDigits = \b : Bin =>
-  binToDigitsAcc b (nil [U8])
+poly binToDigits =
+  \b : Bin => binToDigitsAcc b (nil [U8])

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -1,0 +1,1947 @@
+import { stat, readdir } from "node:fs/promises";
+import { basename, extname, join, resolve } from "node:path";
+import { parseTripLang } from "../parser/tripLang.ts";
+import { scanTrip, type ScanKind, type ScanToken } from "./lexer.ts";
+import {
+  KneserNeyLM,
+  getTrainedLMSync,
+  getStatisticalDiagnostics,
+} from "./statistical.ts";
+export { getTrainedLMSync };
+
+type TokenKind = Exclude<ScanKind, "space" | "newline">;
+
+interface Token extends Omit<ScanToken, "kind"> {
+  kind: TokenKind;
+}
+
+export interface TripFormatResult {
+  formatted: string;
+  changed: boolean;
+}
+
+export interface TripLintFix {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+export interface TripLintDiagnostic {
+  code: string;
+  message: string;
+  line: number;
+  column: number;
+  offset: number;
+  endOffset: number;
+  fix?: TripLintFix;
+}
+
+export interface TripLintResult {
+  diagnostics: TripLintDiagnostic[];
+  fixed: string;
+  changed: boolean;
+}
+
+const TOP_LEVEL_KEYWORDS = new Set([
+  "module",
+  "import",
+  "export",
+  "opaque",
+  "native",
+  "type",
+  "data",
+  "poly",
+  "combinator",
+]);
+
+const DEFINITION_KEYWORDS = new Set([
+  "opaque",
+  "native",
+  "type",
+  "data",
+  "poly",
+  "combinator",
+]);
+
+const GENERATED_DIRS = new Set([
+  ".git",
+  ".claude",
+  "node_modules",
+  "dist",
+  "ts_out",
+]);
+
+function normalizeSource(source: string): string {
+  return source.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function isAscii(source: string): boolean {
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) > 0x7f) return false;
+  }
+  return true;
+}
+
+function isSyntaxToken(token: ScanToken): token is Token {
+  return token.kind !== "space" && token.kind !== "newline";
+}
+
+function lexTrip(sourceText: string): Token[] {
+  const source = normalizeSource(sourceText);
+  if (!isAscii(source)) {
+    throw new Error("improvize only accepts ASCII Trip source");
+  }
+
+  return scanTrip(source, true).filter(isSyntaxToken);
+}
+
+function isComment(token: Token): boolean {
+  return token.kind === "lineComment" || token.kind === "blockComment";
+}
+
+function nonComment(tokens: readonly Token[]): Token[] {
+  return tokens.filter((token) => !isComment(token));
+}
+
+function shouldSkipDir(name: string): boolean {
+  return (
+    GENERATED_DIRS.has(name) ||
+    name.startsWith("bazel-") ||
+    name.startsWith(".tmp")
+  );
+}
+
+export async function discoverTripFiles(
+  inputPaths: readonly string[],
+  cwd = process.cwd(),
+): Promise<string[]> {
+  const files: string[] = [];
+
+  async function visit(path: string): Promise<void> {
+    const fullPath = resolve(cwd, path);
+    let stats;
+    try {
+      stats = await stat(fullPath);
+    } catch (error: any) {
+      if (error.code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+    if (stats.isFile()) {
+      if (extname(fullPath) === ".trip") {
+        files.push(fullPath);
+      }
+      return;
+    }
+    if (!stats.isDirectory()) {
+      return;
+    }
+    if (shouldSkipDir(basename(fullPath))) {
+      return;
+    }
+    const entries = await readdir(fullPath, { withFileTypes: true });
+    await Promise.all(
+      entries.map(async (entry) => {
+        if (entry.isDirectory() && shouldSkipDir(entry.name)) {
+          return;
+        }
+        await visit(join(fullPath, entry.name));
+      }),
+    );
+  }
+
+  await Promise.all(inputPaths.map(visit));
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function tokenTextForInline(token: Token): string {
+  return token.text;
+}
+
+function isNoSpaceBefore(token: Token): boolean {
+  return (
+    token.text === ")" ||
+    token.text === "]" ||
+    token.text === "}" ||
+    token.text === ","
+  );
+}
+
+function isNoSpaceAfter(token: Token): boolean {
+  return (
+    token.text === "(" ||
+    token.text === "[" ||
+    token.text === "{" ||
+    token.text === "#" ||
+    token.text === "\\"
+  );
+}
+
+function isOperatorLike(token: Token): boolean {
+  return token.text === "=" || token.text === "=>" || token.text === "->";
+}
+
+function needsInlineSpace(prev: Token | undefined, current: Token): boolean {
+  if (!prev) return false;
+  if (prev.text === "#") return false;
+  if (current.text === "(" && prev.text === "u8") return false;
+  if (prev.text === "(" || current.text === ")") return false;
+  if (prev.text === "[" || current.text === "]") return false;
+  if (current.text === "," || prev.text === ",") return prev.text === ",";
+  if (current.text === ":" || prev.text === ":") return true;
+  if (isOperatorLike(prev) || isOperatorLike(current)) return true;
+  if (isNoSpaceAfter(prev) || isNoSpaceBefore(current)) return false;
+  return true;
+}
+
+function formatInline(tokens: readonly Token[]): string {
+  const parts: string[] = [];
+  let prev: Token | undefined;
+  for (const token of tokens) {
+    if (isComment(token)) continue;
+    if (needsInlineSpace(prev, token)) {
+      parts.push(" ");
+    }
+    parts.push(tokenTextForInline(token));
+    prev = token;
+  }
+  return parts.join("").trim();
+}
+
+function appendIndentedLine(
+  lines: string[],
+  indent: number,
+  text: string,
+): void {
+  lines.push(`${" ".repeat(indent)}${text.trimEnd()}`);
+}
+
+function formatCommentToken(token: Token, indent: number): string[] {
+  if (token.kind === "lineComment") {
+    return [`${" ".repeat(indent)}${token.text.trimEnd()}`];
+  }
+  return token.text.split("\n").map((line) => {
+    const trimmed = line.trimEnd();
+    return trimmed.length === 0 ? "" : `${" ".repeat(indent)}${trimmed}`;
+  });
+}
+
+function splitLeadingComments(tokens: readonly Token[]): {
+  leading: Token[];
+  rest: Token[];
+} {
+  const leading: Token[] = [];
+  let index = 0;
+  while (index < tokens.length && isComment(tokens[index]!)) {
+    leading.push(tokens[index]!);
+    index++;
+  }
+  return { leading, rest: tokens.slice(index) };
+}
+
+// ---- Top-level token scanning --------------------------------------------
+// The pretty-printer repeatedly locates or splits tokens that sit at the
+// outermost bracket-nesting level. These helpers centralize the depth
+// bookkeeping that was otherwise copy-pasted into every check. A single
+// combined depth suffices: for the well-nested token streams the formatter
+// handles, "combined depth zero" coincides with "every bracket kind balanced".
+
+function bracketDepthDelta(token: Token): number {
+  switch (token.text) {
+    case "(":
+    case "[":
+    case "{":
+      return 1;
+    case ")":
+    case "]":
+    case "}":
+      return -1;
+    default:
+      return 0;
+  }
+}
+
+/** Index of the first non-comment token at top level satisfying `predicate`, or -1. */
+function findTopLevel(
+  tokens: readonly Token[],
+  predicate: (token: Token) => boolean,
+  from = 0,
+): number {
+  let depth = 0;
+  for (let i = from; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (isComment(token)) continue;
+    if (depth === 0 && predicate(token)) return i;
+    depth += bracketDepthDelta(token);
+  }
+  return -1;
+}
+
+/** Indices of every non-comment token at top level satisfying `predicate`. */
+function topLevelIndices(
+  tokens: readonly Token[],
+  predicate: (token: Token) => boolean,
+  from = 0,
+): number[] {
+  const indices: number[] = [];
+  let depth = 0;
+  for (let i = from; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (isComment(token)) continue;
+    if (depth === 0 && predicate(token)) indices.push(i);
+    depth += bracketDepthDelta(token);
+  }
+  return indices;
+}
+
+/**
+ * Splits `tokens` on top-level separator tokens, which are dropped. Empty
+ * groups are kept so callers can apply their own emptiness filter.
+ */
+function splitTopLevel(
+  tokens: readonly Token[],
+  isSeparator: (token: Token) => boolean,
+): Token[][] {
+  const groups: Token[][] = [];
+  let current: Token[] = [];
+  let depth = 0;
+  for (const token of tokens) {
+    if (depth === 0 && !isComment(token) && isSeparator(token)) {
+      groups.push(current);
+      current = [];
+      continue;
+    }
+    current.push(token);
+    if (!isComment(token)) depth += bracketDepthDelta(token);
+  }
+  groups.push(current);
+  return groups;
+}
+
+const isPipe = (token: Token): boolean => token.text === "|";
+
+/** A top-level operator: an arrow or any non-bracket symbol. */
+function isOperatorToken(token: Token): boolean {
+  return (
+    token.kind === "arrow" ||
+    token.kind === "fatArrow" ||
+    (token.kind === "symbol" && bracketDepthDelta(token) === 0)
+  );
+}
+
+function splitAtTopLevelEquals(tokens: readonly Token[]): {
+  before: Token[];
+  after: Token[];
+} {
+  const idx = findTopLevel(tokens, (token) => token.text === "=");
+  if (idx === -1) return { before: [...tokens], after: [] };
+  return { before: tokens.slice(0, idx), after: tokens.slice(idx + 1) };
+}
+
+function splitConstructors(tokens: readonly Token[]): Token[][] {
+  return splitTopLevel(tokens, isPipe).filter(
+    (group) => nonComment(group).length > 0,
+  );
+}
+
+function isBlockLike(tokens: readonly Token[]): boolean {
+  return tokens.some(
+    (t) => t.text === "let" || t.text === "match" || t.text === "if",
+  );
+}
+
+function findMatchingBrace(
+  tokens: readonly Token[],
+  startIdx: number,
+  open: string,
+  close: string,
+): number {
+  let depth = 0;
+  for (let i = startIdx; i < tokens.length; i++) {
+    const t = tokens[i]!;
+    if (t.text === open) depth++;
+    else if (t.text === close) {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+function formatExpressionRecursiveRaw(
+  tokens: readonly Token[],
+  indent: number,
+): string[] {
+  const nonComments = tokens.filter((t) => !isComment(t));
+  if (nonComments.length === 0) return [];
+
+  // Check 1: Binder chains at the very beginning
+  const firstToken = nonComments[0]!;
+  if (firstToken.text === "\\" || firstToken.text === "#") {
+    const arrowIdx = findTopLevel(tokens, (t) => t.text === "=>");
+    if (arrowIdx !== -1) {
+      const binderTokens = tokens.slice(0, arrowIdx + 1);
+      const bodyTokens = tokens.slice(arrowIdx + 1);
+      const binderStr = formatInline(binderTokens);
+      if (isBlockLike(bodyTokens) || formatInline(bodyTokens).length > 60) {
+        return [
+          `${" ".repeat(indent)}${binderStr}`,
+          ...formatExpressionRecursive(bodyTokens, indent + 2),
+        ];
+      } else {
+        return [
+          `${" ".repeat(indent)}${binderStr} ${formatInline(bodyTokens).trim()}`,
+        ];
+      }
+    }
+  }
+
+  // Check 2: Let chains at top level
+  const letIdx = findTopLevel(tokens, (t) => t.text === "let");
+
+  if (letIdx !== -1) {
+    const inIdx = findTopLevel(tokens, (t) => t.text === "in", letIdx + 1);
+
+    if (inIdx !== -1) {
+      const beforeLet = tokens.slice(0, letIdx);
+      const letBinding = tokens.slice(letIdx, inIdx + 1);
+      const letBody = tokens.slice(inIdx + 1);
+
+      const letBindingStr = formatInline(letBinding);
+      const bodyLines = formatExpressionRecursive(letBody, indent);
+
+      const lines: string[] = [];
+      if (beforeLet.length > 0) {
+        lines.push(`${" ".repeat(indent)}${formatInline(beforeLet)}`);
+      }
+      lines.push(`${" ".repeat(indent)}${letBindingStr}`);
+      lines.push(...bodyLines);
+      return lines;
+    }
+  }
+
+  // Check 3: Match expressions
+  const matchIdx = findTopLevel(tokens, (t) => t.text === "match");
+
+  if (matchIdx !== -1) {
+    const openBraceIdx = findTopLevel(
+      tokens,
+      (t) => t.text === "{",
+      matchIdx + 1,
+    );
+    if (openBraceIdx !== -1) {
+      const closeBraceIdx = findMatchingBrace(tokens, openBraceIdx, "{", "}");
+      if (closeBraceIdx !== -1) {
+        const beforeMatch = tokens.slice(0, matchIdx);
+        const matchHeader = tokens.slice(matchIdx, openBraceIdx);
+        const insideBraces = tokens.slice(openBraceIdx + 1, closeBraceIdx);
+        const afterMatch = tokens.slice(closeBraceIdx + 1);
+
+        const headerStr = formatInline(matchHeader) + " {";
+        const lines: string[] = [];
+
+        if (beforeMatch.length > 0) {
+          lines.push(`${" ".repeat(indent)}${formatInline(beforeMatch)}`);
+        }
+        lines.push(`${" ".repeat(indent)}${headerStr}`);
+
+        const armTokens = splitTopLevel(insideBraces, isPipe).filter(
+          (arm) => arm.length > 0,
+        );
+
+        for (const arm of armTokens) {
+          let fatArrowIdx = -1;
+          for (let i = 0; i < arm.length; i++) {
+            if (arm[i]!.text === "=>") {
+              fatArrowIdx = i;
+              break;
+            }
+          }
+          if (fatArrowIdx !== -1) {
+            const patternTokens = arm.slice(0, fatArrowIdx);
+            const armBodyTokens = arm.slice(fatArrowIdx + 1);
+            const patternStr = `| ${formatInline(patternTokens)} =>`;
+
+            if (
+              isBlockLike(armBodyTokens) ||
+              formatInline(armBodyTokens).length > 50
+            ) {
+              lines.push(`${" ".repeat(indent + 2)}${patternStr}`);
+              lines.push(
+                ...formatExpressionRecursive(armBodyTokens, indent + 4),
+              );
+            } else {
+              lines.push(
+                `${" ".repeat(indent + 2)}${patternStr} ${formatInline(armBodyTokens)}`,
+              );
+            }
+          } else {
+            lines.push(`${" ".repeat(indent + 2)}${formatInline(arm)}`);
+          }
+        }
+
+        lines.push(`${" ".repeat(indent)}}`);
+        if (afterMatch.length > 0) {
+          lines.push(...formatExpressionRecursive(afterMatch, indent));
+        }
+        return lines;
+      }
+    }
+  }
+
+  // Check 4: Structured 'if' expressions
+  const ifIdx = findTopLevel(tokens, (t) => t.text === "if");
+
+  if (ifIdx !== -1) {
+    const beforeIf = tokens.slice(0, ifIdx);
+    const ifRest = tokens.slice(ifIdx);
+
+    const argIndices = topLevelIndices(ifRest, (t) => t.text === "(", 1);
+
+    if (argIndices.length >= 2) {
+      const thenStart = argIndices[argIndices.length - 2]!;
+      const elseStart = argIndices[argIndices.length - 1]!;
+
+      const headerTokens = ifRest.slice(0, thenStart);
+      const thenTokens = ifRest.slice(thenStart, elseStart);
+      const elseTokens = ifRest.slice(elseStart);
+
+      const headerStr = formatInline(headerTokens);
+      const lines: string[] = [];
+      if (beforeIf.length > 0) {
+        lines.push(`${" ".repeat(indent)}${formatInline(beforeIf)}`);
+      }
+      lines.push(`${" ".repeat(indent)}${headerStr}`);
+      lines.push(...formatExpressionRecursive(thenTokens, indent + 2));
+      lines.push(...formatExpressionRecursive(elseTokens, indent + 2));
+      return lines;
+    }
+  }
+
+  // Check 5: Parenthesized expressions
+  if (
+    tokens.length >= 2 &&
+    tokens[0]!.text === "(" &&
+    findMatchingBrace(tokens, 0, "(", ")") === tokens.length - 1
+  ) {
+    const inner = tokens.slice(1, tokens.length - 1);
+    const innerLines = formatExpressionRecursiveRaw(inner, indent + 2);
+    if (innerLines.length > 0) {
+      if (innerLines.length > 1) {
+        return [
+          `${" ".repeat(indent)}(`,
+          ...innerLines,
+          `${" ".repeat(indent)})`,
+        ];
+      } else {
+        const inlineStr = `${" ".repeat(indent)}(${innerLines[0]!.trim()})`;
+        if (inlineStr.length <= 80) {
+          return [inlineStr];
+        } else {
+          return [
+            `${" ".repeat(indent)}(`,
+            innerLines[0]!,
+            `${" ".repeat(indent)})`,
+          ];
+        }
+      }
+    }
+  }
+
+  // Check 6: List and Pair literals
+  if (
+    tokens.length >= 3 &&
+    tokens[0]!.text === "{" &&
+    findMatchingBrace(tokens, 0, "{", "}") === tokens.length - 1
+  ) {
+    const innerPipe = findTopLevel(tokens.slice(1, tokens.length - 1), isPipe);
+    const pipeIdx = innerPipe === -1 ? -1 : innerPipe + 1;
+
+    if (pipeIdx !== -1) {
+      // Keep the literal on one line when it fits and holds no block construct,
+      // mirroring the parenthesized-expression fast-path above; only overflow
+      // (or a nested let/match/if) forces the element-per-line layout.
+      const inlineStr = `${" ".repeat(indent)}${formatInline(tokens)}`;
+      if (inlineStr.length <= 80 && !isBlockLike(tokens)) {
+        return [inlineStr];
+      }
+
+      const header = tokens.slice(0, pipeIdx + 1);
+      const body = tokens.slice(pipeIdx + 1, tokens.length - 1);
+      const headerStr = formatInline(header);
+
+      const args = splitTopLevelArguments(body);
+      if (args.length > 0) {
+        const lines = [`${" ".repeat(indent)}${headerStr}`];
+        for (const arg of args) {
+          lines.push(...formatExpressionRecursive(arg, indent + 2));
+        }
+        lines.push(`${" ".repeat(indent)}}`);
+        return lines;
+      }
+    }
+  }
+
+  // Check 7: Function application splitting for long lines
+  const inlineStr = `${" ".repeat(indent)}${formatInline(tokens)}`;
+  if (inlineStr.length > 80 && !hasTopLevelOperators(tokens)) {
+    const args = splitTopLevelArguments(tokens);
+    if (args.length > 1) {
+      const firstArg = args[0]!;
+      const restArgs = args.slice(1);
+      const lines = [...formatExpressionRecursive(firstArg, indent)];
+      for (const arg of restArgs) {
+        lines.push(...formatExpressionRecursive(arg, indent + 2));
+      }
+      return lines;
+    }
+  }
+
+  return [`${" ".repeat(indent)}${formatInline(tokens)}`];
+}
+
+function splitTopLevelArguments(tokens: readonly Token[]): Token[][] {
+  const args: Token[][] = [];
+  let current: Token[] = [];
+  let depth = 0;
+
+  for (const t of tokens) {
+    const isStartOfArg =
+      depth === 0 &&
+      current.length > 0 &&
+      !isComment(t) &&
+      (t.kind === "ident" ||
+        t.kind === "number" ||
+        t.kind === "string" ||
+        t.kind === "char" ||
+        t.text === "(" ||
+        t.text === "[" ||
+        t.text === "{" ||
+        t.text === "\\" ||
+        t.text === "#" ||
+        t.text === "'");
+
+    if (isStartOfArg) {
+      args.push(current);
+      current = [];
+    }
+
+    current.push(t);
+    if (!isComment(t)) depth += bracketDepthDelta(t);
+  }
+
+  if (current.length > 0) {
+    args.push(current);
+  }
+
+  return args;
+}
+
+function hasTopLevelOperators(tokens: readonly Token[]): boolean {
+  return findTopLevel(tokens, isOperatorToken) !== -1;
+}
+
+function formatExpressionRecursive(
+  tokens: readonly Token[],
+  indent: number,
+): string[] {
+  const resultLines = formatExpressionRecursiveRaw(tokens, indent);
+
+  const trailingComments: Token[] = [];
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const t = tokens[i]!;
+    if (isComment(t)) {
+      trailingComments.unshift(t);
+    } else {
+      break;
+    }
+  }
+
+  if (trailingComments.length > 0 && resultLines.length > 0) {
+    const commentStr = trailingComments.map((t) => t.text).join(" ");
+    resultLines[resultLines.length - 1] =
+      `${resultLines[resultLines.length - 1]} ${commentStr}`;
+  }
+  return resultLines;
+}
+
+function formatExpression(tokens: readonly Token[], indent: number): string[] {
+  return formatExpressionRecursive(tokens, indent);
+}
+
+function formatDataDecl(tokens: readonly Token[]): string[] {
+  const { before, after } = splitAtTopLevelEquals(tokens);
+  const lines = [`${formatInline(before)} =`];
+  for (const ctor of splitConstructors(after)) {
+    const comments = ctor.filter(isComment);
+    const rest = ctor.filter((token) => !isComment(token));
+    for (const comment of comments) {
+      lines.push(...formatCommentToken(comment, 2));
+    }
+    appendIndentedLine(lines, 2, `| ${formatInline(rest)}`);
+  }
+  return lines;
+}
+
+function formatDefinitionDecl(tokens: readonly Token[]): string[] {
+  const { before, after } = splitAtTopLevelEquals(tokens);
+  const header = formatInline(before);
+  if (after.length === 0) {
+    return [header];
+  }
+  return [`${header} =`, ...formatExpression(after, 2)];
+}
+
+function formatDecl(tokens: readonly Token[]): string[] {
+  const { leading, rest } = splitLeadingComments(tokens);
+  const lines: string[] = [];
+  for (const comment of leading) {
+    lines.push(...formatCommentToken(comment, 0));
+  }
+  const first = rest.find((token) => !isComment(token));
+  if (!first) return lines;
+
+  if (first.text === "data") {
+    lines.push(...formatDataDecl(rest));
+    return lines;
+  }
+  if (first.text === "poly" || first.text === "combinator") {
+    lines.push(...formatDefinitionDecl(rest));
+    return lines;
+  }
+  lines.push(formatInline(rest));
+  return lines;
+}
+
+function partitionDecls(tokens: readonly Token[]): Token[][] {
+  const groups: Token[][] = [];
+  let current: Token[] = [];
+  let depth = 0;
+  let hasCurrentSyntax = false;
+
+  const flushCurrentBeforeNextDecl = () => {
+    let split = current.length;
+    const lastSyntax = [...current]
+      .reverse()
+      .find((token) => !isComment(token));
+    if (lastSyntax) {
+      while (
+        split > 0 &&
+        isComment(current[split - 1]!) &&
+        current[split - 1]!.line > lastSyntax.line
+      ) {
+        split--;
+      }
+    }
+    const prior = current.slice(0, split);
+    const carry = current.slice(split);
+    if (prior.length > 0) groups.push(prior);
+    current = carry;
+    hasCurrentSyntax = false;
+  };
+
+  for (const token of tokens) {
+    const topLevel =
+      depth === 0 &&
+      token.kind === "ident" &&
+      TOP_LEVEL_KEYWORDS.has(token.text);
+
+    if (topLevel && hasCurrentSyntax) {
+      flushCurrentBeforeNextDecl();
+    }
+
+    current.push(token);
+    if (!isComment(token)) {
+      hasCurrentSyntax = true;
+      depth += bracketDepthDelta(token);
+    }
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+  return groups;
+}
+
+/**
+ * Parses `source` as a TripLang program and returns a stable structural key for
+ * its AST, or `undefined` when it does not parse. The TripLang AST carries no
+ * source positions (see the parse-equivalence tests), so two layouts of the
+ * same program produce identical keys — which lets a key mismatch stand in for
+ * a genuine difference in meaning.
+ */
+function parseProgramOrNull(source: string): string | undefined {
+  try {
+    return JSON.stringify(parseTripLang(source));
+  } catch {
+    return undefined;
+  }
+}
+
+export function formatTripSource(source: string): TripFormatResult {
+  const normalized = normalizeSource(source);
+  const tokens = lexTrip(normalized);
+  if (tokens.length === 0) {
+    return { formatted: "", changed: normalized.length > 0 };
+  }
+
+  const hasProgramDecl = tokens.some(
+    (token) => token.kind === "ident" && TOP_LEVEL_KEYWORDS.has(token.text),
+  );
+  const decls = hasProgramDecl ? partitionDecls(tokens) : [tokens];
+  const blocks = decls
+    .map((decl) =>
+      hasProgramDecl ? formatDecl(decl) : formatExpression(decl, 0),
+    )
+    .filter((block) => block.some((line) => line.trim().length > 0));
+
+  const lines: string[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    if (i > 0) lines.push("");
+    lines.push(...blocks[i]!);
+  }
+  const formatted = `${lines.join("\n").replace(/[ \t]+$/gm, "")}\n`;
+
+  // A formatter must never change a program's meaning. The pretty-printer is a
+  // heuristic token reflow, so verify the result round-trips: when the input is
+  // a parseable program, the output must parse to the same AST. If it does not,
+  // fall back to the input untouched rather than emit a divergent reformat.
+  const before = parseProgramOrNull(normalized);
+  if (before !== undefined && parseProgramOrNull(formatted) !== before) {
+    return { formatted: normalized, changed: false };
+  }
+
+  return { formatted, changed: formatted !== normalized };
+}
+
+function locationAt(
+  source: string,
+  offset: number,
+): { line: number; column: number } {
+  let line = 1;
+  let column = 1;
+  for (let i = 0; i < offset; i++) {
+    if (source[i] === "\n") {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+  return { line, column };
+}
+
+function diagnostic(
+  code: string,
+  message: string,
+  token: Token,
+  fix?: TripLintFix,
+): TripLintDiagnostic {
+  return {
+    code,
+    message,
+    line: token.line,
+    column: token.column,
+    offset: token.start,
+    endOffset: token.end,
+    ...(fix ? { fix } : {}),
+  };
+}
+
+function previousSyntax(
+  tokens: readonly Token[],
+  index: number,
+): Token | undefined {
+  for (let i = index - 1; i >= 0; i--) {
+    const token = tokens[i]!;
+    if (!isComment(token)) return token;
+  }
+  return undefined;
+}
+
+function nextSyntax(
+  tokens: readonly Token[],
+  index: number,
+): Token | undefined {
+  for (let i = index + 1; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (!isComment(token)) return token;
+  }
+  return undefined;
+}
+
+function isExistingU8Literal(tokens: readonly Token[], index: number): boolean {
+  const number = tokens[index]!;
+  const lparenMatch = previousSyntaxWithIndex(tokens, index);
+  if (!lparenMatch || lparenMatch.token.text !== "(") return false;
+  const u8Match = previousSyntaxWithIndex(tokens, lparenMatch.index);
+  if (!u8Match || u8Match.token.text !== "u8") return false;
+  const hashMatch = previousSyntaxWithIndex(tokens, u8Match.index);
+  const rparenMatch = nextSyntaxWithIndex(tokens, index);
+  return (
+    hashMatch?.token.text === "#" &&
+    rparenMatch?.token.text === ")" &&
+    number.kind === "number"
+  );
+}
+
+function collectTopLevelBindings(tokens: readonly Token[]): {
+  moduleName?: string;
+  imports: Set<string>;
+  localDefinitions: Set<string>;
+} {
+  const imports = new Set<string>();
+  const localDefinitions = new Set<string>();
+  let moduleName: string | undefined;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (token.kind !== "ident") continue;
+    if (token.text === "module") {
+      const nameMatch = nextSyntaxWithIndex(tokens, i);
+      if (nameMatch?.token.kind === "ident") moduleName = nameMatch.token.text;
+      continue;
+    }
+    if (token.text === "import") {
+      const fromMatch = nextSyntaxWithIndex(tokens, i);
+      if (fromMatch) {
+        const symbolMatch = nextSyntaxWithIndex(tokens, fromMatch.index);
+        if (
+          fromMatch.token.text === "Prelude" &&
+          symbolMatch?.token.kind === "ident"
+        ) {
+          imports.add(symbolMatch.token.text);
+        }
+      }
+      continue;
+    }
+    if (DEFINITION_KEYWORDS.has(token.text)) {
+      const firstMatch = nextSyntaxWithIndex(tokens, i);
+      if (firstMatch) {
+        let nameMatch = firstMatch;
+        if (token.text === "opaque" && firstMatch.token.text === "type") {
+          const secondMatch = nextSyntaxWithIndex(tokens, firstMatch.index);
+          if (secondMatch) nameMatch = secondMatch;
+        }
+        if (token.text === "poly" && firstMatch.token.text === "rec") {
+          const secondMatch = nextSyntaxWithIndex(tokens, firstMatch.index);
+          if (secondMatch) nameMatch = secondMatch;
+        }
+        if (nameMatch.token.kind === "ident") {
+          localDefinitions.add(nameMatch.token.text);
+        }
+      }
+    }
+  }
+
+  return { moduleName, imports, localDefinitions };
+}
+
+function canUsePrelude(
+  info: ReturnType<typeof collectTopLevelBindings>,
+  name: string,
+): boolean {
+  return (
+    info.moduleName !== "Prelude" &&
+    info.imports.has(name) &&
+    !info.localDefinitions.has(name)
+  );
+}
+
+function simpleTokenReplacement(token: Token): string | undefined {
+  if (
+    token.kind === "ident" ||
+    token.kind === "number" ||
+    token.kind === "string" ||
+    token.kind === "char"
+  ) {
+    return token.text;
+  }
+  return undefined;
+}
+
+function nextSyntaxWithIndex(
+  tokens: readonly Token[],
+  index: number,
+): { token: Token; index: number } | undefined {
+  for (let i = index + 1; i < tokens.length; i++) {
+    const token = tokens[i]!;
+    if (!isComment(token)) return { token, index: i };
+  }
+  return undefined;
+}
+
+function previousSyntaxWithIndex(
+  tokens: readonly Token[],
+  index: number,
+): { token: Token; index: number } | undefined {
+  for (let i = index - 1; i >= 0; i--) {
+    const token = tokens[i]!;
+    if (!isComment(token)) return { token, index: i };
+  }
+  return undefined;
+}
+
+function parseArgExpression(
+  tokens: readonly Token[],
+  index: number,
+): { tokens: Token[]; endIndex: number } | undefined {
+  let startIdx = index;
+  while (startIdx < tokens.length && isComment(tokens[startIdx]!)) {
+    startIdx++;
+  }
+  if (startIdx >= tokens.length) return undefined;
+
+  const firstToken = tokens[startIdx]!;
+  if (
+    firstToken.text === "(" ||
+    firstToken.text === "{" ||
+    firstToken.text === "["
+  ) {
+    const open = firstToken.text;
+    const close = open === "(" ? ")" : open === "{" ? "}" : "]";
+    let depth = 1;
+    const argTokens: Token[] = [firstToken];
+    let cursor = startIdx + 1;
+    while (cursor < tokens.length) {
+      const t = tokens[cursor]!;
+      if (t.text === open) depth++;
+      else if (t.text === close) depth--;
+      argTokens.push(t);
+      if (depth === 0) break;
+      cursor++;
+    }
+    if (depth === 0) {
+      return { tokens: argTokens, endIndex: cursor };
+    }
+    return undefined;
+  }
+
+  if (
+    firstToken.kind === "ident" ||
+    firstToken.kind === "number" ||
+    firstToken.kind === "string" ||
+    firstToken.kind === "char"
+  ) {
+    return { tokens: [firstToken], endIndex: startIdx };
+  }
+
+  return undefined;
+}
+
+function stripOuterParens(tokens: readonly Token[]): Token[] {
+  let list = [...tokens];
+  while (list.length > 0) {
+    let start = 0;
+    while (start < list.length && isComment(list[start]!)) {
+      start++;
+    }
+    let end = list.length - 1;
+    while (end >= 0 && isComment(list[end]!)) {
+      end--;
+    }
+    if (start >= end) break;
+    const first = list[start]!;
+    const last = list[end]!;
+    if (first.text === "(" && last.text === ")") {
+      let depth = 0;
+      let matches = true;
+      for (let i = start; i <= end; i++) {
+        if (list[i]!.text === "(") depth++;
+        else if (list[i]!.text === ")") depth--;
+        if (depth === 0 && i < end) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        list = list.slice(start + 1, end);
+        continue;
+      }
+    }
+    break;
+  }
+  return list;
+}
+
+function parseListChain(
+  tokens: readonly Token[],
+  index: number,
+): { typeText: string; elements: Token[][]; endIndex: number } | undefined {
+  const token = tokens[index];
+  if (!token) return undefined;
+
+  if (token.text === "nil") {
+    const next = nextSyntaxWithIndex(tokens, index);
+    if (next?.token.text === "[") {
+      const typeTokens: Token[] = [];
+      let cursor = next.index + 1;
+      let depth = 1;
+      while (cursor < tokens.length) {
+        const t = tokens[cursor]!;
+        if (t.text === "[") depth++;
+        if (t.text === "]") depth--;
+        if (depth === 0) break;
+        typeTokens.push(t);
+        cursor++;
+      }
+      if (cursor < tokens.length) {
+        return {
+          typeText: formatInline(typeTokens),
+          elements: [],
+          endIndex: cursor,
+        };
+      }
+    }
+  }
+
+  if (token.text === "cons") {
+    const next = nextSyntaxWithIndex(tokens, index);
+    if (next?.token.text === "[") {
+      const typeTokens: Token[] = [];
+      let cursor = next.index + 1;
+      let depth = 1;
+      while (cursor < tokens.length) {
+        const t = tokens[cursor]!;
+        if (t.text === "[") depth++;
+        if (t.text === "]") depth--;
+        if (depth === 0) break;
+        typeTokens.push(t);
+        cursor++;
+      }
+      if (cursor < tokens.length) {
+        const firstArg = parseArgExpression(tokens, cursor + 1);
+        if (firstArg) {
+          const secondArg = parseArgExpression(tokens, firstArg.endIndex + 1);
+          if (secondArg) {
+            const innerTokens = stripOuterParens(secondArg.tokens);
+            const nestedChain = parseListChain(innerTokens, 0);
+            const typeText = formatInline(typeTokens);
+            if (nestedChain && nestedChain.typeText === typeText) {
+              return {
+                typeText,
+                elements: [firstArg.tokens, ...nestedChain.elements],
+                endIndex: secondArg.endIndex,
+              };
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function parseListLiteral(
+  tokens: readonly Token[],
+  index: number,
+): { typeText: string; elements: Token[][]; endIndex: number } | undefined {
+  const token = tokens[index];
+  if (token?.text !== "{") return undefined;
+
+  const closeIdx = findMatchingBrace(tokens, index, "{", "}");
+  if (closeIdx === -1) return undefined;
+
+  const pipeRel = findTopLevel(tokens.slice(index + 1, closeIdx), isPipe);
+  if (pipeRel === -1) return undefined;
+  const pipeIdx = pipeRel + index + 1;
+
+  const typeTokens = tokens.slice(index + 1, pipeIdx);
+  const elementTokens = tokens.slice(pipeIdx + 1, closeIdx);
+
+  const elements: Token[][] = [];
+  let cursor = 0;
+  while (cursor < elementTokens.length) {
+    while (cursor < elementTokens.length && isComment(elementTokens[cursor]!)) {
+      cursor++;
+    }
+    if (cursor >= elementTokens.length) break;
+    const arg = parseArgExpression(elementTokens, cursor);
+    if (!arg) return undefined;
+    elements.push(arg.tokens);
+    cursor = arg.endIndex + 1;
+  }
+
+  return {
+    typeText: formatInline(typeTokens),
+    elements,
+    endIndex: closeIdx,
+  };
+}
+
+function parseAppendChain(
+  tokens: readonly Token[],
+  index: number,
+): { typeText: string; elements: Token[][]; endIndex: number } | undefined {
+  const token = tokens[index];
+  if (token?.text !== "append") return undefined;
+
+  const next = nextSyntaxWithIndex(tokens, index);
+  if (next?.token.text !== "[") return undefined;
+
+  const typeTokens: Token[] = [];
+  let cursor = next.index + 1;
+  let depth = 1;
+  while (cursor < tokens.length) {
+    const t = tokens[cursor]!;
+    if (t.text === "[") depth++;
+    if (t.text === "]") depth--;
+    if (depth === 0) break;
+    typeTokens.push(t);
+    cursor++;
+  }
+  if (cursor >= tokens.length) return undefined;
+
+  const arg1 = parseArgExpression(tokens, cursor + 1);
+  if (!arg1) return undefined;
+
+  const arg2 = parseArgExpression(tokens, arg1.endIndex + 1);
+  if (!arg2) return undefined;
+
+  const list1 = resolveAsStaticList(arg1.tokens);
+  const list2 = resolveAsStaticList(arg2.tokens);
+
+  const typeText = formatInline(typeTokens);
+  if (
+    list1 &&
+    list2 &&
+    list1.typeText === typeText &&
+    list2.typeText === typeText
+  ) {
+    return {
+      typeText,
+      elements: [...list1.elements, ...list2.elements],
+      endIndex: arg2.endIndex,
+    };
+  }
+
+  return undefined;
+}
+
+function resolveAsStaticList(
+  tokens: readonly Token[],
+): { typeText: string; elements: Token[][] } | undefined {
+  const stripped = stripOuterParens(tokens);
+  if (stripped.length === 0) return undefined;
+
+  const chain = parseListChain(stripped, 0);
+  if (chain) return { typeText: chain.typeText, elements: chain.elements };
+
+  const literal = parseListLiteral(stripped, 0);
+  if (literal && literal.endIndex === stripped.length - 1) {
+    return { typeText: literal.typeText, elements: literal.elements };
+  }
+
+  const append = parseAppendChain(stripped, 0);
+  if (append && append.endIndex === stripped.length - 1) {
+    return { typeText: append.typeText, elements: append.elements };
+  }
+
+  return undefined;
+}
+
+function convertToStaticString(elements: Token[][]): string | undefined {
+  const chars: string[] = [];
+  for (const elem of elements) {
+    if (elem.length !== 1 || elem[0]!.kind !== "char") {
+      return undefined;
+    }
+    const charText = elem[0]!.text;
+    if (!charText.startsWith("'") || !charText.endsWith("'")) {
+      return undefined;
+    }
+    const inner = charText.slice(1, -1);
+    if (inner === "\\'") {
+      chars.push("'");
+    } else if (inner === '"') {
+      chars.push('\\"');
+    } else {
+      chars.push(inner);
+    }
+  }
+  return `"${chars.join("")}"`;
+}
+
+function matchMkPair(
+  tokens: readonly Token[],
+  index: number,
+):
+  | {
+      type1Text: string;
+      type2Text: string;
+      term1Tokens: Token[];
+      term2Tokens: Token[];
+      endIndex: number;
+    }
+  | undefined {
+  const token = tokens[index];
+  if (token?.text !== "MkPair") return undefined;
+
+  const next1 = nextSyntaxWithIndex(tokens, index);
+  if (next1?.token.text !== "[") return undefined;
+
+  const type1Tokens: Token[] = [];
+  let cursor = next1.index + 1;
+  let depth = 1;
+  while (cursor < tokens.length) {
+    const t = tokens[cursor]!;
+    if (t.text === "[") depth++;
+    if (t.text === "]") depth--;
+    if (depth === 0) break;
+    type1Tokens.push(t);
+    cursor++;
+  }
+  if (cursor >= tokens.length) return undefined;
+
+  const next2 = nextSyntaxWithIndex(tokens, cursor);
+  if (next2?.token.text !== "[") return undefined;
+
+  const type2Tokens: Token[] = [];
+  cursor = next2.index + 1;
+  depth = 1;
+  while (cursor < tokens.length) {
+    const t = tokens[cursor]!;
+    if (t.text === "[") depth++;
+    if (t.text === "]") depth--;
+    if (depth === 0) break;
+    type2Tokens.push(t);
+    cursor++;
+  }
+  if (cursor >= tokens.length) return undefined;
+
+  const term1 = parseArgExpression(tokens, cursor + 1);
+  if (!term1) return undefined;
+
+  const term2 = parseArgExpression(tokens, term1.endIndex + 1);
+  if (!term2) return undefined;
+
+  return {
+    type1Text: formatInline(type1Tokens),
+    type2Text: formatInline(type2Tokens),
+    term1Tokens: term1.tokens,
+    term2Tokens: term2.tokens,
+    endIndex: term2.endIndex,
+  };
+}
+
+function matchPairType(
+  tokens: readonly Token[],
+  index: number,
+):
+  | { type1Tokens: Token[]; type2Tokens: Token[]; endIndex: number }
+  | undefined {
+  const token = tokens[index];
+  if (token?.text !== "Pair") return undefined;
+
+  const type1 = parseArgExpression(tokens, index + 1);
+  if (!type1) return undefined;
+
+  const type2 = parseArgExpression(tokens, type1.endIndex + 1);
+  if (!type2) return undefined;
+
+  return {
+    type1Tokens: type1.tokens,
+    type2Tokens: type2.tokens,
+    endIndex: type2.endIndex,
+  };
+}
+
+function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
+  const diagnostics: TripLintDiagnostic[] = [];
+  const topLevel = collectTopLevelBindings(tokens);
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]!;
+
+    // 1. Append chain simplification
+    const appendMatch = parseAppendChain(tokens, i);
+    if (appendMatch) {
+      if (appendMatch.typeText === "U8") {
+        const strLit = convertToStaticString(appendMatch.elements);
+        if (strLit !== undefined) {
+          diagnostics.push(
+            diagnostic(
+              "trip-string-append",
+              `Use double-quoted string literal ${strLit} instead of character list/append`,
+              tokens[i]!,
+              {
+                start: tokens[i]!.start,
+                end: tokens[appendMatch.endIndex]!.end,
+                replacement: strLit,
+              },
+            ),
+          );
+          i = appendMatch.endIndex;
+          continue;
+        }
+      }
+
+      const elementsStr = appendMatch.elements
+        .map((t) => formatInline(t))
+        .join(" ");
+      const replacement = `{${appendMatch.typeText} |${elementsStr ? " " + elementsStr : ""}}`;
+      diagnostics.push(
+        diagnostic(
+          "trip-list-append",
+          `Use syntactic sugar {${appendMatch.typeText} | ...} for list append/construction`,
+          tokens[i]!,
+          {
+            start: tokens[i]!.start,
+            end: tokens[appendMatch.endIndex]!.end,
+            replacement,
+          },
+        ),
+      );
+      i = appendMatch.endIndex;
+      continue;
+    }
+
+    // 2. List cons/nil chain simplification
+    const listChainMatch = parseListChain(tokens, i);
+    if (listChainMatch) {
+      if (listChainMatch.typeText === "U8") {
+        const strLit = convertToStaticString(listChainMatch.elements);
+        if (strLit !== undefined) {
+          diagnostics.push(
+            diagnostic(
+              "trip-string-literal",
+              `Use double-quoted string literal ${strLit} instead of character list/cons`,
+              tokens[i]!,
+              {
+                start: tokens[i]!.start,
+                end: tokens[listChainMatch.endIndex]!.end,
+                replacement: strLit,
+              },
+            ),
+          );
+          i = listChainMatch.endIndex;
+          continue;
+        }
+      }
+
+      const elementsStr = listChainMatch.elements
+        .map((t) => formatInline(t))
+        .join(" ");
+      const replacement = `{${listChainMatch.typeText} |${elementsStr ? " " + elementsStr : ""}}`;
+      diagnostics.push(
+        diagnostic(
+          "trip-list-literal",
+          `Use syntactic sugar {${listChainMatch.typeText} | ...} for list construction`,
+          tokens[i]!,
+          {
+            start: tokens[i]!.start,
+            end: tokens[listChainMatch.endIndex]!.end,
+            replacement,
+          },
+        ),
+      );
+      i = listChainMatch.endIndex;
+      continue;
+    }
+
+    // 3. List literal to string literal conversion (for U8 chars)
+    const listLiteralMatch = parseListLiteral(tokens, i);
+    if (listLiteralMatch) {
+      if (listLiteralMatch.typeText === "U8") {
+        const strLit = convertToStaticString(listLiteralMatch.elements);
+        if (strLit !== undefined) {
+          diagnostics.push(
+            diagnostic(
+              "trip-string-literal",
+              `Use double-quoted string literal ${strLit} instead of U8 character list`,
+              tokens[i]!,
+              {
+                start: tokens[i]!.start,
+                end: tokens[listLiteralMatch.endIndex]!.end,
+                replacement: strLit,
+              },
+            ),
+          );
+          i = listLiteralMatch.endIndex;
+          continue;
+        }
+      }
+    }
+
+    // 4. Pair literal simplification
+    const pairLiteralMatch = matchMkPair(tokens, i);
+    if (pairLiteralMatch) {
+      const replacement = `{${pairLiteralMatch.type1Text}, ${pairLiteralMatch.type2Text} | ${formatInline(pairLiteralMatch.term1Tokens)}, ${formatInline(pairLiteralMatch.term2Tokens)}}`;
+      diagnostics.push(
+        diagnostic(
+          "trip-pair-literal",
+          `Use syntactic sugar {${pairLiteralMatch.type1Text}, ${pairLiteralMatch.type2Text} | ...} for pair creation`,
+          tokens[i]!,
+          {
+            start: tokens[i]!.start,
+            end: tokens[pairLiteralMatch.endIndex]!.end,
+            replacement,
+          },
+        ),
+      );
+      i = pairLiteralMatch.endIndex;
+      continue;
+    }
+
+    // 5. Pair type simplification
+    const prevText = previousSyntax(tokens, i)?.text;
+    if (prevText !== "data" && prevText !== "type") {
+      const pairTypeMatch = matchPairType(tokens, i);
+      if (pairTypeMatch) {
+        const replacement = `(${formatInline(pairTypeMatch.type1Tokens)}, ${formatInline(pairTypeMatch.type2Tokens)})`;
+        diagnostics.push(
+          diagnostic(
+            "trip-pair-type",
+            `Use syntactic sugar (Type1, Type2) for pair type`,
+            tokens[i]!,
+            {
+              start: tokens[i]!.start,
+              end: tokens[pairTypeMatch.endIndex]!.end,
+              replacement,
+            },
+          ),
+        );
+        i = pairTypeMatch.endIndex;
+        continue;
+      }
+    }
+    if (token.kind === "number") {
+      const value = Number(token.text);
+      if (
+        Number.isInteger(value) &&
+        value >= 0 &&
+        value <= 255 &&
+        !isExistingU8Literal(tokens, i)
+      ) {
+        diagnostics.push(
+          diagnostic(
+            "trip-u8-literal",
+            `Use canonical #u8(${value}) spelling for byte literals`,
+            token,
+            {
+              start: token.start,
+              end: token.end,
+              replacement: `#u8(${value})`,
+            },
+          ),
+        );
+      }
+    }
+
+    if (token.text === "(") {
+      const prevMatch = previousSyntaxWithIndex(tokens, i);
+      const beforePrevMatch = prevMatch
+        ? previousSyntaxWithIndex(tokens, prevMatch.index)
+        : undefined;
+      if (
+        prevMatch?.token.text === "u8" &&
+        beforePrevMatch?.token.text === "#"
+      ) {
+        continue;
+      }
+      const atomMatch = nextSyntaxWithIndex(tokens, i);
+      if (atomMatch) {
+        const closeMatch = nextSyntaxWithIndex(tokens, atomMatch.index);
+        if (
+          closeMatch?.token.text === ")" &&
+          simpleTokenReplacement(atomMatch.token)
+        ) {
+          diagnostics.push(
+            diagnostic(
+              "trip-redundant-parens",
+              "Remove redundant parentheses around an atomic expression",
+              token,
+              {
+                start: token.start,
+                end: closeMatch.token.end,
+                replacement: atomMatch.token.text,
+              },
+            ),
+          );
+        }
+      }
+    }
+
+    if (token.text === "\\") {
+      const nameMatch = nextSyntaxWithIndex(tokens, i);
+      if (!nameMatch || nameMatch.token.kind !== "ident") continue;
+      const colonMatch = nextSyntaxWithIndex(tokens, nameMatch.index);
+      if (colonMatch?.token.text !== ":") continue;
+      let cursor = colonMatch.index;
+      let arrowMatch: { token: Token; index: number } | undefined;
+      while ((arrowMatch = nextSyntaxWithIndex(tokens, cursor))) {
+        cursor = arrowMatch.index;
+        if (arrowMatch.token.text === "=>") break;
+        if (
+          arrowMatch.token.text === ")" ||
+          arrowMatch.token.text === "}" ||
+          arrowMatch.token.text === "|"
+        ) {
+          arrowMatch = undefined;
+          break;
+        }
+      }
+      if (!arrowMatch) continue;
+      const fnMatch = nextSyntaxWithIndex(tokens, arrowMatch.index);
+      if (!fnMatch) continue;
+      const argMatch = nextSyntaxWithIndex(tokens, fnMatch.index);
+      if (!argMatch) continue;
+      const afterArgMatch = nextSyntaxWithIndex(tokens, argMatch.index);
+      if (
+        fnMatch.token.kind === "ident" &&
+        argMatch.token.kind === "ident" &&
+        argMatch.token.text === nameMatch.token.text &&
+        fnMatch.token.text !== nameMatch.token.text &&
+        (!afterArgMatch ||
+          [")", "}", "|"].includes(afterArgMatch.token.text) ||
+          TOP_LEVEL_KEYWORDS.has(afterArgMatch.token.text))
+      ) {
+        diagnostics.push(
+          diagnostic(
+            "trip-eta-reduce",
+            `Eta-reduce \\${nameMatch.token.text} -> ${fnMatch.token.text}`,
+            token,
+            {
+              start: token.start,
+              end: argMatch.token.end,
+              replacement: fnMatch.token.text,
+            },
+          ),
+        );
+      }
+    }
+
+    if (token.text === "#") {
+      const nameMatch = nextSyntaxWithIndex(tokens, i);
+      if (nameMatch?.token.kind === "ident") {
+        const arrowMatch = nextSyntaxWithIndex(tokens, nameMatch.index);
+        if (arrowMatch?.token.text === "=>") {
+          const fnMatch = nextSyntaxWithIndex(tokens, arrowMatch.index);
+          if (fnMatch?.token.kind === "ident") {
+            const lbracketMatch = nextSyntaxWithIndex(tokens, fnMatch.index);
+            if (lbracketMatch?.token.text === "[") {
+              const tyMatch = nextSyntaxWithIndex(tokens, lbracketMatch.index);
+              if (
+                tyMatch?.token.kind === "ident" &&
+                tyMatch.token.text === nameMatch.token.text
+              ) {
+                const rbracketMatch = nextSyntaxWithIndex(
+                  tokens,
+                  tyMatch.index,
+                );
+                if (rbracketMatch?.token.text === "]") {
+                  diagnostics.push(
+                    diagnostic(
+                      "trip-type-eta-reduce",
+                      `Type-eta-reduce #${nameMatch.token.text}`,
+                      token,
+                      {
+                        start: token.start,
+                        end: rbracketMatch.token.end,
+                        replacement: fnMatch.token.text,
+                      },
+                    ),
+                  );
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (token.text === "let") {
+      const nameMatch = nextSyntaxWithIndex(tokens, i);
+      if (nameMatch?.token.kind === "ident") {
+        const eqMatch = nextSyntaxWithIndex(tokens, nameMatch.index);
+        if (eqMatch?.token.text === "=") {
+          const valueMatch = nextSyntaxWithIndex(tokens, eqMatch.index);
+          if (valueMatch && simpleTokenReplacement(valueMatch.token)) {
+            const inMatch = nextSyntaxWithIndex(tokens, valueMatch.index);
+            if (inMatch?.token.text === "in") {
+              const bodyMatch = nextSyntaxWithIndex(tokens, inMatch.index);
+              if (
+                bodyMatch?.token.kind === "ident" &&
+                bodyMatch.token.text === nameMatch.token.text
+              ) {
+                diagnostics.push(
+                  diagnostic(
+                    "trip-let-identity",
+                    "Replace identity let binding with its value",
+                    token,
+                    {
+                      start: token.start,
+                      end: bodyMatch.token.end,
+                      replacement: valueMatch.token.text,
+                    },
+                  ),
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (canUsePrelude(topLevel, "not")) {
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]!;
+      if (token.text !== "not") continue;
+      const argMatch = nextSyntaxWithIndex(tokens, i);
+      if (argMatch?.token.text === "true" || argMatch?.token.text === "false") {
+        diagnostics.push(
+          diagnostic(
+            "trip-bool-constant",
+            `Simplify not ${argMatch.token.text}`,
+            token,
+            {
+              start: token.start,
+              end: argMatch.token.end,
+              replacement: argMatch.token.text === "true" ? "false" : "true",
+            },
+          ),
+        );
+      }
+    }
+  }
+
+  for (const op of ["and", "or"] as const) {
+    if (!canUsePrelude(topLevel, op)) continue;
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]!;
+      if (token.text !== op) continue;
+      const leftMatch = nextSyntaxWithIndex(tokens, i);
+      if (leftMatch) {
+        const rightMatch = nextSyntaxWithIndex(tokens, leftMatch.index);
+        if (rightMatch) {
+          const left = leftMatch.token;
+          const right = rightMatch.token;
+          const rightReplacement = simpleTokenReplacement(right);
+          const leftReplacement = simpleTokenReplacement(left);
+          if (op === "and" && left.text === "true" && rightReplacement) {
+            diagnostics.push(
+              diagnostic("trip-bool-identity", "Simplify and true x", token, {
+                start: token.start,
+                end: right.end,
+                replacement: rightReplacement,
+              }),
+            );
+          } else if (op === "and" && right.text === "true" && leftReplacement) {
+            diagnostics.push(
+              diagnostic("trip-bool-identity", "Simplify and x true", token, {
+                start: token.start,
+                end: right.end,
+                replacement: leftReplacement,
+              }),
+            );
+          } else if (
+            op === "and" &&
+            (left.text === "false" || right.text === "false")
+          ) {
+            diagnostics.push(
+              diagnostic("trip-bool-constant", "Simplify and false", token, {
+                start: token.start,
+                end: right.end,
+                replacement: "false",
+              }),
+            );
+          } else if (op === "or" && left.text === "false" && rightReplacement) {
+            diagnostics.push(
+              diagnostic("trip-bool-identity", "Simplify or false x", token, {
+                start: token.start,
+                end: right.end,
+                replacement: rightReplacement,
+              }),
+            );
+          } else if (op === "or" && right.text === "false" && leftReplacement) {
+            diagnostics.push(
+              diagnostic("trip-bool-identity", "Simplify or x false", token, {
+                start: token.start,
+                end: right.end,
+                replacement: leftReplacement,
+              }),
+            );
+          } else if (
+            op === "or" &&
+            (left.text === "true" || right.text === "true")
+          ) {
+            diagnostics.push(
+              diagnostic("trip-bool-constant", "Simplify or true", token, {
+                start: token.start,
+                end: right.end,
+                replacement: "true",
+              }),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (canUsePrelude(topLevel, "if")) {
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i]!;
+      if (token.text !== "if") continue;
+      const lbracketMatch = nextSyntaxWithIndex(tokens, i);
+      if (lbracketMatch?.token.text === "[") {
+        let cursor = lbracketMatch.index;
+        let rbracketMatch: { token: Token; index: number } | undefined;
+        while ((rbracketMatch = nextSyntaxWithIndex(tokens, cursor))) {
+          cursor = rbracketMatch.index;
+          if (rbracketMatch.token.text === "]") break;
+        }
+        if (rbracketMatch?.token.text === "]") {
+          const condMatch = nextSyntaxWithIndex(tokens, rbracketMatch.index);
+          const cond = condMatch?.token;
+          if (cond?.text === "true" || cond?.text === "false") {
+            diagnostics.push(
+              diagnostic(
+                "trip-if-constant",
+                `Condition is constant ${cond.text}; simplify the if expression manually`,
+                token,
+              ),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  // Recompute line/column for any token-like diagnostics produced after source
+  // normalization. This keeps CRLF input diagnostics stable.
+  return diagnostics.map((diag) => {
+    const loc = locationAt(source, diag.offset);
+    return { ...diag, line: loc.line, column: loc.column };
+  });
+}
+
+function fixesOverlap(a: TripLintFix, b: TripLintFix): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+// Lint fixes fall into two soundness classes. AST-preserving rewrites (syntactic
+// sugar and canonical spellings) must parse to the *same* AST as the code they
+// replace; we verify that and drop any rewrite that would change it. Semantic
+// rewrites (eta/eta-type reduction, boolean algebra, identity-let elimination)
+// change the AST on purpose, so the rule owns soundness and we only require that
+// the result still parses.
+const AST_PRESERVING_FIX_CODES: ReadonlySet<string> = new Set([
+  "trip-list-literal",
+  "trip-pair-literal",
+  "trip-pair-type",
+  "trip-string-literal",
+  "trip-redundant-parens",
+  "trip-u8-literal",
+  "trip-formatting-deviation",
+]);
+
+/**
+ * Applies the selected fixes one at a time, from the end of the file backwards
+ * so untouched offsets stay valid even when a fix is skipped. Every fix is
+ * verified before it is kept: no fix may turn a parseable program into an
+ * unparseable one, and an AST-preserving fix may never change the AST.
+ */
+function applyVerifiedFixes(
+  source: string,
+  diagnostics: readonly TripLintDiagnostic[],
+): string {
+  const selected: TripLintDiagnostic[] = [];
+  for (const diag of diagnostics) {
+    if (!diag.fix) continue;
+    if (selected.some((other) => fixesOverlap(other.fix!, diag.fix!))) {
+      continue;
+    }
+    selected.push(diag);
+  }
+  selected.sort((a, b) => b.fix!.start - a.fix!.start);
+
+  let current = source;
+  let currentAst = parseProgramOrNull(current);
+
+  for (const diag of selected) {
+    const fix = diag.fix!;
+    const candidate =
+      current.slice(0, fix.start) + fix.replacement + current.slice(fix.end);
+    const candidateAst = parseProgramOrNull(candidate);
+
+    // Never regress a parseable program into an unparseable one.
+    if (currentAst !== undefined && candidateAst === undefined) {
+      continue;
+    }
+    // Sugar / canonical-spelling rewrites must be exact AST round-trips.
+    if (
+      AST_PRESERVING_FIX_CODES.has(diag.code) &&
+      currentAst !== undefined &&
+      candidateAst !== currentAst
+    ) {
+      continue;
+    }
+
+    current = candidate;
+    currentAst = candidateAst;
+  }
+
+  return current;
+}
+
+export function lintTripSource(
+  sourceText: string,
+  options: { fix?: boolean; lm?: KneserNeyLM; verbose?: boolean } = {},
+): TripLintResult {
+  const source = normalizeSource(sourceText);
+
+  const tStartLex = Date.now();
+  const tokens = lexTrip(source);
+  if (options.verbose) {
+    console.log(
+      `[profile-lint] lexTrip completed in ${Date.now() - tStartLex}ms`,
+    );
+  }
+
+  const tStartLintTokens = Date.now();
+  const diagnostics = lintTokens(source, tokens);
+  if (options.verbose) {
+    console.log(
+      `[profile-lint] lintTokens completed in ${Date.now() - tStartLintTokens}ms`,
+    );
+  }
+
+  const tStartTrainLM = Date.now();
+  const lm = options.lm || getTrainedLMSync();
+  if (options.verbose) {
+    console.log(
+      `[profile-lint] getTrainedLMSync completed in ${Date.now() - tStartTrainLM}ms`,
+    );
+  }
+
+  const tStartStats = Date.now();
+  const statDiagnostics = getStatisticalDiagnostics(source, lm);
+  if (options.verbose) {
+    console.log(
+      `[profile-lint] getStatisticalDiagnostics completed in ${Date.now() - tStartStats}ms`,
+    );
+  }
+  diagnostics.push(...statDiagnostics);
+
+  if (!options.fix || diagnostics.every((diag) => !diag.fix)) {
+    return { diagnostics, fixed: source, changed: false };
+  }
+
+  // Apply only the fixes that pass per-fix verification, then format. The
+  // formatter is itself AST-preserving (see formatTripSource), so the final
+  // output differs from `source` only by verified, meaning-preserving edits.
+  const fixed = applyVerifiedFixes(source, diagnostics);
+  const { formatted } = formatTripSource(fixed);
+  return {
+    diagnostics,
+    fixed: formatted,
+    changed: formatted !== source,
+  };
+}
+
+export function lintAndFormatTripSource(source: string): TripLintResult {
+  return lintTripSource(formatTripSource(source).formatted, { fix: false });
+}

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -113,7 +113,7 @@ function shouldSkipDir(name: string): boolean {
 
 export async function discoverTripFiles(
   inputPaths: readonly string[],
-  cwd = process.cwd(),
+  cwd: string = process.cwd(),
 ): Promise<string[]> {
   const files: string[] = [];
 

--- a/lib/improvize/lexer.ts
+++ b/lib/improvize/lexer.ts
@@ -1,0 +1,254 @@
+/**
+ * Shared TripLang scanner.
+ *
+ * The formatter's lexer (`lexTrip`) and the statistical tokenizer
+ * (`tokenizeFormatting`) must agree on TripLang's lexical grammar: the same
+ * comment, arrow, string, identifier, number, and symbol rules. They differ
+ * only in presentation -- the formatter discards whitespace and coarsens
+ * keywords/symbols, while the statistics path keeps whitespace and a
+ * fine-grained kind per keyword and symbol. This module owns the one scanner;
+ * each consumer adapts the stream to its own token shape.
+ *
+ * @module
+ */
+
+export type ScanKind =
+  | "space"
+  | "newline"
+  | "ident"
+  | "number"
+  | "string"
+  | "char"
+  | "lineComment"
+  | "blockComment"
+  | "symbol"
+  | "arrow"
+  | "fatArrow";
+
+export interface ScanToken {
+  kind: ScanKind;
+  text: string;
+  start: number;
+  end: number;
+  line: number;
+  column: number;
+}
+
+function isAlpha(ch: string): boolean {
+  return /[A-Za-z_]/.test(ch);
+}
+
+function isIdentChar(ch: string): boolean {
+  return /[A-Za-z0-9_]/.test(ch);
+}
+
+function isDigit(ch: string): boolean {
+  return ch >= "0" && ch <= "9";
+}
+
+/**
+ * Scans `source` into a position-tracked token stream that always retains
+ * whitespace. `strict` (used by the formatter lexer) throws on unterminated
+ * strings, character literals, and block comments; the lenient mode (used by
+ * the statistics tokenizer) stops at end of input instead. The caller owns
+ * normalization: `lexTrip` scans CRLF-normalized text, while the statistics
+ * path scans raw source so token offsets index the original text.
+ */
+export function scanTrip(source: string, strict: boolean): ScanToken[] {
+  const tokens: ScanToken[] = [];
+  let index = 0;
+  let line = 1;
+  let column = 1;
+
+  const push = (
+    kind: ScanKind,
+    text: string,
+    start: number,
+    startLine: number,
+    startColumn: number,
+  ): void => {
+    tokens.push({
+      kind,
+      text,
+      start,
+      end: index,
+      line: startLine,
+      column: startColumn,
+    });
+  };
+
+  const advance = (): string => {
+    const ch = source[index]!;
+    index++;
+    if (ch === "\r") {
+      if (source[index] === "\n") index++;
+      line++;
+      column = 1;
+    } else if (ch === "\n") {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+    return ch;
+  };
+
+  while (index < source.length) {
+    const ch = source[index]!;
+    const start = index;
+    const startLine = line;
+    const startColumn = column;
+
+    // Newlines: collapse CRLF (and a lone CR) into one newline token.
+    if (ch === "\n" || ch === "\r") {
+      advance();
+      push("newline", "\n", start, startLine, startColumn);
+      continue;
+    }
+
+    // Runs of spaces and tabs.
+    if (ch === " " || ch === "\t") {
+      while (
+        index < source.length &&
+        (source[index] === " " || source[index] === "\t")
+      ) {
+        advance();
+      }
+      push("space", source.slice(start, index), start, startLine, startColumn);
+      continue;
+    }
+
+    // Line comment: "--" to end of line.
+    if (source.startsWith("--", index)) {
+      advance();
+      advance();
+      while (
+        index < source.length &&
+        source[index] !== "\n" &&
+        source[index] !== "\r"
+      ) {
+        advance();
+      }
+      push(
+        "lineComment",
+        source.slice(start, index),
+        start,
+        startLine,
+        startColumn,
+      );
+      continue;
+    }
+
+    // Nested block comment: "{- ... -}".
+    if (source.startsWith("{-", index)) {
+      let depth = 0;
+      while (index < source.length) {
+        if (source.startsWith("{-", index)) {
+          depth++;
+          advance();
+          advance();
+          continue;
+        }
+        if (source.startsWith("-}", index)) {
+          depth--;
+          advance();
+          advance();
+          if (depth === 0) break;
+          continue;
+        }
+        advance();
+      }
+      if (depth !== 0 && strict) {
+        throw new Error(
+          `unterminated block comment at ${startLine}:${startColumn}`,
+        );
+      }
+      push(
+        "blockComment",
+        source.slice(start, index),
+        start,
+        startLine,
+        startColumn,
+      );
+      continue;
+    }
+
+    if (source.startsWith("=>", index)) {
+      advance();
+      advance();
+      push("fatArrow", "=>", start, startLine, startColumn);
+      continue;
+    }
+
+    if (source.startsWith("->", index)) {
+      advance();
+      advance();
+      push("arrow", "->", start, startLine, startColumn);
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const label = ch === '"' ? "string" : "character";
+      advance(); // opening quote
+      for (;;) {
+        if (index >= source.length) {
+          if (strict) {
+            throw new Error(
+              `unterminated ${label} literal at ${startLine}:${startColumn}`,
+            );
+          }
+          break;
+        }
+        const c = advance();
+        if (c === "\n" || c === "\r") {
+          if (strict) {
+            throw new Error(
+              `unterminated ${label} literal at ${startLine}:${startColumn}`,
+            );
+          }
+          continue;
+        }
+        if (c === "\\") {
+          if (index >= source.length) {
+            if (strict) {
+              throw new Error(
+                `unterminated escape sequence at ${startLine}:${startColumn}`,
+              );
+            }
+            break;
+          }
+          advance();
+          continue;
+        }
+        if (c === ch) break;
+      }
+      push(
+        ch === '"' ? "string" : "char",
+        source.slice(start, index),
+        start,
+        startLine,
+        startColumn,
+      );
+      continue;
+    }
+
+    if (isAlpha(ch)) {
+      advance();
+      while (index < source.length && isIdentChar(source[index]!)) advance();
+      push("ident", source.slice(start, index), start, startLine, startColumn);
+      continue;
+    }
+
+    if (isDigit(ch)) {
+      advance();
+      while (index < source.length && isDigit(source[index]!)) advance();
+      push("number", source.slice(start, index), start, startLine, startColumn);
+      continue;
+    }
+
+    advance();
+    push("symbol", ch, start, startLine, startColumn);
+  }
+
+  return tokens;
+}

--- a/lib/improvize/statistical.ts
+++ b/lib/improvize/statistical.ts
@@ -1,0 +1,568 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { parseTripLang } from "../parser/tripLang.ts";
+import { discoverTripFiles } from "./index.ts";
+import { scanTrip, type ScanToken } from "./lexer.ts";
+import { workspaceRoot } from "../shared/workspaceRoot.ts";
+
+export interface FormattingToken {
+  kind: string;
+  text: string;
+  start: number;
+  end: number;
+}
+
+const FORMATTING_KEYWORDS = new Set([
+  "module",
+  "import",
+  "export",
+  "opaque",
+  "native",
+  "type",
+  "data",
+  "poly",
+  "combinator",
+  "let",
+  "in",
+  "match",
+  "if",
+]);
+
+const FORMATTING_SYMBOLS = new Set([
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  ",",
+  ":",
+  "=",
+  "|",
+  "#",
+  "\\",
+]);
+
+function formattingKind(token: ScanToken): string {
+  if (token.kind === "ident" && FORMATTING_KEYWORDS.has(token.text)) {
+    return token.text;
+  }
+  if (token.kind === "symbol") {
+    return FORMATTING_SYMBOLS.has(token.text) ? token.text : "unknown";
+  }
+  return token.kind;
+}
+
+/**
+ * Tokenizer that retains all spaces and newlines for formatting evaluation.
+ */
+export function tokenizeFormatting(source: string): FormattingToken[] {
+  return scanTrip(source, false).map((token) => ({
+    kind: formattingKind(token),
+    text: token.text,
+    start: token.start,
+    end: token.end,
+  }));
+}
+
+/**
+ * Maps a FormattingToken to a vocabulary representation string.
+ */
+export function getVocabRep(token: FormattingToken): string {
+  if (token.kind === "space") {
+    if (token.text.length === 1) return "<space>";
+    return `<spaces:${token.text.length}>`;
+  }
+  if (token.kind === "newline") return "<newline>";
+  if (token.kind === "ident") return "<ident>";
+  if (token.kind === "number") return "<number>";
+  if (token.kind === "string") return "<string>";
+  if (token.kind === "char") return "<char>";
+  if (token.kind === "lineComment") return "<lineComment>";
+  if (token.kind === "blockComment") return "<blockComment>";
+  if (token.kind === "unknown") return "<unknown>";
+  return token.kind;
+}
+
+/**
+ * 8-Gram Kneser-Ney Language Model implementation for unsupervised style learning.
+ */
+export class KneserNeyLM {
+  counts: Map<string, number>[] = [];
+  // Precomputed Kneser-Ney statistics, indexed by gram order to match `counts`.
+  // contextTotals[k] maps a (k-1)-token prefix to the summed count of k-grams
+  // with that prefix — the denominator c(context). followerCounts[k] maps the
+  // same prefix to the number of distinct k-grams with it — the continuation
+  // count N1+(context.). Both are filled during training so a probability query
+  // never has to scan the vocabulary.
+  contextTotals: Map<string, number>[] = [];
+  followerCounts: Map<string, number>[] = [];
+  vocab: Set<string> = new Set();
+  uniquePreceders: Map<string, Set<string>> = new Map();
+  totalUniqueBigrams = 0;
+  maxOrder = 8;
+  discount = 0.75;
+
+  constructor(maxOrder = 8) {
+    this.maxOrder = maxOrder;
+    for (let i = 0; i <= maxOrder; i++) {
+      this.counts.push(new Map());
+      this.contextTotals.push(new Map());
+      this.followerCounts.push(new Map());
+    }
+  }
+
+  train(tokenSequences: string[][]) {
+    for (const seq of tokenSequences) {
+      for (const token of seq) {
+        this.vocab.add(token);
+      }
+
+      for (let order = 1; order <= this.maxOrder; order++) {
+        for (let i = 0; i <= seq.length - order; i++) {
+          const slice = seq.slice(i, i + order);
+          const ngram = slice.join("|");
+          const countMap = this.counts[order]!;
+          const prevCount = countMap.get(ngram);
+          countMap.set(ngram, (prevCount || 0) + 1);
+
+          // Accumulate the context denominator, and — the first time an n-gram
+          // is seen — its prefix's distinct-follower count. The prefix is keyed
+          // off the token array (not the joined string) so a literal "|" token
+          // can't be confused with the "|" join delimiter.
+          if (order >= 2) {
+            const prefix = slice.slice(0, order - 1).join("|");
+            const totals = this.contextTotals[order]!;
+            totals.set(prefix, (totals.get(prefix) || 0) + 1);
+            if (prevCount === undefined) {
+              const followers = this.followerCounts[order]!;
+              followers.set(prefix, (followers.get(prefix) || 0) + 1);
+            }
+          }
+
+          if (order === 2) {
+            const w_prev = seq[i]!;
+            const w_curr = seq[i + 1]!;
+            if (!this.uniquePreceders.has(w_curr)) {
+              this.uniquePreceders.set(w_curr, new Set());
+            }
+            this.uniquePreceders.get(w_curr)!.add(w_prev);
+          }
+        }
+      }
+    }
+
+    this.totalUniqueBigrams = 0;
+    for (const prevSet of this.uniquePreceders.values()) {
+      this.totalUniqueBigrams += prevSet.size;
+    }
+  }
+
+  getNgramCount(ngramArr: string[]): number {
+    const order = ngramArr.length;
+    if (order > this.maxOrder) return 0;
+    return this.counts[order]!.get(ngramArr.join("|")) || 0;
+  }
+
+  getContextCount(contextArr: string[]): number {
+    const order = contextArr.length;
+    if (order + 1 > this.maxOrder) return 0;
+    return this.contextTotals[order + 1]!.get(contextArr.join("|")) || 0;
+  }
+
+  getUniqueFollowersCount(contextArr: string[]): number {
+    const order = contextArr.length;
+    if (order + 1 > this.maxOrder) return 0;
+    return this.followerCounts[order + 1]!.get(contextArr.join("|")) || 0;
+  }
+
+  getProbability(word: string, context: string[]): number {
+    return this.calculateProbabilityRecursive(
+      word,
+      context.slice(-this.maxOrder + 1),
+    );
+  }
+
+  private calculateProbabilityRecursive(
+    word: string,
+    context: string[],
+  ): number {
+    const order = context.length + 1;
+
+    if (order === 1) {
+      if (this.totalUniqueBigrams === 0) {
+        return 1 / Math.max(1, this.vocab.size);
+      }
+      const uniquePrev = this.uniquePreceders.get(word)?.size || 0;
+      const continuationProb = uniquePrev / this.totalUniqueBigrams;
+      return continuationProb > 0
+        ? continuationProb
+        : 1 / Math.max(1, this.vocab.size);
+    }
+
+    const contextCount = this.getContextCount(context);
+    if (contextCount === 0) {
+      return this.calculateProbabilityRecursive(word, context.slice(1));
+    }
+
+    const ngramArr = [...context, word];
+    const ngramCount = this.getNgramCount(ngramArr);
+
+    const uniqueFollowers = this.getUniqueFollowersCount(context);
+    const lambda = (this.discount / contextCount) * uniqueFollowers;
+
+    const term1 = Math.max(ngramCount - this.discount, 0) / contextCount;
+    const term2 =
+      lambda * this.calculateProbabilityRecursive(word, context.slice(1));
+
+    return term1 + term2;
+  }
+}
+
+/**
+ * Calculates the cross-entropy of a token sequence under the Kneser-Ney LM.
+ */
+export function calculateCrossEntropy(
+  lm: KneserNeyLM,
+  sequence: string[],
+): number {
+  if (sequence.length === 0) return 0;
+  let logSum = 0;
+  for (let i = 0; i < sequence.length; i++) {
+    const word = sequence[i]!;
+    const context = sequence.slice(Math.max(0, i - lm.maxOrder + 1), i);
+    const prob = lm.getProbability(word, context);
+    logSum += Math.log2(prob);
+  }
+  return -logSum / sequence.length;
+}
+
+/**
+ * Calculates local token-level style evaluation scores using a rolling 20-token window.
+ */
+export function computeTokenScores(
+  lm: KneserNeyLM,
+  sequence: string[],
+): number[] {
+  const windowSize = 20;
+  const tokenScores = new Array(sequence.length).fill(0);
+  const tokenWindowCounts = new Array(sequence.length).fill(0);
+
+  if (sequence.length < windowSize) {
+    for (let i = 0; i < sequence.length; i++) {
+      const context = sequence.slice(Math.max(0, i - lm.maxOrder + 1), i);
+      tokenScores[i] = -Math.log2(lm.getProbability(sequence[i]!, context));
+    }
+    return tokenScores;
+  }
+
+  for (let i = 0; i <= sequence.length - windowSize; i++) {
+    const windowSeq = sequence.slice(i, i + windowSize);
+    const entropy = calculateCrossEntropy(lm, windowSeq);
+    for (let j = i; j < i + windowSize; j++) {
+      tokenScores[j] += entropy;
+      tokenWindowCounts[j]++;
+    }
+  }
+
+  for (let i = 0; i < sequence.length; i++) {
+    if (tokenWindowCounts[i] > 0) {
+      tokenScores[i] /= tokenWindowCounts[i];
+    } else {
+      const context = sequence.slice(Math.max(0, i - lm.maxOrder + 1), i);
+      tokenScores[i] = -Math.log2(lm.getProbability(sequence[i]!, context));
+    }
+  }
+
+  return tokenScores;
+}
+
+/**
+ * Normalizes scores to [0, 1] where 1 is the most natural (lowest entropy) and 0 is the most anomalous.
+ */
+export function getNormalizedScores(scores: number[]): number[] {
+  if (scores.length === 0) return [];
+  const min = Math.min(...scores);
+  const max = Math.max(...scores);
+  const diff = max - min;
+  if (diff === 0) return new Array(scores.length).fill(1);
+  return scores.map((s) => (max - s) / diff);
+}
+
+/**
+ * Dynamically trains the Kneser-Ney LM on all valid .trip files in the workspace.
+ */
+export async function getTrainedLM(excludeFile?: string): Promise<KneserNeyLM> {
+  const lm = new KneserNeyLM(8);
+  const workspacePath = workspaceRoot;
+  const files = await discoverTripFiles([workspacePath]);
+  const sequences: string[][] = [];
+
+  for (const file of files) {
+    if (excludeFile && resolve(file) === resolve(excludeFile)) continue;
+    try {
+      const content = await readFile(file, "utf8");
+      parseTripLang(content);
+      const fTokens = tokenizeFormatting(content);
+      sequences.push(fTokens.map(getVocabRep));
+    } catch {
+      // Ignore invalid or unparseable files
+    }
+  }
+
+  if (sequences.length === 0) {
+    try {
+      const preludePath = join(workspacePath, "lib", "prelude.trip");
+      const content = await readFile(preludePath, "utf8");
+      const fTokens = tokenizeFormatting(content);
+      sequences.push(fTokens.map(getVocabRep));
+    } catch {
+      // Fallback
+    }
+  }
+
+  lm.train(sequences);
+  return lm;
+}
+
+/**
+ * Dynamically trains the Kneser-Ney LM synchronously.
+ */
+let cachedSyncLM: KneserNeyLM | undefined;
+
+export function getTrainedLMSync(excludeFile?: string): KneserNeyLM {
+  // Training reads and tokenizes the entire .trip corpus, so cache the
+  // corpus-wide model — the only variant any caller asks for. The leave-one-out
+  // form (excludeFile) is rebuilt fresh: each exclusion is a different model and
+  // is never on the hot path.
+  if (excludeFile === undefined && cachedSyncLM !== undefined) {
+    return cachedSyncLM;
+  }
+
+  const lm = new KneserNeyLM(8);
+  const workspacePath = workspaceRoot;
+  const sequences: string[][] = [];
+
+  const dirs = [join(workspacePath, "lib"), join(workspacePath, "bootstrap")];
+  for (const dir of dirs) {
+    try {
+      const stats = statSync(dir);
+      if (stats.isDirectory()) {
+        const entries = readdirSync(dir);
+        for (const entry of entries) {
+          const fullPath = join(dir, entry);
+          if (entry.endsWith(".trip")) {
+            if (excludeFile && resolve(fullPath) === resolve(excludeFile))
+              continue;
+            try {
+              const content = readFileSync(fullPath, "utf8");
+              parseTripLang(content);
+              const fTokens = tokenizeFormatting(content);
+              sequences.push(fTokens.map(getVocabRep));
+            } catch {
+              // Ignore invalid files
+            }
+          }
+        }
+      }
+    } catch {
+      // Ignore directory read errors
+    }
+  }
+
+  if (sequences.length === 0) {
+    try {
+      const preludePath = join(workspacePath, "lib", "prelude.trip");
+      const content = readFileSync(preludePath, "utf8");
+      const fTokens = tokenizeFormatting(content);
+      sequences.push(fTokens.map(getVocabRep));
+    } catch {
+      // Fallback
+    }
+  }
+
+  lm.train(sequences);
+
+  if (excludeFile === undefined) {
+    cachedSyncLM = lm;
+  }
+  return lm;
+}
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+
+/**
+ * Performs unsupervised formatting deviation detection and generates safe, AST-equivalent fixes.
+ */
+export function getStatisticalDiagnostics(
+  sourceText: string,
+  lm: KneserNeyLM,
+): any[] {
+  const fTokens = tokenizeFormatting(sourceText);
+  const sequence = fTokens.map(getVocabRep);
+  if (sequence.length < 25 || sequence.length > 300) {
+    return [];
+  }
+  const tokenScores = computeTokenScores(lm, sequence);
+  const normalizedScores = getNormalizedScores(tokenScores); // 1 = natural, 0 = anomalous
+
+  const diagnostics: any[] = [];
+  let originalAstStr = "";
+  try {
+    originalAstStr = JSON.stringify(parseTripLang(sourceText));
+  } catch {
+    return []; // Only run on syntactically valid files
+  }
+
+  const originalEntropy = calculateCrossEntropy(lm, sequence);
+
+  // 1. Scan and score all candidate tokens to build a ranked list of deviations
+  const candidatesToEvaluate: { idx: number; modifiedErrProb: number }[] = [];
+
+  for (let idx = 0; idx < fTokens.length; idx++) {
+    const token = fTokens[idx]!;
+    if (
+      token.kind === "lineComment" ||
+      token.kind === "blockComment" ||
+      token.kind === "ident" ||
+      token.kind === "string"
+    ) {
+      continue;
+    }
+
+    const context = sequence.slice(Math.max(0, idx - lm.maxOrder + 1), idx);
+    const prob = lm.getProbability(sequence[idx]!, context);
+    const errProb = 1 - prob;
+    const normScore = normalizedScores[idx]!;
+    const modifiedErrProb = errProb * (1 - normScore);
+
+    if (modifiedErrProb > 0.5) {
+      candidatesToEvaluate.push({ idx, modifiedErrProb });
+    }
+  }
+
+  // 2. Sort by modifiedErrProb descending and limit to top 3 most critical layout issues
+  candidatesToEvaluate.sort((a, b) => b.modifiedErrProb - a.modifiedErrProb);
+  const topCandidates = candidatesToEvaluate.slice(0, 3);
+
+  // 3. Evaluate spacing/newline fixes for the top layout deviations
+  for (const item of topCandidates) {
+    const idx = item.idx;
+    const token = fTokens[idx]!;
+    const candidates: {
+      start: number;
+      end: number;
+      replacement: string;
+      entropy: number;
+    }[] = [];
+
+    // Generate prospective edits
+    const editOptions: { replacement: string; start: number; end: number }[] =
+      [];
+
+    // 1. Deletion (for spacing or newlines)
+    if (token.kind === "space" || token.kind === "newline") {
+      editOptions.push({ replacement: "", start: token.start, end: token.end });
+    }
+
+    // 2. Replacement
+    if (token.kind === "space") {
+      editOptions.push({
+        replacement: "\n",
+        start: token.start,
+        end: token.end,
+      });
+    } else if (token.kind === "newline") {
+      editOptions.push({
+        replacement: " ",
+        start: token.start,
+        end: token.end,
+      });
+    }
+
+    // 3. Insertion before
+    editOptions.push({
+      replacement: " ",
+      start: token.start,
+      end: token.start,
+    });
+    editOptions.push({
+      replacement: "\n",
+      start: token.start,
+      end: token.start,
+    });
+
+    const prospectiveCandidates: {
+      start: number;
+      end: number;
+      replacement: string;
+      entropy: number;
+    }[] = [];
+
+    for (const edit of editOptions) {
+      const editedText =
+        sourceText.slice(0, edit.start) +
+        edit.replacement +
+        sourceText.slice(edit.end);
+
+      const editedTokens = tokenizeFormatting(editedText).map(getVocabRep);
+      const editedEntropy = calculateCrossEntropy(lm, editedTokens);
+      // Must improve cross-entropy (naturalness)
+      if (editedEntropy < originalEntropy * 0.99) {
+        prospectiveCandidates.push({ ...edit, entropy: editedEntropy });
+      }
+    }
+
+    // Sort by lowest entropy
+    prospectiveCandidates.sort((a, b) => a.entropy - b.entropy);
+
+    // Verify AST-equivalence starting from the best entropy candidate
+    for (const cand of prospectiveCandidates) {
+      const editedText =
+        sourceText.slice(0, cand.start) +
+        cand.replacement +
+        sourceText.slice(cand.end);
+      try {
+        const editedAstStr = JSON.stringify(parseTripLang(editedText));
+        if (editedAstStr === originalAstStr) {
+          candidates.push(cand);
+          break; // Found the best safe candidate; stop checking others!
+        }
+      } catch {
+        // Reject invalid edits
+      }
+    }
+
+    if (candidates.length > 0) {
+      const best = candidates[0]!;
+
+      // Determine line and column
+      let line = 1;
+      let column = 1;
+      for (let charIdx = 0; charIdx < token.start; charIdx++) {
+        if (sourceText[charIdx] === "\n") {
+          line++;
+          column = 1;
+        } else {
+          column++;
+        }
+      }
+
+      diagnostics.push({
+        code: "trip-formatting-deviation",
+        message: `Unnatural spacing/layout formatting around "${token.text.replace(/\n/g, "\\n")}"`,
+        line,
+        column,
+        offset: token.start,
+        endOffset: token.end,
+        fix: {
+          start: best.start,
+          end: best.end,
+          replacement: best.replacement,
+        },
+      });
+    }
+  }
+
+  return diagnostics;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -50,6 +50,17 @@ export type {
 // ─── TripLang LLVM backend (single entry for source → native IR) ────────
 export { compileTripSourceToLlvm } from "./compiler/llvmCompiler.ts";
 
+// ─── TripLang source tools ──────────────────────────────────────────────
+export {
+  discoverTripFiles,
+  formatTripSource,
+  lintTripSource,
+  type TripFormatResult,
+  type TripLintDiagnostic,
+  type TripLintFix,
+  type TripLintResult,
+} from "./improvize/index.ts";
+
 // ─── Built-in module providers ─────────────────────────────────────────
 export { getAvlObject } from "./avl.ts";
 export { getBinObject } from "./bin.ts";

--- a/lib/nat.trip
+++ b/lib/nat.trip
@@ -1,81 +1,116 @@
 module Nat
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude Pair
+
 import Prelude pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin incBin
 
 export Nat
+
 export zero
+
 export succ
+
 export add
+
 export mul
+
 export isZero
+
 export eq
+
 export pred
+
 export sub
+
 export lte
+
 export gte
+
 export toBin
+
 export fromBin
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly zero = #X => \s : X -> X => \z : X => z
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-poly succ = \n : Nat =>
-  #a => \s : a -> a => \z : a =>
-    s (n [a] s z)
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly add = \m : Nat => \n : Nat =>
-  #a => \s : a -> a => \z : a =>
-    m [a] s (n [a] s z)
+poly add =
+  \m : Nat =>
+    \n : Nat => #a => \s : a -> a => \z : a => m [a] s (n [a] s z)
 
-poly mul = \m : Nat => \n : Nat =>
-  #a => \s : a -> a => \z : a =>
-    m [a] (n [a] s) z
+poly mul =
+  \m : Nat => \n : Nat => #a => \s : a -> a => \z : a => m [a] (n [a] s) z
 
-poly isZero = \n : Nat =>
-  n [Bool] (\x : Bool => false) true
+poly isZero =
+  \n : Nat => n [Bool] (\x : Bool => false) true
 
-poly eq = \m : Nat => \n : Nat =>
-  #X => \s : X -> X => \z : X =>
-    m [X] (\x : X => n [X] (\y : X => x) z) (n [X] (\x : X => z) z)
+poly eq =
+  \m : Nat =>
+    \n : Nat =>
+      #X =>
+        \s : X -> X =>
+          \z : X =>
+            m [X] (\x : X => n [X] (\y : X => x) z) (n [X] (\x : X => z) z)
 
-poly pred = \n : Nat =>
-  fst [Nat] [Nat]
-    ( n [#Y -> (Nat -> Nat -> Y) -> Y]
-        ( \p : #Y -> (Nat -> Nat -> Y) -> Y =>
-            pair [Nat] [Nat]
-              (snd [Nat] [Nat] p)
-              (succ (snd [Nat] [Nat] p))
-        )
-        (pair [Nat] [Nat] zero zero)
-    )
+poly pred =
+  \n : Nat =>
+    fst
+      [Nat]
+      [Nat]
+      (
+        n
+          [#Y -> (Nat -> Nat -> Y) -> Y]
+          (
+            \p : #Y -> (Nat -> Nat -> Y) -> Y =>
+              pair [Nat] [Nat] (snd [Nat] [Nat] p) (succ (snd [Nat] [Nat] p))
+          )
+          (pair [Nat] [Nat] zero zero)
+      )
 
-poly sub = \a : Nat => \b : Nat => b [Nat] pred a
+poly sub =
+  \a : Nat => \b : Nat => b [Nat] pred a
 
-poly lte = \a : Nat => \b : Nat => isZero (sub a b)
+poly lte =
+  \a : Nat => \b : Nat => isZero (sub a b)
 
-poly gte = \a : Nat => \b : Nat => lte b a
+poly gte =
+  \a : Nat => \b : Nat => lte b a
 
-poly toBin = \n : Nat => n [Bin] incBin BZ
+poly toBin =
+  \n : Nat => n [Bin] incBin BZ
 
-poly rec fromBin = \b : Bin =>
-  match b [Nat] {
-    | BZ => zero
-    | B0 rest =>
+poly rec fromBin =
+  \b : Bin =>
+    match b [Nat] {
+      | BZ => zero
+      | B0 rest =>
         let r = fromBin rest in
         add r r
-    | B1 rest =>
+      | B1 rest =>
         let r = fromBin rest in
         succ (add r r)
-  }
+    }

--- a/lib/prelude.trip
+++ b/lib/prelude.trip
@@ -1,234 +1,467 @@
 module Prelude
 
 export Bool
+
 export id
+
 export true
+
 export false
+
 export pair
+
 export fst
+
 export snd
+
 export if
+
 export not
+
 export and
+
 export or
+
 export readOne
+
 export writeOne
+
 export List
+
 export nil
+
 export cons
+
 export matchList
+
 export listIsEmpty
+
 export head
+
 export tail
+
 export error
+
 export Pair
+
 export MkPair
+
 export Result
+
 export Err
+
 export Ok
+
 export Maybe
+
 export Some
+
 export None
+
 export append
+
 export map
+
 export foldl
+
 export takeWhile
+
 export dropWhile
+
 export span
+
 export reverse
+
 export Bin
+
 export BZ
+
 export B0
+
 export B1
+
 export eqU8
+
 export ltU8
+
 export lteU8
+
 export addU8
+
 export subU8
+
 export divU8
+
 export modU8
+
 export U8
+
 export eqListU8
+
 export ltListU8
+
 export lteListU8
+
 export digitToAscii
+
 export singletonU8
+
 export u8ToDigits
 
-opaque type U8
+opaque
+
+type U8
+
 native eqU8 : U8 -> U8 -> Bool
+
 native ltU8 : U8 -> U8 -> Bool
+
 native addU8 : U8 -> U8 -> U8
+
 native subU8 : U8 -> U8 -> U8
+
 native divU8 : U8 -> U8 -> U8
+
 native modU8 : U8 -> U8 -> U8
+
 native readOne : #R -> (U8 -> R) -> R
+
 native writeOne : U8 -> #R -> (U8 -> R) -> R
 
 type Bool = #B -> B -> B -> B
+
 type List = #A -> #R -> R -> (A -> R -> R) -> R
+
 type Parser = #A -> List Bin -> Result ParseError (Pair A (List Bin))
 
-data Pair A B = MkPair A B
-data Result E T = Err E | Ok T
-data Bin = BZ | B0 Bin | B1 Bin
-data ParseError = MkParseError (List U8)
-data Maybe A = None | Some A
+data Pair A B =
+  | MkPair A B
 
-poly id : #a->a->a = #a => \x:a => x
+data Result E T =
+  | Err E
+  | Ok T
 
-poly true = #B => \t : B => \f : B => t
+data Bin =
+  | BZ
+  | B0 Bin
+  | B1 Bin
 
-poly false = #B => \t : B => \f : B => f
+data ParseError =
+  | MkParseError (List U8)
 
-poly pair = #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
+data Maybe A =
+  | None
+  | Some A
 
-poly fst = #A => #B => \p : #Y -> (A->B->Y)->Y =>
-  p [A] (\x:A => \y:B => x)
+poly id : #a -> a -> a =
+  #a => \x : a => x
 
-poly snd = #A => #B => \p : #Y -> (A->B->Y)->Y =>
-  p [B] (\x:A => \y:B => y)
+poly true =
+  #B => \t : B => \f : B => t
 
-poly not = \b : Bool =>
-  b [Bool] false true
+poly false =
+  #B => \t : B => \f : B => f
 
-poly and = \a : Bool => \b : Bool =>
-  a [Bool] b false
+poly pair =
+  #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
 
-poly or = \a : Bool => \b : Bool =>
-  a [Bool] true b
+poly fst =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [A] (\x : A => \y : B => x)
 
-poly lteU8 = \a : U8 => \b : U8 => or (eqU8 a b) (ltU8 a b)
+poly snd =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [B] (\x : A => \y : B => y)
 
-poly if = #A => \b : Bool => \t : U8 -> A => \f : U8 -> A =>
-  b [U8 -> A] t f #u8(0)
+poly not =
+  \b : Bool => b [Bool] false true
 
-poly nil = #A => #R => \n : R => \c : (A -> List A -> R) => n
+poly and =
+  \a : Bool => \b : Bool => a [Bool] b false
 
-poly cons = #A => \x : A => \xs : List A =>
-  #R => \n : R => \c : (A -> List A -> R) => c x xs
+poly or =
+  \a : Bool => \b : Bool => a [Bool] true b
 
-poly matchList = #A => #R => \l : List A => \onNil : R =>
-  \onCons : (A -> List A -> R) =>
-    l [R] onNil onCons
+poly lteU8 =
+  \a : U8 => \b : U8 => or (eqU8 a b) (ltU8 a b)
 
-poly listIsEmpty = #A => \xs : List A =>
-  matchList [A] [Bool] xs true (\h : A => \t : List A => false)
+poly if =
+  #A =>
+    \b : Bool => \t : U8 -> A => \f : U8 -> A => b [U8 -> A] t f #u8(0)
 
-poly head = #A => \l : List A =>
-  l [A] (error [A]) (\h : A => \t : List A => h)
+poly nil =
+  #A => #R => \n : R => \c : (A -> List A -> R) => n
 
-poly tail = #A => \l : List A =>
-  l [List A] (nil [A]) (\h : A => \t : List A => t)
+poly cons =
+  #A =>
+    \x : A =>
+      \xs : List A => #R => \n : R => \c : (A -> List A -> R) => c x xs
 
-poly rec appendAcc = #A => \xs : List A => \acc : List A =>
-  matchList [A] [List A] xs acc
-    (\h : A => \t : List A => appendAcc [A] t (cons [A] h acc))
+poly matchList =
+  #A =>
+    #R =>
+      \l : List A =>
+        \onNil : R => \onCons : (A -> List A -> R) => l [R] onNil onCons
 
-poly append = #A => \xs : List A => \ys : List A =>
-  appendAcc [A] (reverse [A] xs) ys
+poly listIsEmpty =
+  #A =>
+    \xs : List A =>
+      matchList [A] [Bool] xs true (\h : A => \t : List A => false)
 
-poly rec map = #A => #B => \f : A -> B => \l : List A =>
-  matchList [A] [List B] l (nil [B])
-    (\h : A => \t : List A => cons [B] (f h) (map [A] [B] f t))
+poly head =
+  #A =>
+    \l : List A => l [A] (error [A]) (\h : A => \t : List A => h)
 
-poly rec foldl = #A => #B => \f : B -> A -> B => \acc : B => \l : List A =>
-  matchList [A] [B] l acc
-    (\h : A => \t : List A => foldl [A] [B] f (f acc h) t)
+poly tail =
+  #A =>
+    \l : List A => l [List A] (nil [A]) (\h : A => \t : List A => t)
 
-poly rec takeWhile = #A => \p : A -> Bool => \l : List A =>
-  matchList [A] [List A] l (nil [A])
-    (\h : A => \t : List A =>
-      if [List A] (p h)
-        (\u : U8 => cons [A] h (takeWhile [A] p t))
-        (\u : U8 => nil [A]))
+poly rec appendAcc =
+  #A =>
+    \xs : List A =>
+      \acc : List A =>
+        matchList
+          [A]
+          [List A]
+          xs
+          acc
+          (\h : A => \t : List A => appendAcc [A] t (cons [A] h acc))
 
-poly rec dropWhile = #A => \p : A -> Bool => \l : List A =>
-  matchList [A] [List A] l (nil [A])
-    (\h : A => \t : List A =>
-      if [List A] (p h)
-        (\u : U8 => dropWhile [A] p t)
-        (\u : U8 => cons [A] h t))
+poly append =
+  #A =>
+    \xs : List A => \ys : List A => appendAcc [A] (reverse [A] xs) ys
 
-poly rec span = #A => \p : A -> Bool => \l : List A =>
-  matchList [A] [Pair (List A) (List A)] l
-    (MkPair [List A] [List A] (nil [A]) (nil [A]))
-    (\h : A => \t : List A =>
-      if [Pair (List A) (List A)] (p h)
-        (\u : U8 =>
-          let res = span [A] p t in
-          MkPair [List A] [List A]
-            (cons [A] h (fst [List A] [List A] res))
-            (snd [List A] [List A] res))
-        (\u : U8 => MkPair [List A] [List A] (nil [A]) l))
+poly rec map =
+  #A =>
+    #B =>
+      \f : A -> B =>
+        \l : List A =>
+          matchList
+            [A]
+            [List B]
+            l
+            (nil [B])
+            (\h : A => \t : List A => cons [B] (f h) (map [A] [B] f t))
 
-poly rec reverseAcc = #A => \xs : List A => \acc : List A =>
-  matchList [A] [List A] xs acc
-    (\h : A => \t : List A => reverseAcc [A] t (cons [A] h acc))
+poly rec foldl =
+  #A =>
+    #B =>
+      \f : B -> A -> B =>
+        \acc : B =>
+          \l : List A =>
+            matchList
+              [A]
+              [B]
+              l
+              acc
+              (\h : A => \t : List A => foldl [A] [B] f (f acc h) t)
 
-poly reverse = #A => \xs : List A =>
-  foldl [A] [List A]
-    (\acc : List A => \x : A => cons [A] x acc)
-    (nil [A])
-    xs
+poly rec takeWhile =
+  #A =>
+    \p : A -> Bool =>
+      \l : List A =>
+        matchList
+          [A]
+          [List A]
+          l
+          (nil [A])
+          (
+            \h : A =>
+              \t : List A =>
+                if [List A] (p h)
+                  (\u : U8 => cons [A] h (takeWhile [A] p t))
+                  (\u : U8 => nil [A])
+          )
 
-poly error = #A =>
-  (\x : A => x) (\x : A => x)
+poly rec dropWhile =
+  #A =>
+    \p : A -> Bool =>
+      \l : List A =>
+        matchList
+          [A]
+          [List A]
+          l
+          (nil [A])
+          (
+            \h : A =>
+              \t : List A =>
+                if [List A] (p h)
+                  (\u : U8 => dropWhile [A] p t)
+                  (\u : U8 => cons [A] h t)
+          )
 
-poly rec eqListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    (matchList [U8] [Bool] b true (\h : U8 => \t : List U8 => false))
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b
-        false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => eqListU8 ta tb)
-            (\u : U8 => false)))
+poly rec span =
+  #A =>
+    \p : A -> Bool =>
+      \l : List A =>
+        matchList
+          [A]
+          [Pair (List A) (List A)]
+          l
+          (MkPair [List A] [List A] (nil [A]) (nil [A]))
+          (
+            \h : A =>
+              \t : List A =>
+                if [Pair (List A) (List A)] (p h)
+                  (
+                    \u : U8 =>
+                      let res = span [A] p t in
+                      MkPair
+                        [List A]
+                        [List A]
+                        (cons [A] h (fst [List A] [List A] res))
+                        (snd [List A] [List A] res)
+                  )
+                  (\u : U8 => MkPair [List A] [List A] (nil [A]) l)
+          )
 
-poly rec ltListU8 = \a : List U8 => \b : List U8 =>
-  matchList [U8] [Bool] a
-    (matchList [U8] [Bool] b false (\h : U8 => \t : List U8 => true))
-    (\ha : U8 => \ta : List U8 =>
-      matchList [U8] [Bool] b
-        false
-        (\hb : U8 => \tb : List U8 =>
-          if [Bool] (eqU8 ha hb)
-            (\u : U8 => ltListU8 ta tb)
-            (\u : U8 => ltU8 ha hb)))
+poly rec reverseAcc =
+  #A =>
+    \xs : List A =>
+      \acc : List A =>
+        matchList
+          [A]
+          [List A]
+          xs
+          acc
+          (\h : A => \t : List A => reverseAcc [A] t (cons [A] h acc))
 
-poly lteListU8 = \a : List U8 => \b : List U8 =>
-  or (eqListU8 a b) (ltListU8 a b)
+poly reverse =
+  #A =>
+    \xs : List A =>
+      foldl
+        [A]
+        [List A]
+        (\acc : List A => \x : A => cons [A] x acc)
+        (nil [A])
+        xs
 
-poly digitToAscii = \n : U8 =>
-  if [U8] (eqU8 n #u8(0)) (\u : U8 => '0')
-  (if [U8] (eqU8 n #u8(1)) (\u : U8 => '1')
-  (if [U8] (eqU8 n #u8(2)) (\u : U8 => '2')
-  (if [U8] (eqU8 n #u8(3)) (\u : U8 => '3')
-  (if [U8] (eqU8 n #u8(4)) (\u : U8 => '4')
-  (if [U8] (eqU8 n #u8(5)) (\u : U8 => '5')
-  (if [U8] (eqU8 n #u8(6)) (\u : U8 => '6')
-  (if [U8] (eqU8 n #u8(7)) (\u : U8 => '7')
-  (if [U8] (eqU8 n #u8(8)) (\u : U8 => '8')
-  ('9')))))))))
+poly error =
+  #A => (\x : A => x) (\x : A => x)
 
-poly singletonU8 = \c : U8 => cons [U8] c (nil [U8])
+poly rec eqListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
+        (matchList [U8] [Bool] b true (\h : U8 => \t : List U8 => false))
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => eqListU8 ta tb)
+                        (\u : U8 => false)
+                )
+        )
 
-poly u8ToDigits = \n : U8 =>
-  if [List U8] (ltU8 n #u8(10))
-    (\u : U8 => singletonU8 (digitToAscii n))
-    (\u : U8 =>
-      if [List U8] (ltU8 n #u8(100))
-        (\u : U8 =>
-          cons [U8]
-            (digitToAscii (divU8 n #u8(10)))
-            (singletonU8 (digitToAscii (modU8 n #u8(10)))))
-        (\u : U8 =>
-          let hundreds = divU8 n #u8(100) in
-          let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-          let ones = modU8 n #u8(10) in
-          cons [U8]
-            (digitToAscii hundreds)
-            (cons [U8]
-              (digitToAscii tens)
-              (singletonU8 (digitToAscii ones)))))
+poly rec ltListU8 =
+  \a : List U8 =>
+    \b : List U8 =>
+      matchList
+        [U8]
+        [Bool]
+        a
+        (matchList [U8] [Bool] b false (\h : U8 => \t : List U8 => true))
+        (
+          \ha : U8 =>
+            \ta : List U8 =>
+              matchList
+                [U8]
+                [Bool]
+                b
+                false
+                (
+                  \hb : U8 =>
+                    \tb : List U8 =>
+                      if [Bool] (eqU8 ha hb)
+                        (\u : U8 => ltListU8 ta tb)
+                        (\u : U8 => ltU8 ha hb)
+                )
+        )
+
+poly lteListU8 =
+  \a : List U8 => \b : List U8 => or (eqListU8 a b) (ltListU8 a b)
+
+poly digitToAscii =
+  \n : U8 =>
+    if [U8] (eqU8 n #u8(0))
+      (\u : U8 => '0')
+      (
+        if [U8] (eqU8 n #u8(1))
+          (\u : U8 => '1')
+          (
+            if [U8] (eqU8 n #u8(2))
+              (\u : U8 => '2')
+              (
+                if [U8] (eqU8 n #u8(3))
+                  (\u : U8 => '3')
+                  (
+                    if [U8] (eqU8 n #u8(4))
+                      (\u : U8 => '4')
+                      (
+                        if [U8] (eqU8 n #u8(5))
+                          (\u : U8 => '5')
+                          (
+                            if [U8] (eqU8 n #u8(6))
+                              (\u : U8 => '6')
+                              (
+                                if [U8] (eqU8 n #u8(7))
+                                  (\u : U8 => '7')
+                                  (
+                                    if [U8] (eqU8 n #u8(8))
+                                      (\u : U8 => '8')
+                                      ('9')
+                                  )
+                              )
+                          )
+                      )
+                  )
+              )
+          )
+      )
+
+poly singletonU8 =
+  \c : U8 => cons [U8] c (nil [U8])
+
+poly u8ToDigits =
+  \n : U8 =>
+    if [List U8] (ltU8 n #u8(10))
+      (\u : U8 => singletonU8 (digitToAscii n))
+      (
+        \u : U8 =>
+          if [List U8] (ltU8 n #u8(100))
+            (
+              \u : U8 =>
+                cons
+                  [U8]
+                  (digitToAscii (divU8 n #u8(10)))
+                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
+            )
+            (
+              \u : U8 =>
+                let hundreds = divU8 n #u8(100) in
+                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
+                let ones = modU8 n #u8(10) in
+                cons
+                  [U8]
+                  (digitToAscii hundreds)
+                  (
+                    cons
+                      [U8]
+                      (digitToAscii tens)
+                      (singletonU8 (digitToAscii ones))
+                  )
+            )
+      )

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "license": "MIT",
   "type": "module",
   "exports": {
     ".": "./lib/index.ts",
-    "./bin/tripc": "./bin/tripc.ts"
+    "./bin/tripc": "./bin/tripc.ts",
+    "./bin/improvize": "./bin/improvize.ts"
   },
   "files": [
     "README.md",
@@ -40,6 +41,7 @@
   "scripts": {
     "build:ts": "tsc --project tsconfig.emit.json",
     "tripc": "node --disable-warning=ExperimentalWarning ts_out/bin/tripc.js",
+    "improvize": "node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js",
     "bench:avl": "node --disable-warning=ExperimentalWarning ts_out/test/avlBenchmark.js",
     "dist": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/bazel.js dist",
     "typecheck": "tsc --noEmit",

--- a/scripts/findUnusedExports.ts
+++ b/scripts/findUnusedExports.ts
@@ -47,7 +47,7 @@ for (const file of files) {
   }
 }
 
-const PROD_ROOTS = ["lib/index.ts", "bin/tripc.ts"];
+const PROD_ROOTS = ["lib/index.ts", "bin/tripc.ts", "bin/improvize.ts"];
 const TEST_ROOTS = files.filter(
   (f) => f.startsWith("test/") && f.endsWith(".test.ts"),
 );

--- a/test/bin/cli.test.ts
+++ b/test/bin/cli.test.ts
@@ -102,11 +102,11 @@ function llvmArgs(): string[] {
   return [
     "--emit",
     "llvm",
-    "test/compiler/llvm/helloWorld.trip",
+    join(srcRoot, "test/compiler/llvm/helloWorld.trip"),
     "--entry-module",
     "Main",
     "--module-source",
-    "Prelude=lib/prelude.trip",
+    `Prelude=${join(srcRoot, "lib/prelude.trip")}`,
     "--emit-main-wrapper",
     "--stdout",
   ];
@@ -169,7 +169,7 @@ describe("CLI Tests", () => {
         "bin/tripc.js",
         "--emit",
         "llvm",
-        "test/bin/fixtures/invalid_syntax.trip",
+        join(srcRoot, "test/bin/fixtures/invalid_syntax.trip"),
       ]);
 
       assert.strictEqual(result.success, false);
@@ -282,7 +282,7 @@ describe("CLI Tests", () => {
       const result = await runCommand([
         process.execPath,
         "bin/tripc.js",
-        "test/bin/fixtures/empty.txt",
+        join(srcRoot, "test/bin/fixtures/empty.txt"),
       ]);
       assert.strictEqual(result.success, false);
       assert.ok(result.stderr.includes("must have .trip extension"));

--- a/test/bin/fixtures/invalid_expression.trip
+++ b/test/bin/fixtures/invalid_expression.trip
@@ -1,2 +1,4 @@
 module Test
-poly id = invalid syntax here
+
+poly id =
+  invalid syntax here

--- a/test/bin/fixtures/large.trip
+++ b/test/bin/fixtures/large.trip
@@ -1,201 +1,501 @@
 module LargeModule
+
 export func0
-poly func0 = #a => \x:a => x
+
+poly func0 =
+  #a => \x : a => x
+
 export func1
-poly func1 = #a => \x:a => x
+
+poly func1 =
+  #a => \x : a => x
+
 export func2
-poly func2 = #a => \x:a => x
+
+poly func2 =
+  #a => \x : a => x
+
 export func3
-poly func3 = #a => \x:a => x
+
+poly func3 =
+  #a => \x : a => x
+
 export func4
-poly func4 = #a => \x:a => x
+
+poly func4 =
+  #a => \x : a => x
+
 export func5
-poly func5 = #a => \x:a => x
+
+poly func5 =
+  #a => \x : a => x
+
 export func6
-poly func6 = #a => \x:a => x
+
+poly func6 =
+  #a => \x : a => x
+
 export func7
-poly func7 = #a => \x:a => x
+
+poly func7 =
+  #a => \x : a => x
+
 export func8
-poly func8 = #a => \x:a => x
+
+poly func8 =
+  #a => \x : a => x
+
 export func9
-poly func9 = #a => \x:a => x
+
+poly func9 =
+  #a => \x : a => x
+
 export func10
-poly func10 = #a => \x:a => x
+
+poly func10 =
+  #a => \x : a => x
+
 export func11
-poly func11 = #a => \x:a => x
+
+poly func11 =
+  #a => \x : a => x
+
 export func12
-poly func12 = #a => \x:a => x
+
+poly func12 =
+  #a => \x : a => x
+
 export func13
-poly func13 = #a => \x:a => x
+
+poly func13 =
+  #a => \x : a => x
+
 export func14
-poly func14 = #a => \x:a => x
+
+poly func14 =
+  #a => \x : a => x
+
 export func15
-poly func15 = #a => \x:a => x
+
+poly func15 =
+  #a => \x : a => x
+
 export func16
-poly func16 = #a => \x:a => x
+
+poly func16 =
+  #a => \x : a => x
+
 export func17
-poly func17 = #a => \x:a => x
+
+poly func17 =
+  #a => \x : a => x
+
 export func18
-poly func18 = #a => \x:a => x
+
+poly func18 =
+  #a => \x : a => x
+
 export func19
-poly func19 = #a => \x:a => x
+
+poly func19 =
+  #a => \x : a => x
+
 export func20
-poly func20 = #a => \x:a => x
+
+poly func20 =
+  #a => \x : a => x
+
 export func21
-poly func21 = #a => \x:a => x
+
+poly func21 =
+  #a => \x : a => x
+
 export func22
-poly func22 = #a => \x:a => x
+
+poly func22 =
+  #a => \x : a => x
+
 export func23
-poly func23 = #a => \x:a => x
+
+poly func23 =
+  #a => \x : a => x
+
 export func24
-poly func24 = #a => \x:a => x
+
+poly func24 =
+  #a => \x : a => x
+
 export func25
-poly func25 = #a => \x:a => x
+
+poly func25 =
+  #a => \x : a => x
+
 export func26
-poly func26 = #a => \x:a => x
+
+poly func26 =
+  #a => \x : a => x
+
 export func27
-poly func27 = #a => \x:a => x
+
+poly func27 =
+  #a => \x : a => x
+
 export func28
-poly func28 = #a => \x:a => x
+
+poly func28 =
+  #a => \x : a => x
+
 export func29
-poly func29 = #a => \x:a => x
+
+poly func29 =
+  #a => \x : a => x
+
 export func30
-poly func30 = #a => \x:a => x
+
+poly func30 =
+  #a => \x : a => x
+
 export func31
-poly func31 = #a => \x:a => x
+
+poly func31 =
+  #a => \x : a => x
+
 export func32
-poly func32 = #a => \x:a => x
+
+poly func32 =
+  #a => \x : a => x
+
 export func33
-poly func33 = #a => \x:a => x
+
+poly func33 =
+  #a => \x : a => x
+
 export func34
-poly func34 = #a => \x:a => x
+
+poly func34 =
+  #a => \x : a => x
+
 export func35
-poly func35 = #a => \x:a => x
+
+poly func35 =
+  #a => \x : a => x
+
 export func36
-poly func36 = #a => \x:a => x
+
+poly func36 =
+  #a => \x : a => x
+
 export func37
-poly func37 = #a => \x:a => x
+
+poly func37 =
+  #a => \x : a => x
+
 export func38
-poly func38 = #a => \x:a => x
+
+poly func38 =
+  #a => \x : a => x
+
 export func39
-poly func39 = #a => \x:a => x
+
+poly func39 =
+  #a => \x : a => x
+
 export func40
-poly func40 = #a => \x:a => x
+
+poly func40 =
+  #a => \x : a => x
+
 export func41
-poly func41 = #a => \x:a => x
+
+poly func41 =
+  #a => \x : a => x
+
 export func42
-poly func42 = #a => \x:a => x
+
+poly func42 =
+  #a => \x : a => x
+
 export func43
-poly func43 = #a => \x:a => x
+
+poly func43 =
+  #a => \x : a => x
+
 export func44
-poly func44 = #a => \x:a => x
+
+poly func44 =
+  #a => \x : a => x
+
 export func45
-poly func45 = #a => \x:a => x
+
+poly func45 =
+  #a => \x : a => x
+
 export func46
-poly func46 = #a => \x:a => x
+
+poly func46 =
+  #a => \x : a => x
+
 export func47
-poly func47 = #a => \x:a => x
+
+poly func47 =
+  #a => \x : a => x
+
 export func48
-poly func48 = #a => \x:a => x
+
+poly func48 =
+  #a => \x : a => x
+
 export func49
-poly func49 = #a => \x:a => x
+
+poly func49 =
+  #a => \x : a => x
+
 export func50
-poly func50 = #a => \x:a => x
+
+poly func50 =
+  #a => \x : a => x
+
 export func51
-poly func51 = #a => \x:a => x
+
+poly func51 =
+  #a => \x : a => x
+
 export func52
-poly func52 = #a => \x:a => x
+
+poly func52 =
+  #a => \x : a => x
+
 export func53
-poly func53 = #a => \x:a => x
+
+poly func53 =
+  #a => \x : a => x
+
 export func54
-poly func54 = #a => \x:a => x
+
+poly func54 =
+  #a => \x : a => x
+
 export func55
-poly func55 = #a => \x:a => x
+
+poly func55 =
+  #a => \x : a => x
+
 export func56
-poly func56 = #a => \x:a => x
+
+poly func56 =
+  #a => \x : a => x
+
 export func57
-poly func57 = #a => \x:a => x
+
+poly func57 =
+  #a => \x : a => x
+
 export func58
-poly func58 = #a => \x:a => x
+
+poly func58 =
+  #a => \x : a => x
+
 export func59
-poly func59 = #a => \x:a => x
+
+poly func59 =
+  #a => \x : a => x
+
 export func60
-poly func60 = #a => \x:a => x
+
+poly func60 =
+  #a => \x : a => x
+
 export func61
-poly func61 = #a => \x:a => x
+
+poly func61 =
+  #a => \x : a => x
+
 export func62
-poly func62 = #a => \x:a => x
+
+poly func62 =
+  #a => \x : a => x
+
 export func63
-poly func63 = #a => \x:a => x
+
+poly func63 =
+  #a => \x : a => x
+
 export func64
-poly func64 = #a => \x:a => x
+
+poly func64 =
+  #a => \x : a => x
+
 export func65
-poly func65 = #a => \x:a => x
+
+poly func65 =
+  #a => \x : a => x
+
 export func66
-poly func66 = #a => \x:a => x
+
+poly func66 =
+  #a => \x : a => x
+
 export func67
-poly func67 = #a => \x:a => x
+
+poly func67 =
+  #a => \x : a => x
+
 export func68
-poly func68 = #a => \x:a => x
+
+poly func68 =
+  #a => \x : a => x
+
 export func69
-poly func69 = #a => \x:a => x
+
+poly func69 =
+  #a => \x : a => x
+
 export func70
-poly func70 = #a => \x:a => x
+
+poly func70 =
+  #a => \x : a => x
+
 export func71
-poly func71 = #a => \x:a => x
+
+poly func71 =
+  #a => \x : a => x
+
 export func72
-poly func72 = #a => \x:a => x
+
+poly func72 =
+  #a => \x : a => x
+
 export func73
-poly func73 = #a => \x:a => x
+
+poly func73 =
+  #a => \x : a => x
+
 export func74
-poly func74 = #a => \x:a => x
+
+poly func74 =
+  #a => \x : a => x
+
 export func75
-poly func75 = #a => \x:a => x
+
+poly func75 =
+  #a => \x : a => x
+
 export func76
-poly func76 = #a => \x:a => x
+
+poly func76 =
+  #a => \x : a => x
+
 export func77
-poly func77 = #a => \x:a => x
+
+poly func77 =
+  #a => \x : a => x
+
 export func78
-poly func78 = #a => \x:a => x
+
+poly func78 =
+  #a => \x : a => x
+
 export func79
-poly func79 = #a => \x:a => x
+
+poly func79 =
+  #a => \x : a => x
+
 export func80
-poly func80 = #a => \x:a => x
+
+poly func80 =
+  #a => \x : a => x
+
 export func81
-poly func81 = #a => \x:a => x
+
+poly func81 =
+  #a => \x : a => x
+
 export func82
-poly func82 = #a => \x:a => x
+
+poly func82 =
+  #a => \x : a => x
+
 export func83
-poly func83 = #a => \x:a => x
+
+poly func83 =
+  #a => \x : a => x
+
 export func84
-poly func84 = #a => \x:a => x
+
+poly func84 =
+  #a => \x : a => x
+
 export func85
-poly func85 = #a => \x:a => x
+
+poly func85 =
+  #a => \x : a => x
+
 export func86
-poly func86 = #a => \x:a => x
+
+poly func86 =
+  #a => \x : a => x
+
 export func87
-poly func87 = #a => \x:a => x
+
+poly func87 =
+  #a => \x : a => x
+
 export func88
-poly func88 = #a => \x:a => x
+
+poly func88 =
+  #a => \x : a => x
+
 export func89
-poly func89 = #a => \x:a => x
+
+poly func89 =
+  #a => \x : a => x
+
 export func90
-poly func90 = #a => \x:a => x
+
+poly func90 =
+  #a => \x : a => x
+
 export func91
-poly func91 = #a => \x:a => x
+
+poly func91 =
+  #a => \x : a => x
+
 export func92
-poly func92 = #a => \x:a => x
+
+poly func92 =
+  #a => \x : a => x
+
 export func93
-poly func93 = #a => \x:a => x
+
+poly func93 =
+  #a => \x : a => x
+
 export func94
-poly func94 = #a => \x:a => x
+
+poly func94 =
+  #a => \x : a => x
+
 export func95
-poly func95 = #a => \x:a => x
+
+poly func95 =
+  #a => \x : a => x
+
 export func96
-poly func96 = #a => \x:a => x
+
+poly func96 =
+  #a => \x : a => x
+
 export func97
-poly func97 = #a => \x:a => x
+
+poly func97 =
+  #a => \x : a => x
+
 export func98
-poly func98 = #a => \x:a => x
+
+poly func98 =
+  #a => \x : a => x
+
 export func99
-poly func99 = #a => \x:a => x
+
+poly func99 =
+  #a => \x : a => x

--- a/test/bin/fixtures/multiple_modules.trip
+++ b/test/bin/fixtures/multiple_modules.trip
@@ -1,3 +1,6 @@
 module First
+
 module Second
-poly id = #a => \x:a => x
+
+poly id =
+  #a => \x : a => x

--- a/test/bin/fixtures/no_module.trip
+++ b/test/bin/fixtures/no_module.trip
@@ -1,1 +1,2 @@
-poly id = #a => \x:a => x
+poly id =
+  #a => \x : a => x

--- a/test/bin/fixtures/simple.trip
+++ b/test/bin/fixtures/simple.trip
@@ -1,3 +1,6 @@
 module Simple
+
 export id
-poly id = #a => \x:a => x
+
+poly id =
+  #a => \x : a => x

--- a/test/bin/fixtures/test.trip
+++ b/test/bin/fixtures/test.trip
@@ -1,6 +1,8 @@
 module TestModule
 
 import Math add
+
 export id
 
-poly id = #a => \x:a => x
+poly id =
+  #a => \x : a => x

--- a/test/bin/fixtures/with_combinators.trip
+++ b/test/bin/fixtures/with_combinators.trip
@@ -1,5 +1,11 @@
 module WithCombinators
+
 export K
+
 export S
-combinator K = K
-combinator S = S
+
+combinator K =
+  K
+
+combinator S =
+  S

--- a/test/bin/fixtures/with_imports.trip
+++ b/test/bin/fixtures/with_imports.trip
@@ -1,5 +1,10 @@
 module WithImports
+
 import Math add
+
 import Utils format
+
 export double
-poly double = \x:Int => add x x
+
+poly double =
+  \x : Int => add x x

--- a/test/bin/fixtures/with_types.trip
+++ b/test/bin/fixtures/with_types.trip
@@ -1,5 +1,10 @@
 module WithTypes
+
 export Nat
+
 export zero
+
 type Nat = Int
-poly zero = #a => \s:a->a => \z:a => z
+
+poly zero =
+  #a => \s : a -> a => \z : a => z

--- a/test/bin/improvize.test.ts
+++ b/test/bin/improvize.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+import {
+  cleanupTempWorkspace,
+  createTempWorkspace,
+  jsRoot,
+} from "../util/tripcHarness.ts";
+
+const improvizeScriptPath = join(jsRoot, "bin", "improvize.js");
+
+function runImprovize(args: string[], cwd?: string) {
+  return spawnSync(
+    process.execPath,
+    ["--disable-warning=ExperimentalWarning", improvizeScriptPath, ...args],
+    {
+      cwd,
+      encoding: "utf8",
+    },
+  );
+}
+
+describe("improvize CLI", () => {
+  it("prints help and version", () => {
+    const help = runImprovize(["--help"]);
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /improvize/);
+    assert.match(help.stdout, /format/);
+    assert.match(help.stdout, /lint/);
+    assert.match(help.stdout, /--version/);
+    assert.match(help.stdout, /--verbose/);
+
+    const version = runImprovize(["--version"]);
+    assert.equal(version.status, 0);
+    assert.match(version.stdout.trim(), /^improvize v\d+\.\d+\.\d+$/);
+  });
+
+  it("checks formatting and writes formatted files", async () => {
+    const workspace = await createTempWorkspace("typed-ski-improvize-cli-");
+    try {
+      const file = join(workspace, "Main.trip");
+      await writeFile(file, "module M\npoly main = #A=>\\x:A=>x\n", "utf8");
+
+      const check = runImprovize(["format", "--check", file]);
+      assert.equal(check.status, 1);
+      assert.match(check.stdout, /needs formatting/);
+
+      const write = runImprovize(["format", "--write", file]);
+      assert.equal(write.status, 0, write.stderr);
+      const formatted = await readFile(file, "utf8");
+      assert.match(formatted, /poly main =\n  #A => \\x : A => x\n/);
+
+      const recheck = runImprovize(["format", "--check", file]);
+      assert.equal(recheck.status, 0);
+
+      const stdoutFormat = runImprovize(["format", file]);
+      assert.equal(stdoutFormat.status, 0, stdoutFormat.stderr);
+      assert.equal(stdoutFormat.stdout, formatted);
+    } finally {
+      await cleanupTempWorkspace(workspace);
+    }
+  });
+
+  it("reports lint findings and applies fixes", async () => {
+    const workspace = await createTempWorkspace("typed-ski-improvize-lint-");
+    try {
+      const file = join(workspace, "Main.trip");
+      await writeFile(file, "module M\npoly main = 7\n", "utf8");
+
+      const lint = runImprovize(["lint", file]);
+      assert.equal(lint.status, 1);
+      assert.match(lint.stdout, /trip-u8-literal/);
+
+      const fixed = runImprovize(["lint", "--fix", file]);
+      assert.equal(fixed.status, 0, fixed.stderr);
+      const content = await readFile(file, "utf8");
+      assert.match(content, /#u8\(7\)/);
+    } finally {
+      await cleanupTempWorkspace(workspace);
+    }
+  });
+
+  it("keeps lint --fix nonzero when diagnostics remain", async () => {
+    const workspace = await createTempWorkspace("typed-ski-improvize-lint-");
+    try {
+      const file = join(workspace, "Main.trip");
+      await writeFile(
+        file,
+        "module M\nimport Prelude if\npoly main = if [A] true t f\n",
+        "utf8",
+      );
+
+      const fixed = runImprovize(["lint", "--fix", file]);
+      assert.equal(fixed.status, 1);
+      assert.match(fixed.stdout, /trip-if-constant/);
+    } finally {
+      await cleanupTempWorkspace(workspace);
+    }
+  });
+});

--- a/test/bin/integration.test.ts
+++ b/test/bin/integration.test.ts
@@ -49,12 +49,12 @@ describe("CLI Integration", () => {
       const result = runTripc([
         "--emit",
         "llvm",
-        "test/compiler/llvm/helloWorld.trip",
+        join(workspaceRoot, "test/compiler/llvm/helloWorld.trip"),
         outPath,
         "--entry-module",
         "Main",
         "--module-source",
-        "Prelude=lib/prelude.trip",
+        `Prelude=${join(workspaceRoot, "lib/prelude.trip")}`,
         "--emit-main-wrapper",
       ]);
 

--- a/test/bin/jsrPackaging.test.ts
+++ b/test/bin/jsrPackaging.test.ts
@@ -28,10 +28,23 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const jsRoot = join(__dirname, "../..");
 const srcRoot = workspaceRoot;
 
+function jsrJsonPath(): string {
+  const candidates = [
+    process.env["TYPED_SKI_JSR_JSON_PATH"],
+    join(srcRoot, "jsr.json"),
+    join(jsRoot, "..", "..", "..", "jsr.json"),
+  ];
+  const found = candidates.find(
+    (candidate): candidate is string =>
+      candidate !== undefined && existsSync(candidate),
+  );
+  return found ?? join(srcRoot, "jsr.json");
+}
+
 describe("JSR Packaging Configuration", () => {
   describe("jsr.json configuration", () => {
     it("has required fields", async () => {
-      const configPath = join(srcRoot, "jsr.json");
+      const configPath = jsrJsonPath();
       assert.strictEqual(existsSync(configPath), true);
 
       const configContent = await readFile(configPath, "utf-8");
@@ -50,19 +63,24 @@ describe("JSR Packaging Configuration", () => {
     });
 
     it("exports field configuration", async () => {
-      const configPath = join(srcRoot, "jsr.json");
+      const configPath = jsrJsonPath();
       const configContent = await readFile(configPath, "utf-8");
       const config = parseJsonc(configContent) as any;
 
       assert.ok(config.exports !== undefined);
       assert.ok("./bin/tripc" in config.exports);
+      assert.ok("./bin/improvize" in config.exports);
 
       assert.strictEqual(config.exports["."], "./lib/index.ts");
       assert.strictEqual(config.exports["./bin/tripc"], "./bin/tripc.ts");
+      assert.strictEqual(
+        config.exports["./bin/improvize"],
+        "./bin/improvize.ts",
+      );
     });
 
     it("publish include configuration", async () => {
-      const configPath = join(srcRoot, "jsr.json");
+      const configPath = jsrJsonPath();
       const configContent = await readFile(configPath, "utf-8");
       const config = parseJsonc(configContent) as any;
 
@@ -74,7 +92,7 @@ describe("JSR Packaging Configuration", () => {
     });
 
     it("uses Deno's built-in Node types without requiring node_modules", async () => {
-      const configPath = join(srcRoot, "jsr.json");
+      const configPath = jsrJsonPath();
       const configContent = await readFile(configPath, "utf-8");
       const config = parseJsonc(configContent) as any;
 
@@ -94,14 +112,24 @@ describe("JSR Packaging Configuration", () => {
 
       // Core CLI files
       assert.strictEqual(existsSync(join(binDir, "tripc.ts")), true);
+      assert.strictEqual(existsSync(join(binDir, "improvize.ts")), true);
 
       // Documentation and scripts
     });
 
     it("CLI files have proper shebang", async () => {
       const tripcTs = await readFile(join(srcRoot, "bin/tripc.ts"), "utf-8");
+      const improvizeTs = await readFile(
+        join(srcRoot, "bin/improvize.ts"),
+        "utf-8",
+      );
       assert.ok(
         tripcTs.includes(
+          "#!/usr/bin/env -S node --disable-warning=ExperimentalWarning",
+        ),
+      );
+      assert.ok(
+        improvizeTs.includes(
           "#!/usr/bin/env -S node --disable-warning=ExperimentalWarning",
         ),
       );
@@ -175,8 +203,7 @@ describe("JSR Packaging Configuration", () => {
       const packageJson = JSON.parse(await readFile(packageJsonPath, "utf-8"));
       const version = packageJson.version;
 
-      const jsrJsonPath = join(srcRoot, "jsr.json");
-      const jsrJson = JSON.parse(await readFile(jsrJsonPath, "utf-8"));
+      const jsrJson = JSON.parse(await readFile(jsrJsonPath(), "utf-8"));
       assert.strictEqual(jsrJson.version, version);
 
       // Read the VERSION via static import rather than file-system probe.
@@ -239,7 +266,7 @@ describe("JSR Packaging Configuration", () => {
             "--entry-module",
             "Main",
             "--module-source",
-            "Prelude=lib/prelude.trip",
+            `Prelude=${join(srcRoot, "lib/prelude.trip")}`,
             "--emit-main-wrapper",
           ],
           {

--- a/test/compiler/inputs/binWithNat.trip
+++ b/test/compiler/inputs/binWithNat.trip
@@ -1,27 +1,47 @@
 module Bin
 
 import Nat Nat
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat mul
 
 export Bin
+
 export BZ
+
 export B0
+
 export B1
+
 export incBin
+
 export toBin
+
 export fromBin
+
 export addBin
+
 export mulBin
+
 export subBin
+
 export predBin
+
 export isZeroBin
+
 export eqBin
+
 export lteBin
 
 data Bin =
@@ -29,100 +49,113 @@ data Bin =
   | B0 Bin
   | B1 Bin
 
-poly rec isZeroBin = \b : Bin =>
-  match b [Bool] {
-    | BZ => true
-    | B0 rest => isZeroBin rest
-    | B1 _ => false
-  }
+poly rec isZeroBin =
+  \b : Bin =>
+    match b [Bool] {
+      | BZ => true
+      | B0 rest => isZeroBin rest
+      | B1 _ => false
+    }
 
-poly rec incBin = \b : Bin =>
-  match b [Bin] {
-    | BZ => B1 BZ
-    | B0 rest => B1 rest
-    | B1 rest => B0 (incBin rest)
-  }
+poly rec incBin =
+  \b : Bin =>
+    match b [Bin] {
+      | BZ => B1 BZ
+      | B0 rest => B1 rest
+      | B1 rest => B0 (incBin rest)
+    }
 
-poly toBin = \n : Nat => n [Bin] incBin BZ
+poly toBin =
+  \n : Nat => n [Bin] incBin BZ
 
-poly rec fromBin = \b : Bin =>
-  match b [Nat] {
-    | BZ => zero
-    | B0 rest =>
+poly rec fromBin =
+  \b : Bin =>
+    match b [Nat] {
+      | BZ => zero
+      | B0 rest =>
         let r = fromBin rest in
         add r r
-    | B1 rest =>
+      | B1 rest =>
         let r = fromBin rest in
         succ (add r r)
-  }
+    }
 
-poly rec addBin = \a : Bin => \b : Bin =>
-  match a [Bin] {
-    | BZ => b
-    | B0 pa =>
-        match b [Bin] {
-          | BZ => a
-          | B0 pb => B0 (addBin pa pb)
-          | B1 pb => B1 (addBin pa pb)
-        }
-    | B1 pa =>
-        match b [Bin] {
-          | BZ => a
-          | B0 pb => B1 (addBin pa pb)
-          | B1 pb => B0 (incBin (addBin pa pb))
-        }
-  }
+poly rec addBin =
+  \a : Bin =>
+    \b : Bin =>
+      match a [Bin] {
+        | BZ => b
+        | B0 pa =>
+          match b [Bin] {
+            | BZ => a
+            | B0 pb => B0 (addBin pa pb)
+            | B1 pb => B1 (addBin pa pb)
+          }
+        | B1 pa =>
+          match b [Bin] {
+            | BZ => a
+            | B0 pb => B1 (addBin pa pb)
+            | B1 pb => B0 (incBin (addBin pa pb))
+          }
+      }
 
-poly rec mulBin = \a : Bin => \b : Bin =>
-  match b [Bin] {
-    | BZ => BZ
-    | B0 pb => B0 (mulBin a pb)
-    | B1 pb => addBin a (B0 (mulBin a pb))
-  }
+poly rec mulBin =
+  \a : Bin =>
+    \b : Bin =>
+      match b [Bin] {
+        | BZ => BZ
+        | B0 pb => B0 (mulBin a pb)
+        | B1 pb => addBin a (B0 (mulBin a pb))
+      }
 
-poly rec predBin = \b : Bin =>
-  match b [Bin] {
-    | BZ => BZ
-    | B0 rest => B1 (predBin rest)
-    | B1 rest => B0 rest
-  }
+poly rec predBin =
+  \b : Bin =>
+    match b [Bin] {
+      | BZ => BZ
+      | B0 rest => B1 (predBin rest)
+      | B1 rest => B0 rest
+    }
 
-poly rec subBin = \a : Bin => \b : Bin =>
-  match b [Bin] {
-    | BZ => a
-    | B0 pb =>
-        match a [Bin] {
-          | BZ => BZ
-          | B0 pa => B0 (subBin pa pb)
-          | B1 pa => B1 (subBin pa pb)
-        }
-    | B1 pb =>
-        match a [Bin] {
-          | BZ => BZ
-          | B0 pa => B1 (subBin (predBin pa) pb)
-          | B1 pa => B0 (subBin pa pb)
-        }
-  }
+poly rec subBin =
+  \a : Bin =>
+    \b : Bin =>
+      match b [Bin] {
+        | BZ => a
+        | B0 pb =>
+          match a [Bin] {
+            | BZ => BZ
+            | B0 pa => B0 (subBin pa pb)
+            | B1 pa => B1 (subBin pa pb)
+          }
+        | B1 pb =>
+          match a [Bin] {
+            | BZ => BZ
+            | B0 pa => B1 (subBin (predBin pa) pb)
+            | B1 pa => B0 (subBin pa pb)
+          }
+      }
 
-poly rec eqBin = \a : Bin => \b : Bin =>
-  match a [Bool] {
-    | BZ => isZeroBin b
-    | B0 pa =>
-        match b [Bool] {
-          | BZ => false
-          | B0 pb => eqBin pa pb
-          | B1 _ => false
-        }
-    | B1 pa =>
-        match b [Bool] {
-          | BZ => false
-          | B0 _ => false
-          | B1 pb => eqBin pa pb
-        }
-  }
+poly rec eqBin =
+  \a : Bin =>
+    \b : Bin =>
+      match a [Bool] {
+        | BZ => isZeroBin b
+        | B0 pa =>
+          match b [Bool] {
+            | BZ => false
+            | B0 pb => eqBin pa pb
+            | B1 _ => false
+          }
+        | B1 pa =>
+          match b [Bool] {
+            | BZ => false
+            | B0 _ => false
+            | B1 pb => eqBin pa pb
+          }
+      }
 
-poly lteBin = \a : Bin => \b : Bin =>
-  isZeroBin (subBin a b)
+poly lteBin =
+  \a : Bin => \b : Bin => isZeroBin (subBin a b)
 
-poly gteBin = \a : Bin => \b : Bin =>
-  lteBin b a
+poly gteBin =
+  \a : Bin => \b : Bin => lteBin b a

--- a/test/compiler/inputs/combinatorCompiler/literalZero.trip
+++ b/test/compiler/inputs/combinatorCompiler/literalZero.trip
@@ -1,3 +1,6 @@
 module Main
+
 export main
-poly main = 0
+
+poly main =
+  #u8(0)

--- a/test/compiler/inputs/combinatorCompiler/withPreludeImport.trip
+++ b/test/compiler/inputs/combinatorCompiler/withPreludeImport.trip
@@ -1,4 +1,8 @@
 module Main
+
 import Prelude id
+
 export main
-poly main = id
+
+poly main =
+  id

--- a/test/compiler/inputs/preludeTest.trip
+++ b/test/compiler/inputs/preludeTest.trip
@@ -1,29 +1,45 @@
 module TestPrelude
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Prelude not
+
 import Prelude and
+
 import Prelude or
+
 import Prelude pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Nat pred
+
 import Nat sub
+
 import Nat isZero
+
 import Nat lte
+
 import Nat gte
+
 import Prelude true
+
 import Prelude false
+
 import Nat Nat
 
 export main
 
 poly main =
-  let a = (not false) [Nat] (succ zero) zero in
-  let b = add a ((and true true) [Nat] (succ zero) zero) in
-  let c = add b ((or false true) [Nat] (succ zero) zero) in
+  let a = (true) [Nat] (succ zero) zero in
+  let b = add a ((true) [Nat] (succ zero) zero) in
+  let c = add b ((true) [Nat] (succ zero) zero) in
   let d = add c (pred (succ (succ zero))) in
   let e = add d (sub (succ (succ (succ zero))) (succ zero)) in
   let f = add e ((lte (succ zero) (succ (succ zero))) [Nat] (succ zero) zero) in

--- a/test/compiler/inputs/small.trip
+++ b/test/compiler/inputs/small.trip
@@ -1,3 +1,6 @@
 module Small
+
 export id
-poly id = \x => x
+
+poly id =
+  \x => x

--- a/test/compiler/inputs/subU8Test.trip
+++ b/test/compiler/inputs/subU8Test.trip
@@ -1,8 +1,10 @@
 module SubU8Test
 
 import Prelude subU8
+
 import Prelude U8
 
 export main
 
-poly main = subU8 #u8(10) #u8(2)
+poly main =
+  subU8 #u8(10) #u8(2)

--- a/test/compiler/inputs/testBinOps.trip
+++ b/test/compiler/inputs/testBinOps.trip
@@ -1,32 +1,51 @@
 module Test
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin addBin
+
 import Bin mulBin
+
 import Bin subBin
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly one : Bin = B1 BZ
-poly two : Bin = B0 (B1 BZ)
-poly three : Bin = B1 (B1 BZ)
-poly four : Bin = B0 (B0 (B1 BZ))
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
+
+poly one : Bin =
+  B1 BZ
+
+poly two : Bin =
+  B0 (B1 BZ)
+
+poly three : Bin =
+  B1 (B1 BZ)
+
+poly four : Bin =
+  B0 (B0 (B1 BZ))
 
 poly main =
   let product = mulBin two three in

--- a/test/compiler/inputs/testIsSpace.trip
+++ b/test/compiler/inputs/testIsSpace.trip
@@ -1,8 +1,10 @@
 module Test
 
 import Lexer isSpaceU8
+
 import Prelude Bool
 
 export main
 
-poly main = isSpaceU8 (#u8(0))
+poly main =
+  isSpaceU8 (#u8(0))

--- a/test/compiler/inputs/testLexArrows.trip
+++ b/test/compiler/inputs/testLexArrows.trip
@@ -1,68 +1,72 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude eqU8
+
 import Prelude U8
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer T_Arrow
+
 import Lexer T_FatArrow
+
 import Lexer T_Eq
 
 export main
 
-poly isArrowToken = \tok : Token =>
-  eqU8 (tokenTag tok) (tokenTag T_Arrow)
+poly isArrowToken =
+  \tok : Token => eqU8 (tokenTag tok) (tokenTag T_Arrow)
 
-poly isFatArrowToken = \tok : Token =>
-  eqU8 (tokenTag tok) (tokenTag T_FatArrow)
+poly isFatArrowToken =
+  \tok : Token => eqU8 (tokenTag tok) (tokenTag T_FatArrow)
 
-poly isEqToken = \tok : Token =>
-  eqU8 (tokenTag tok) (tokenTag T_Eq)
+poly isEqToken =
+  \tok : Token => eqU8 (tokenTag tok) (tokenTag T_Eq)
 
-poly listArrow : List U8 = "->"
-poly listFatArrow : List U8 = "=>"
-poly listEq : List U8 = "="
+poly listArrow : List U8 =
+  "->"
+
+poly listFatArrow : List U8 =
+  "=>"
+
+poly listEq : List U8 =
+  "="
 
 poly main =
-  let testArrow =
-    match (tokenize listArrow) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isArrowToken h)
-    }
-  in
-  let testFatArrow =
-    match (tokenize listFatArrow) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isFatArrowToken h)
-    }
-  in
-  let testEq =
-    match (tokenize listEq) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isEqToken h)
-    }
-  in
+  let testArrow = match (tokenize listArrow) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isArrowToken h)} in
+  let testFatArrow = match (tokenize listFatArrow) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isFatArrowToken h)} in
+  let testEq = match (tokenize listEq) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isEqToken h)} in
   if [Bool] testArrow
-    (\u : U8 =>
-      if [Bool] testFatArrow
-        (\u : U8 => testEq)
-        (\u : U8 => false))
+    (
+      \u : U8 =>
+        if [Bool] testFatArrow
+          (\u : U8 => testEq)
+          (\u : U8 => false)
+    )
     (\u : U8 => false)

--- a/test/compiler/inputs/testLexCoreKeywords.trip
+++ b/test/compiler/inputs/testLexCoreKeywords.trip
@@ -1,54 +1,94 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude U8
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude eqU8
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer T_KwLet
+
 import Lexer T_KwIn
+
 import Lexer T_KwMatch
+
 import Lexer T_KwNative
+
 import Lexer T_KwOpaque
 
 export main
 
-poly listLet : List U8 = "let"
-poly listMatch : List U8 = "match"
-poly listIn : List U8 = "in"
-poly listNative : List U8 = "native"
-poly listOpaque : List U8 = "opaque"
+poly listLet : List U8 =
+  "let"
 
-poly firstHasTag = \src : List U8 => \expectedTag : U8 =>
-  match (tokenize src) [Bool] {
-    | Err e => false
-    | Ok toks =>
-        matchList [Token] [Bool] toks false
-          (\h : Token => \t : List Token =>
-            eqU8 (tokenTag h) expectedTag)
-  }
+poly listMatch : List U8 =
+  "match"
+
+poly listIn : List U8 =
+  "in"
+
+poly listNative : List U8 =
+  "native"
+
+poly listOpaque : List U8 =
+  "opaque"
+
+poly firstHasTag =
+  \src : List U8 =>
+    \expectedTag : U8 =>
+      match (tokenize src) [Bool] {
+        | Err e => false
+        | Ok toks =>
+          matchList
+            [Token]
+            [Bool]
+            toks
+            false
+            (\h : Token => \t : List Token => eqU8 (tokenTag h) expectedTag)
+      }
 
 poly main =
   if [Bool] (firstHasTag listLet (tokenTag T_KwLet))
-    (\u : U8 =>
-      if [Bool] (firstHasTag listMatch (tokenTag T_KwMatch))
-        (\u : U8 =>
-          if [Bool] (firstHasTag listIn (tokenTag T_KwIn))
-            (\u : U8 =>
-              if [Bool] (firstHasTag listNative (tokenTag T_KwNative))
-                (\u : U8 => firstHasTag listOpaque (tokenTag T_KwOpaque))
-                (\u : U8 => false))
-            (\u : U8 => false))
-        (\u : U8 => false))
+    (
+      \u : U8 =>
+        if [Bool] (firstHasTag listMatch (tokenTag T_KwMatch))
+          (
+            \u : U8 =>
+              if [Bool] (firstHasTag listIn (tokenTag T_KwIn))
+                (
+                  \u : U8 =>
+                    if [Bool] (firstHasTag listNative (tokenTag T_KwNative))
+                      (\u : U8 => firstHasTag listOpaque (tokenTag T_KwOpaque))
+                      (\u : U8 => false)
+                )
+                (\u : U8 => false)
+          )
+          (\u : U8 => false)
+    )
     (\u : U8 => false)

--- a/test/compiler/inputs/testLexIdentVsKw.trip
+++ b/test/compiler/inputs/testLexIdentVsKw.trip
@@ -1,74 +1,83 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer tokenText
+
 import Lexer T_KwPoly
+
 import Lexer T_Ident
+
 import Prelude eqListU8
 
 export main
 
-poly listAbc : List U8 = "abc"
-poly listPoly : List U8 = "poly"
-poly listX : List U8 = "x"
-poly listUnderscore : List U8 = "_"
+poly listAbc : List U8 =
+  "abc"
 
-poly isIdentAbcToken = \tok : Token =>
-  if [Bool] (eqU8 (tokenTag tok) (tokenTag (T_Ident listX)))
-    (\u : U8 => eqListU8 (tokenText tok) listAbc)
-    (\u : U8 => false)
+poly listPoly : List U8 =
+  "poly"
 
-poly isKeywordPolyToken = \tok : Token =>
-  eqU8 (tokenTag tok) (tokenTag T_KwPoly)
+poly listX : List U8 =
+  "x"
 
-poly isIdentUnderscoreToken = \tok : Token =>
-  if [Bool] (eqU8 (tokenTag tok) (tokenTag (T_Ident listX)))
-    (\u : U8 => eqListU8 (tokenText tok) listUnderscore)
-    (\u : U8 => false)
+poly listUnderscore : List U8 =
+  "_"
+
+poly isIdentAbcToken =
+  \tok : Token =>
+    if [Bool] (eqU8 (tokenTag tok) (tokenTag (T_Ident listX)))
+      (\u : U8 => eqListU8 (tokenText tok) listAbc)
+      (\u : U8 => false)
+
+poly isKeywordPolyToken =
+  \tok : Token => eqU8 (tokenTag tok) (tokenTag T_KwPoly)
+
+poly isIdentUnderscoreToken =
+  \tok : Token =>
+    if [Bool] (eqU8 (tokenTag tok) (tokenTag (T_Ident listX)))
+      (\u : U8 => eqListU8 (tokenText tok) listUnderscore)
+      (\u : U8 => false)
 
 poly main =
-  let testIdent =
-    match (tokenize listAbc) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isIdentAbcToken h)
-    }
-  in
-  let testKeyword =
-    match (tokenize listPoly) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isKeywordPolyToken h)
-    }
-  in
-  let testUnderscore =
-    match (tokenize listUnderscore) [Bool] {
-      | Err e => false
-      | Ok toks =>
-          matchList [Token] [Bool] toks false
-            (\h : Token => \t : List Token => isIdentUnderscoreToken h)
-    }
-  in
+  let testIdent = match (tokenize listAbc) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isIdentAbcToken h)} in
+  let testKeyword = match (tokenize listPoly) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isKeywordPolyToken h)} in
+  let testUnderscore = match (tokenize listUnderscore) [Bool] {| Err e => false | Ok toks => matchList [Token] [Bool] toks false (\h : Token => \t : List Token => isIdentUnderscoreToken h)} in
   if [Bool] testIdent
-    (\u : U8 =>
-      if [Bool] testKeyword
-        (\u : U8 => testUnderscore)
-        (\u : U8 => false))
+    (
+      \u : U8 =>
+        if [Bool] testKeyword
+          (\u : U8 => testUnderscore)
+          (\u : U8 => false)
+    )
     (\u : U8 => false)

--- a/test/compiler/inputs/testLexInvalidChar.trip
+++ b/test/compiler/inputs/testLexInvalidChar.trip
@@ -1,19 +1,29 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude List
+
 import Prelude U8
+
 import Lexer tokenize
+
 import Lexer Token
 
 export main
 
-poly listAt : List U8 = "@"
+poly listAt : List U8 =
+  "@"
 
 poly main =
   match (tokenize listAt) [Bool] {

--- a/test/compiler/inputs/testLexNat.trip
+++ b/test/compiler/inputs/testLexNat.trip
@@ -1,37 +1,61 @@
 module Test
 
 import Prelude Bool
+
 import Prelude false
+
 import Prelude if
+
 import Prelude eqU8
+
 import Prelude eqListU8
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer tokenNatValue
 
 export main
 
-poly natTag : U8 = #u8(30)
-poly isNat123Token = \tok : Token =>
-  if [Bool] (eqU8 (tokenTag tok) natTag)
-    (\u : U8 => eqListU8 (tokenNatValue tok) list123)
-    (\u : U8 => false)
+poly natTag : U8 =
+  #u8(30)
 
-poly list123 : List U8 = "123"
+poly isNat123Token =
+  \tok : Token =>
+    if [Bool] (eqU8 (tokenTag tok) natTag)
+      (\u : U8 => eqListU8 (tokenNatValue tok) list123)
+      (\u : U8 => false)
+
+poly list123 : List U8 =
+  "123"
 
 poly main =
   match (tokenize list123) [Bool] {
     | Err e => false
     | Ok toks =>
-        matchList [Token] [Bool] toks false
-          (\h : Token => \t : List Token => isNat123Token h)
+      matchList
+        [Token]
+        [Bool]
+        toks
+        false
+        (\h : Token => \t : List Token => isNat123Token h)
   }

--- a/test/compiler/inputs/testLexRecKeyword.trip
+++ b/test/compiler/inputs/testLexRecKeyword.trip
@@ -1,35 +1,64 @@
 module Test
 
 import Prelude Bool
+
 import Prelude false
+
 import Prelude if
+
 import Prelude List
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Prelude eqU8
+
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer T_KwPoly
+
 import Lexer T_KwRec
 
 export main
 
-poly source : List U8 = "poly rec p = p"
+poly source : List U8 =
+  "poly rec p = p"
 
 poly main =
   match (tokenize source) [Bool] {
     | Err e => false
     | Ok toks =>
-        matchList [Token] [Bool] toks false
-          (\h : Token => \t : List Token =>
-            if [Bool] (eqU8 (tokenTag h) (tokenTag T_KwPoly))
-              (\u : U8 =>
-                matchList [Token] [Bool] t false
-                  (\h2 : Token => \t2 : List Token =>
-                    eqU8 (tokenTag h2) (tokenTag T_KwRec)))
-              (\u : U8 => false))
+      matchList
+        [Token]
+        [Bool]
+        toks
+        false
+        (
+          \h : Token =>
+            \t : List Token =>
+              if [Bool] (eqU8 (tokenTag h) (tokenTag T_KwPoly))
+                (
+                  \u : U8 =>
+                    matchList
+                      [Token]
+                      [Bool]
+                      t
+                      false
+                      (
+                        \h2 : Token => \t2 : List Token => eqU8 (tokenTag h2) (tokenTag T_KwRec)
+                      )
+                )
+                (\u : U8 => false)
+        )
   }

--- a/test/compiler/inputs/testParseApp.trip
+++ b/test/compiler/inputs/testParseApp.trip
@@ -1,75 +1,88 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Ident
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseApp
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
-poly isVarNamed = \expr : Expr => \name : List Bin =>
-  match expr [Bool] {
-    | E_Var n => eqListU8 n name
-    | E_App lhs rhs => false
-    | E_Lam var body => false
-    | E_Let var val body => false
-    | E_Nat n => false
-    | E_Match scrutinee arms => false
-  }
+poly isVarNamed =
+  \expr : Expr =>
+    \name : List Bin =>
+      match expr [Bool] {
+        | E_Var n => eqListU8 n name
+        | E_App lhs rhs => false
+        | E_Lam var body => false
+        | E_Let var val body => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
 
 poly main =
-  let input =
-    {Token | (T_Ident "f") (T_Ident "x") (T_Ident "y") T_EOF}
-  in
+  let input = {Token | (T_Ident "f") (T_Ident "x") (T_Ident "y") T_EOF} in
   match (parseApp input) [Bool] {
     | Err e => false
     | Ok res =>
-        let expr = fst [Expr] [List Token] res in
-        match expr [Bool] {
-          | E_Var n => false
-          | E_App lhs rhs =>
-              let rhsOk = isVarNamed rhs "y" in
-              let lhsOk =
-                match lhs [Bool] {
-                  | E_Var n => false
-                  | E_App f x =>
-                      if [Bool] (isVarNamed f "f")
-                        (\u : Bin => isVarNamed x "x")
-                        (\u : Bin => false)
-                  | E_Lam var body => false
-                  | E_Let var val body => false
-                  | E_Nat n => false
-                  | E_Match scrutinee arms => false
-                }
-              in
-              if [Bool] lhsOk
-                (\u : Bin => rhsOk)
-                (\u : Bin => false)
-          | E_Lam var body => false
-          | E_Let var val body => false
-          | E_Nat n => false
-          | E_Match scrutinee arms => false
-        }
+      let expr = fst [Expr] [List Token] res in
+      match expr [Bool] {
+        | E_Var n => false
+        | E_App lhs rhs =>
+          let rhsOk = isVarNamed rhs "y" in
+          let lhsOk = match lhs [Bool] {| E_Var n => false | E_App f x => if [Bool] (isVarNamed f "f") (\u : Bin => isVarNamed x "x") (\u : Bin => false) | E_Lam var body => false | E_Let var val body => false | E_Nat n => false | E_Match scrutinee arms => false} in
+          if [Bool] lhsOk
+            (\u : Bin => rhsOk)
+            (\u : Bin => false)
+        | E_Lam var body => false
+        | E_Let var val body => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
   }

--- a/test/compiler/inputs/testParseAtom.trip
+++ b/test/compiler/inputs/testParseAtom.trip
@@ -1,48 +1,71 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude U8
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Ident
+
 import Lexer T_Nat
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseAtom
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
 poly main =
-  let input =
-    {Token | (T_Ident "x") T_EOF}
-  in
+  let input = {Token | (T_Ident "x") T_EOF} in
   match (parseAtom input) [Bool] {
     | Err e => false
     | Ok res =>
-        let expr = fst [Expr] [List Token] res in
-        match expr [Bool] {
-          | E_Var name => eqListU8 name "x"
-          | E_App f x => false
-          | E_Lam name body => false
-          | E_Let name val body => false
-          | E_Nat n => false
-          | E_Match scrutinee arms => false
-        }
+      let expr = fst [Expr] [List Token] res in
+      match expr [Bool] {
+        | E_Var name => eqListU8 name "x"
+        | E_App f x => false
+        | E_Lam name body => false
+        | E_Let name val body => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
   }

--- a/test/compiler/inputs/testParseDefinitionKinds.trip
+++ b/test/compiler/inputs/testParseDefinitionKinds.trip
@@ -1,128 +1,204 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude U8
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Lexer Token
+
 import Lexer T_KwRec
+
 import Lexer T_KwPoly
+
 import Lexer T_KwCombinator
+
 import Lexer T_KwModule
+
 import Lexer T_Ident
+
 import Lexer T_Eq
+
 import Lexer T_Comma
+
 import Lexer T_Dot
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseProgram
+
 import Parser DefKind
+
 import Parser K_Poly
+
 import Parser K_Combinator
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
 
 export main
 
-poly eqDefKind = \a : DefKind => \b : DefKind =>
-  match a [Bool] {
-    | K_Poly =>
-      match b [Bool] {
-        | K_Poly => true
-        | K_Combinator => false
+poly eqDefKind =
+  \a : DefKind =>
+    \b : DefKind =>
+      match a [Bool] {
+        | K_Poly =>
+          match b [Bool] {
+            | K_Poly => true
+            | K_Combinator => false
+          }
+        | K_Combinator =>
+          match b [Bool] {
+            | K_Poly => false
+            | K_Combinator => true
+          }
       }
-    | K_Combinator =>
-      match b [Bool] {
-        | K_Poly => false
-        | K_Combinator => true
-      }
-  }
 
 poly main =
-  let input =
-    {Token |
-      T_KwModule (T_Ident "M")
-      T_KwPoly T_KwRec (T_Ident "p") T_Eq (T_Ident "p")
-      T_KwCombinator (T_Ident "c") T_Eq T_Comma T_Dot
-      T_EOF}
-  in
+  let input = {Token | T_KwModule (T_Ident "M") T_KwPoly T_KwRec (T_Ident "p") T_Eq (T_Ident "p") T_KwCombinator (T_Ident "c") T_Eq T_Comma T_Dot T_EOF} in
   match (parseProgram input) [Bool] {
     | Err e => false
     | Ok decls =>
-      matchList [Decl] [Bool] decls false
-        (\d0 : Decl => \rest0 : List Decl =>
-          match d0 [Bool] {
-            | D_Module modName =>
-              if [Bool] (eqListU8 modName "M")
-                (\u : U8 =>
-                  matchList [Decl] [Bool] rest0 false
-                    (\d1 : Decl => \rest1 : List Decl =>
-                      match d1 [Bool] {
-                        | D_Module name => false
-                        | D_Import m s => false
-                        | D_Export x => false
-                        | D_Opaque x => false
-                        | D_Native x => false
-                        | D_Type x => false
-                        | D_Data x ctors => false
-                        | D_Def kind isRec name body =>
-                          if [Bool] (eqDefKind kind K_Poly)
-                            (\u : U8 =>
-                              if [Bool] isRec
-                                (\u : U8 =>
-                                  if [Bool] (eqListU8 name "p")
-                                    (\u : U8 =>
-                                      matchList [Decl] [Bool] rest1 false
-                                        (\d2 : Decl => \rest2 : List Decl =>
-                                          match d2 [Bool] {
-                                            | D_Module name => false
-                                            | D_Import m s => false
-                                            | D_Export x => false
-                                            | D_Opaque x => false
-                                            | D_Native x => false
-                                            | D_Type x => false
-                                            | D_Data x ctors => false
-                                            | D_Def kind2 isRec2 name2 body2 =>
-                                              if [Bool] (eqDefKind kind2 K_Combinator)
-                                                (\u : U8 =>
-                                                  if [Bool] isRec2
-                                                    (\u : U8 => false)
-                                                    (\u : U8 =>
-                                                      if [Bool] (eqListU8 name2 "c")
-                                                        (\u : U8 =>
-                                                          matchList [Decl] [Bool] rest2 true
-                                                            (\d3 : Decl => \rest3 : List Decl => false))
-                                                        (\u : U8 => false)))
-                                                (\u : U8 => false)
-                                          })
-                                    )
-                                    (\u : U8 => false))
-                                (\u : U8 => false))
-                            (\u : U8 => false)
-                      })
-                )
-                (\u : U8 => false)
-            | D_Import m s => false
-            | D_Export x => false
-            | D_Opaque x => false
-            | D_Native x => false
-            | D_Type x => false
-            | D_Data x ctors => false
-            | D_Def kind isRec name body => false
-          })
+      matchList
+        [Decl]
+        [Bool]
+        decls
+        false
+        (
+          \d0 : Decl =>
+            \rest0 : List Decl =>
+              match d0 [Bool] {
+                | D_Module modName =>
+                  if [Bool] (eqListU8 modName "M")
+                    (
+                      \u : U8 =>
+                        matchList
+                          [Decl]
+                          [Bool]
+                          rest0
+                          false
+                          (
+                            \d1 : Decl =>
+                              \rest1 : List Decl =>
+                                match d1 [Bool] {
+                                  | D_Module name => false
+                                  | D_Import m s => false
+                                  | D_Export x => false
+                                  | D_Opaque x => false
+                                  | D_Native x => false
+                                  | D_Type x => false
+                                  | D_Data x ctors => false
+                                  | D_Def kind isRec name body =>
+                                    if [Bool] (eqDefKind kind K_Poly)
+                                      (
+                                        \u : U8 =>
+                                          if [Bool] isRec
+                                            (
+                                              \u : U8 =>
+                                                if [Bool] (eqListU8 name "p")
+                                                  (
+                                                    \u : U8 =>
+                                                      matchList
+                                                        [Decl]
+                                                        [Bool]
+                                                        rest1
+                                                        false
+                                                        (
+                                                          \d2 : Decl =>
+                                                            \rest2 : List Decl =>
+                                                              match d2 [Bool] {
+                                                                | D_Module name => false
+                                                                | D_Import m s => false
+                                                                | D_Export x => false
+                                                                | D_Opaque x => false
+                                                                | D_Native x => false
+                                                                | D_Type x => false
+                                                                | D_Data x ctors => false
+                                                                | D_Def kind2 isRec2 name2 body2 =>
+                                                                  if [Bool] (eqDefKind kind2 K_Combinator)
+                                                                    (
+                                                                      \u : U8 =>
+                                                                        if [Bool] isRec2
+                                                                          (
+                                                                            \u : U8 => false
+                                                                          )
+                                                                          (
+                                                                            \u : U8 =>
+                                                                              if [Bool] (eqListU8 name2 "c")
+                                                                                (
+                                                                                  \u : U8 =>
+                                                                                    matchList
+                                                                                      [Decl]
+                                                                                      [Bool]
+                                                                                      rest2
+                                                                                      true
+                                                                                      (
+                                                                                        \d3 : Decl => \rest3 : List Decl => false
+                                                                                      )
+                                                                                )
+                                                                                (
+                                                                                  \u : U8 => false
+                                                                                )
+                                                                          )
+                                                                    )
+                                                                    (
+                                                                      \u : U8 => false
+                                                                    )
+                                                              }
+                                                        )
+                                                  )
+                                                  (\u : U8 => false)
+                                            )
+                                            (\u : U8 => false)
+                                      )
+                                      (\u : U8 => false)
+                                }
+                          )
+                    )
+                    (\u : U8 => false)
+                | D_Import m s => false
+                | D_Export x => false
+                | D_Opaque x => false
+                | D_Native x => false
+                | D_Type x => false
+                | D_Data x ctors => false
+                | D_Def kind isRec name body => false
+              }
+        )
   }

--- a/test/compiler/inputs/testParseExprCombinatorTokens.trip
+++ b/test/compiler/inputs/testParseExprCombinatorTokens.trip
@@ -1,48 +1,73 @@
 module Test
 
 import Prelude Bool
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Comma
+
 import Lexer T_Dot
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
-poly isVarNamed = \expr : Expr => \name : List Bin =>
-  match expr [Bool] {
-    | E_Var n => eqListU8 n name
-    | E_App f x => false
-    | E_Lam n body => false
-    | E_Let n v b => false
-    | E_Nat n => false
-    | E_Match scrutinee arms => false
-  }
+poly isVarNamed =
+  \expr : Expr =>
+    \name : List Bin =>
+      match expr [Bool] {
+        | E_Var n => eqListU8 n name
+        | E_App f x => false
+        | E_Lam n body => false
+        | E_Let n v b => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
 
 poly main =
-  let input =
-    {Token | T_Comma T_Dot T_EOF}
-  in
+  let input = {Token | T_Comma T_Dot T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>

--- a/test/compiler/inputs/testParseExprLambdaTyped.trip
+++ b/test/compiler/inputs/testParseExprLambdaTyped.trip
@@ -1,42 +1,69 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude U8
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Backslash
+
 import Lexer T_Ident
+
 import Lexer T_Colon
+
 import Lexer T_FatArrow
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
 poly main =
-  let input =
-    {Token | T_Backslash (T_Ident "x") T_Colon (T_Ident "Bin") T_FatArrow (T_Ident "x") T_EOF}
-  in
+  let input = {Token | T_Backslash (T_Ident "x") T_Colon (T_Ident "Bin") T_FatArrow (T_Ident "x") T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>
@@ -46,15 +73,17 @@ poly main =
         | E_App f x => false
         | E_Lam name body =>
           if [Bool] (eqListU8 name "x")
-            (\u : Bin =>
-              match body [Bool] {
-                | E_Var n => eqListU8 n "x"
-                | E_App f x => false
-                | E_Lam name body => false
-                | E_Let name val body => false
-                | E_Nat n => false
-                | E_Match scrutinee arms => false
-              })
+            (
+              \u : Bin =>
+                match body [Bool] {
+                  | E_Var n => eqListU8 n "x"
+                  | E_App f x => false
+                  | E_Lam name body => false
+                  | E_Let name val body => false
+                  | E_Nat n => false
+                  | E_Match scrutinee arms => false
+                }
+            )
             (\u : Bin => false)
         | E_Let name val body => false
         | E_Nat n => false

--- a/test/compiler/inputs/testParseExprLetTyped.trip
+++ b/test/compiler/inputs/testParseExprLetTyped.trip
@@ -1,54 +1,85 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude U8
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_KwLet
+
 import Lexer T_KwIn
+
 import Lexer T_Ident
+
 import Lexer T_Colon
+
 import Lexer T_Eq
+
 import Lexer T_Nat
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
-poly isVarNamed = \expr : Expr => \name : List U8 =>
-  match expr [Bool] {
-    | E_Var n => eqListU8 n name
-    | E_App f x => false
-    | E_Lam name body => false
-    | E_Let name val body => false
-    | E_Nat n => false
-    | E_Match scrutinee arms => false
-  }
+poly isVarNamed =
+  \expr : Expr =>
+    \name : List U8 =>
+      match expr [Bool] {
+        | E_Var n => eqListU8 n name
+        | E_App f x => false
+        | E_Lam name body => false
+        | E_Let name val body => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
 
 poly main =
-  let input =
-    {Token | T_KwLet (T_Ident "x") T_Colon (T_Ident "Bin") T_Eq (T_Nat "1") T_KwIn (T_Ident "x") T_EOF}
-  in
+  let input = {Token | T_KwLet (T_Ident "x") T_Colon (T_Ident "Bin") T_Eq (T_Nat "1") T_KwIn (T_Ident "x") T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>
@@ -59,15 +90,17 @@ poly main =
         | E_Lam name body => false
         | E_Let name val body =>
           if [Bool] (eqListU8 name "x")
-            (\u : Bin =>
-              match val [Bool] {
-                | E_Var n => false
-                | E_App f x => false
-                | E_Lam name body => false
-                | E_Let name val body => false
-                | E_Nat n => isVarNamed body "x"
-                | E_Match scrutinee arms => false
-              })
+            (
+              \u : Bin =>
+                match val [Bool] {
+                  | E_Var n => false
+                  | E_App f x => false
+                  | E_Lam name body => false
+                  | E_Let name val body => false
+                  | E_Nat n => isVarNamed body "x"
+                  | E_Match scrutinee arms => false
+                }
+            )
             (\u : Bin => false)
         | E_Nat n => false
         | E_Match scrutinee arms => false

--- a/test/compiler/inputs/testParseExprMatchTyped.trip
+++ b/test/compiler/inputs/testParseExprMatchTyped.trip
@@ -1,76 +1,128 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude U8
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_KwMatch
+
 import Lexer T_Ident
+
 import Lexer T_LBracket
+
 import Lexer T_RBracket
+
 import Lexer T_LBrace
+
 import Lexer T_RBrace
+
 import Lexer T_Pipe
+
 import Lexer T_FatArrow
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Pattern
+
 import Parser P_Ctor
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
-poly isVarNamed = \expr : Expr => \name : List U8 =>
-  match expr [Bool] {
-    | E_Var n => eqListU8 n name
-    | E_App f x => false
-    | E_Lam name body => false
-    | E_Let name val body => false
-    | E_Nat n => false
-    | E_Match scrutinee arms => false
-  }
+poly isVarNamed =
+  \expr : Expr =>
+    \name : List U8 =>
+      match expr [Bool] {
+        | E_Var n => eqListU8 n name
+        | E_App f x => false
+        | E_Lam name body => false
+        | E_Let name val body => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
 
-poly isSingleArg = \args : List (List Bin) => \name : List Bin =>
-  matchList [List Bin] [Bool] args false
-    (\h : List Bin => \t : List (List Bin) =>
-      if [Bool] (eqListU8 h name)
-        (\u : Bin =>
-          matchList [List Bin] [Bool] t true
-            (\x : List Bin => \xs : List (List Bin) => false))
-        (\u : Bin => false))
+poly isSingleArg =
+  \args : List (List Bin) =>
+    \name : List Bin =>
+      matchList
+        [List Bin]
+        [Bool]
+        args
+        false
+        (
+          \h : List Bin =>
+            \t : List (List Bin) =>
+              if [Bool] (eqListU8 h name)
+                (
+                  \u : Bin =>
+                    matchList
+                      [List Bin]
+                      [Bool]
+                      t
+                      true
+                      (\x : List Bin => \xs : List (List Bin) => false)
+                )
+                (\u : Bin => false)
+        )
 
-poly isNoArgs = \args : List (List Bin) =>
-  matchList [List Bin] [Bool] args true
-    (\h : List Bin => \t : List (List Bin) => false)
+poly isNoArgs =
+  \args : List (List Bin) =>
+    matchList
+      [List Bin]
+      [Bool]
+      args
+      true
+      (\h : List Bin => \t : List (List Bin) => false)
 
 poly main =
-  let input =
-    {Token |
-      T_KwMatch (T_Ident "res") T_LBracket (T_Ident "List") (T_Ident "Token") T_RBracket T_LBrace
-      T_Pipe (T_Ident "Some") (T_Ident "x") T_FatArrow (T_Ident "x")
-      T_Pipe (T_Ident "None") T_FatArrow (T_Ident "res")
-      T_RBrace T_EOF}
-  in
+  let input = {Token | T_KwMatch (T_Ident "res") T_LBracket (T_Ident "List") (T_Ident "Token") T_RBracket T_LBrace T_Pipe (T_Ident "Some") (T_Ident "x") T_FatArrow (T_Ident "x") T_Pipe (T_Ident "None") T_FatArrow (T_Ident "res") T_RBrace T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>
@@ -83,46 +135,51 @@ poly main =
         | E_Nat n => false
         | E_Match scrutinee arms =>
           if [Bool] (isVarNamed scrutinee "res")
-            (\u : Bin =>
-              matchList [Pair Pattern Expr] [Bool] arms false
-                (\arm1 : Pair Pattern Expr => \rest1 : List (Pair Pattern Expr) =>
-                  let pat1 = fst [Pattern] [Expr] arm1 in
-                  let body1 = snd [Pattern] [Expr] arm1 in
-                  let arm1Ok =
-                    match pat1 [Bool] {
-                      | P_Ctor ctor args =>
-                        if [Bool] (eqListU8 ctor "Some")
-                          (\u : Bin =>
-                            if [Bool] (isSingleArg args "x")
-                              (\u : Bin => isVarNamed body1 "x")
-                              (\u : Bin => false))
+            (
+              \u : Bin =>
+                matchList
+                  [Pair Pattern Expr]
+                  [Bool]
+                  arms
+                  false
+                  (
+                    \arm1 : Pair Pattern Expr =>
+                      \rest1 : List (Pair Pattern Expr) =>
+                        let pat1 = fst [Pattern] [Expr] arm1 in
+                        let body1 = snd [Pattern] [Expr] arm1 in
+                        let arm1Ok = match pat1 [Bool] {| P_Ctor ctor args => if [Bool] (eqListU8 ctor "Some") (\u : Bin => if [Bool] (isSingleArg args "x") (\u : Bin => isVarNamed body1 "x") (\u : Bin => false)) (\u : Bin => false)} in
+                        if [Bool] arm1Ok
+                          (
+                            \u : Bin =>
+                              matchList
+                                [Pair Pattern Expr]
+                                [Bool]
+                                rest1
+                                false
+                                (
+                                  \arm2 : Pair Pattern Expr =>
+                                    \rest2 : List (Pair Pattern Expr) =>
+                                      let pat2 = fst [Pattern] [Expr] arm2 in
+                                      let body2 = snd [Pattern] [Expr] arm2 in
+                                      let arm2Ok = match pat2 [Bool] {| P_Ctor ctor args => if [Bool] (eqListU8 ctor "None") (\u : Bin => if [Bool] (isNoArgs args) (\u : Bin => isVarNamed body2 "res") (\u : Bin => false)) (\u : Bin => false)} in
+                                      if [Bool] arm2Ok
+                                        (
+                                          \u : Bin =>
+                                            matchList
+                                              [Pair Pattern Expr]
+                                              [Bool]
+                                              rest2
+                                              true
+                                              (
+                                                \extra : Pair Pattern Expr => \extraRest : List (Pair Pattern Expr) => false
+                                              )
+                                        )
+                                        (\u : Bin => false)
+                                )
+                          )
                           (\u : Bin => false)
-                    }
-                  in
-                  if [Bool] arm1Ok
-                    (\u : Bin =>
-                      matchList [Pair Pattern Expr] [Bool] rest1 false
-                        (\arm2 : Pair Pattern Expr => \rest2 : List (Pair Pattern Expr) =>
-                          let pat2 = fst [Pattern] [Expr] arm2 in
-                          let body2 = snd [Pattern] [Expr] arm2 in
-                          let arm2Ok =
-                            match pat2 [Bool] {
-                              | P_Ctor ctor args =>
-                                if [Bool] (eqListU8 ctor "None")
-                                  (\u : Bin =>
-                                    if [Bool] (isNoArgs args)
-                                      (\u : Bin => isVarNamed body2 "res")
-                                      (\u : Bin => false))
-                                  (\u : Bin => false)
-                            }
-                          in
-                          if [Bool] arm2Ok
-                            (\u : Bin =>
-                              matchList [Pair Pattern Expr] [Bool] rest2 true
-                                (\extra : Pair Pattern Expr => \extraRest : List (Pair Pattern Expr) => false))
-                            (\u : Bin => false))
-                    )
-                    (\u : Bin => false)))
+                  )
+            )
             (\u : Bin => false)
       }
   }

--- a/test/compiler/inputs/testParseExprTypeAbstraction.trip
+++ b/test/compiler/inputs/testParseExprTypeAbstraction.trip
@@ -1,38 +1,61 @@
 module Test
 
 import Prelude Bool
+
 import Prelude false
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude U8
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Hash
+
 import Lexer T_Ident
+
 import Lexer T_FatArrow
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
 poly main =
-  let input =
-    {Token | T_Hash (T_Ident "X") T_FatArrow (T_Ident "x") T_EOF}
-  in
+  let input = {Token | T_Hash (T_Ident "X") T_FatArrow (T_Ident "x") T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>

--- a/test/compiler/inputs/testParseExprTypeApplication.trip
+++ b/test/compiler/inputs/testParseExprTypeApplication.trip
@@ -1,49 +1,75 @@
 module Test
 
 import Prelude Bool
+
 import Prelude false
+
 import Prelude if
+
 import Prelude Bin
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Prelude snd
+
 import Lexer Token
+
 import Lexer T_Ident
+
 import Lexer T_LBracket
+
 import Lexer T_RBracket
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseExpr
+
 import Parser Expr
+
 import Parser E_Var
+
 import Parser E_App
+
 import Parser E_Lam
+
 import Parser E_Let
+
 import Parser E_Nat
+
 import Parser E_Match
 
 export main
 
-poly isVarNamed = \expr : Expr => \name : List Bin =>
-  match expr [Bool] {
-    | E_Var n => eqListU8 n name
-    | E_App f x => false
-    | E_Lam n body => false
-    | E_Let n v b => false
-    | E_Nat n => false
-    | E_Match scrutinee arms => false
-  }
+poly isVarNamed =
+  \expr : Expr =>
+    \name : List Bin =>
+      match expr [Bool] {
+        | E_Var n => eqListU8 n name
+        | E_App f x => false
+        | E_Lam n body => false
+        | E_Let n v b => false
+        | E_Nat n => false
+        | E_Match scrutinee arms => false
+      }
 
 poly main =
-  let input =
-    {Token | (T_Ident "n") T_LBracket (T_Ident "X") T_RBracket (T_Ident "s") (T_Ident "z") T_EOF}
-  in
+  let input = {Token | (T_Ident "n") T_LBracket (T_Ident "X") T_RBracket (T_Ident "s") (T_Ident "z") T_EOF} in
   match (parseExpr input) [Bool] {
     | Err e => false
     | Ok res =>
@@ -52,18 +78,20 @@ poly main =
         | E_Var n => false
         | E_App lhs rhs =>
           if [Bool] (isVarNamed rhs "z")
-            (\u : Bin =>
-              match lhs [Bool] {
-                | E_Var n => false
-                | E_App f x =>
-                  if [Bool] (isVarNamed f "n")
-                    (\u : Bin => isVarNamed x "s")
-                    (\u : Bin => false)
-                | E_Lam n body => false
-                | E_Let n v b => false
-                | E_Nat n => false
-                | E_Match scrutinee arms => false
-              })
+            (
+              \u : Bin =>
+                match lhs [Bool] {
+                  | E_Var n => false
+                  | E_App f x =>
+                    if [Bool] (isVarNamed f "n")
+                      (\u : Bin => isVarNamed x "s")
+                      (\u : Bin => false)
+                  | E_Lam n body => false
+                  | E_Let n v b => false
+                  | E_Nat n => false
+                  | E_Match scrutinee arms => false
+                }
+            )
             (\u : Bin => false)
         | E_Lam n body => false
         | E_Let n v b => false

--- a/test/compiler/inputs/testParseProgramForms.trip
+++ b/test/compiler/inputs/testParseProgramForms.trip
@@ -1,69 +1,101 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Lexer Token
+
 import Lexer T_KwRec
+
 import Lexer T_KwPoly
+
 import Lexer T_KwCombinator
+
 import Lexer T_KwData
+
 import Lexer T_KwType
+
 import Lexer T_KwExport
+
 import Lexer T_KwImport
+
 import Lexer T_KwModule
+
 import Lexer T_Ident
+
 import Lexer T_Eq
+
 import Lexer T_Hash
+
 import Lexer T_Arrow
+
 import Lexer T_Comma
+
 import Lexer T_Dot
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseProgram
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
 
 export main
 
 poly main =
-  let input =
-    {Token |
-      T_KwModule (T_Ident "M")
-      T_KwImport (T_Ident "Prelude") (T_Ident "id")
-      T_KwExport (T_Ident "main")
-      T_KwType (T_Ident "Nat") T_Eq T_Hash (T_Ident "X") T_Arrow (T_Ident "X")
-      T_KwData (T_Ident "Maybe") (T_Ident "A") T_Eq (T_Ident "None") (T_Ident "Some") (T_Ident "A")
-      T_KwCombinator (T_Ident "io") T_Eq T_Comma T_Dot
-      T_KwPoly T_KwRec (T_Ident "main") T_Eq (T_Ident "id")
-      T_EOF}
-  in
+  let input = {Token | T_KwModule (T_Ident "M") T_KwImport (T_Ident "Prelude") (T_Ident "id") T_KwExport (T_Ident "main") T_KwType (T_Ident "Nat") T_Eq T_Hash (T_Ident "X") T_Arrow (T_Ident "X") T_KwData (T_Ident "Maybe") (T_Ident "A") T_Eq (T_Ident "None") (T_Ident "Some") (T_Ident "A") T_KwCombinator (T_Ident "io") T_Eq T_Comma T_Dot T_KwPoly T_KwRec (T_Ident "main") T_Eq (T_Ident "id") T_EOF} in
   match (parseProgram input) [Bool] {
     | Err e => false
     | Ok decls =>
-      matchList [Decl] [Bool] decls false
-        (\h : Decl => \t : List Decl =>
-          match h [Bool] {
-            | D_Module name => eqListU8 name "M"
-            | D_Import m s => false
-            | D_Export x => false
-            | D_Opaque x => false
-            | D_Native x => false
-            | D_Type x => false
-            | D_Data x ctors => false
-            | D_Def kind isRec x body => false
-          })
+      matchList
+        [Decl]
+        [Bool]
+        decls
+        false
+        (
+          \h : Decl =>
+            \t : List Decl =>
+              match h [Bool] {
+                | D_Module name => eqListU8 name "M"
+                | D_Import m s => false
+                | D_Export x => false
+                | D_Opaque x => false
+                | D_Native x => false
+                | D_Type x => false
+                | D_Data x ctors => false
+                | D_Def kind isRec x body => false
+              }
+        )
   }

--- a/test/compiler/inputs/testParseProgramSourceRec.trip
+++ b/test/compiler/inputs/testParseProgramSourceRec.trip
@@ -1,58 +1,91 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude if
+
 import Prelude List
+
 import Prelude matchList
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude U8
+
 import Lexer tokenize
+
 import Prelude eqListU8
+
 import Parser parseProgram
+
 import Parser DefKind
+
 import Parser K_Poly
+
 import Parser K_Combinator
+
 import Parser Decl
+
 import Parser D_Module
+
 import Parser D_Import
+
 import Parser D_Export
+
 import Parser D_Opaque
+
 import Parser D_Native
+
 import Parser D_Type
+
 import Parser D_Data
+
 import Parser D_Def
 
 export main
 
-poly source : List U8 = "poly rec p = p"
+poly source : List U8 =
+  "poly rec p = p"
 
-poly eqDefKind = \a : DefKind => \b : DefKind =>
-  match a [Bool] {
-    | K_Poly =>
-      match b [Bool] {
-        | K_Poly => true
-        | K_Combinator => false
+poly eqDefKind =
+  \a : DefKind =>
+    \b : DefKind =>
+      match a [Bool] {
+        | K_Poly =>
+          match b [Bool] {
+            | K_Poly => true
+            | K_Combinator => false
+          }
+        | K_Combinator =>
+          match b [Bool] {
+            | K_Poly => false
+            | K_Combinator => true
+          }
       }
-    | K_Combinator =>
-      match b [Bool] {
-        | K_Poly => false
-        | K_Combinator => true
-      }
-  }
 
 poly main =
   match (tokenize source) [Bool] {
     | Err e => false
     | Ok toks =>
-        match (parseProgram toks) [Bool] {
-          | Err e => false
-          | Ok decls =>
-              matchList [Decl] [Bool] decls false
-                (\h : Decl => \t : List Decl =>
+      match (parseProgram toks) [Bool] {
+        | Err e => false
+        | Ok decls =>
+          matchList
+            [Decl]
+            [Bool]
+            decls
+            false
+            (
+              \h : Decl =>
+                \t : List Decl =>
                   match h [Bool] {
                     | D_Module name => false
                     | D_Import m s => false
@@ -62,17 +95,30 @@ poly main =
                     | D_Type x => false
                     | D_Data x ctors => false
                     | D_Def kind isRec name body =>
-                        if [Bool] (eqDefKind kind K_Poly)
-                          (\u : U8 =>
+                      if [Bool] (eqDefKind kind K_Poly)
+                        (
+                          \u : U8 =>
                             if [Bool] isRec
-                              (\u : U8 =>
-                                if [Bool] (eqListU8 name "p")
-                                  (\u : U8 =>
-                                    matchList [Decl] [Bool] t true
-                                      (\restH : Decl => \restT : List Decl => false))
-                                  (\u : U8 => false))
-                              (\u : U8 => false))
-                          (\u : U8 => false)
-                  })
-        }
+                              (
+                                \u : U8 =>
+                                  if [Bool] (eqListU8 name "p")
+                                    (
+                                      \u : U8 =>
+                                        matchList
+                                          [Decl]
+                                          [Bool]
+                                          t
+                                          true
+                                          (
+                                            \restH : Decl => \restT : List Decl => false
+                                          )
+                                    )
+                                    (\u : U8 => false)
+                              )
+                              (\u : U8 => false)
+                        )
+                        (\u : U8 => false)
+                  }
+            )
+      }
   }

--- a/test/compiler/inputs/testParseType.trip
+++ b/test/compiler/inputs/testParseType.trip
@@ -1,45 +1,69 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude List
+
 import Prelude cons
+
 import Prelude nil
+
 import Prelude Result
+
 import Prelude Ok
+
 import Prelude Err
+
 import Prelude Pair
+
 import Prelude fst
+
 import Lexer Token
+
 import Lexer T_Ident
+
 import Lexer T_Arrow
+
 import Lexer T_LParen
+
 import Lexer T_RParen
+
 import Lexer T_Hash
+
 import Lexer T_EOF
+
 import Prelude eqListU8
+
 import Parser parseType
+
 import Parser Type
+
 import Parser Ty_Var
+
 import Parser Ty_App
+
 import Parser Ty_Arrow
+
 import Parser Ty_Forall
 
 export main
 
-poly isVarNamed = \ty : Type => \name : List U8 =>
-  match ty [Bool] {
-    | Ty_Var n => eqListU8 n name
-    | Ty_App f x => false
-    | Ty_Arrow l r => false
-    | Ty_Forall n b => false
-  }
+poly isVarNamed =
+  \ty : Type =>
+    \name : List U8 =>
+      match ty [Bool] {
+        | Ty_Var n => eqListU8 n name
+        | Ty_App f x => false
+        | Ty_Arrow l r => false
+        | Ty_Forall n b => false
+      }
 
 poly main =
-  let input =
-    {Token | T_Hash (T_Ident "A") T_Arrow (T_Ident "A") T_Arrow T_LParen (T_Ident "B") (T_Ident "C") T_RParen T_EOF}
-  in
+  let input = {Token | T_Hash (T_Ident "A") T_Arrow (T_Ident "A") T_Arrow T_LParen (T_Ident "B") (T_Ident "C") T_RParen T_EOF} in
   match (parseType input) [Bool] {
     | Err e => false
     | Ok res =>
@@ -50,26 +74,29 @@ poly main =
         | Ty_Arrow l r => false
         | Ty_Forall n b =>
           if [Bool] (eqListU8 n "A")
-            (\u : U8 =>
-              match b [Bool] {
-                | Ty_Var n => false
-                | Ty_App f x => false
-                | Ty_Arrow l r =>
-                  if [Bool] (isVarNamed l "A")
-                    (\u : U8 =>
-                      match r [Bool] {
-                        | Ty_Var n => false
-                        | Ty_App f x =>
-                            if [Bool] (isVarNamed f "B")
-                              (\u : U8 => isVarNamed x "C")
-                              (\u : U8 => false)
-                        | Ty_Arrow l r => false
-                        | Ty_Forall n b => false
-                      }
-                    )
-                    (\u : U8 => false)
-                | Ty_Forall n b => false
-              })
+            (
+              \u : U8 =>
+                match b [Bool] {
+                  | Ty_Var n => false
+                  | Ty_App f x => false
+                  | Ty_Arrow l r =>
+                    if [Bool] (isVarNamed l "A")
+                      (
+                        \u : U8 =>
+                          match r [Bool] {
+                            | Ty_Var n => false
+                            | Ty_App f x =>
+                              if [Bool] (isVarNamed f "B")
+                                (\u : U8 => isVarNamed x "C")
+                                (\u : U8 => false)
+                            | Ty_Arrow l r => false
+                            | Ty_Forall n b => false
+                          }
+                      )
+                      (\u : U8 => false)
+                  | Ty_Forall n b => false
+                }
+            )
             (\u : U8 => false)
       }
   }

--- a/test/compiler/inputs/testTokenize1Space2.trip
+++ b/test/compiler/inputs/testTokenize1Space2.trip
@@ -1,57 +1,111 @@
 module Test
 
 import Lexer tokenize
+
 import Lexer Token
+
 import Lexer tokenTag
+
 import Lexer tokenNatValue
+
 import Prelude eqListU8
+
 import Prelude Result
+
 import Prelude Err
+
 import Prelude Ok
+
 import Prelude List
+
 import Prelude matchList
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude and
+
 import Prelude eqU8
+
 import Prelude U8
 
 export main
 
-poly list1Space2 : List U8 = "1 2"
+poly list1Space2 : List U8 =
+  "1 2"
 
-poly natTag : U8 = (#u8(30))
-poly eofTag : U8 = (#u8(31))
+poly natTag : U8 =
+  (#u8(30))
 
-poly firstIsNat1 = \tok : Token =>
-  and (eqU8 (tokenTag tok) natTag) (eqListU8 (tokenNatValue tok) "1")
+poly eofTag : U8 =
+  (#u8(31))
 
-poly secondIsNat2 = \tok : Token =>
-  and (eqU8 (tokenTag tok) natTag) (eqListU8 (tokenNatValue tok) "2")
+poly firstIsNat1 =
+  \tok : Token =>
+    and (eqU8 (tokenTag tok) natTag) (eqListU8 (tokenNatValue tok) "1")
 
-poly thirdIsEof = \tok : Token =>
-  eqU8 (tokenTag tok) eofTag
+poly secondIsNat2 =
+  \tok : Token =>
+    and (eqU8 (tokenTag tok) natTag) (eqListU8 (tokenNatValue tok) "2")
+
+poly thirdIsEof =
+  \tok : Token => eqU8 (tokenTag tok) eofTag
 
 poly main =
   match (tokenize list1Space2) [Bool] {
     | Err _ => false
     | Ok tokens =>
-      matchList [Token] [Bool] tokens false
-        (\h1 : Token => \rest : List Token =>
-          if [Bool] (firstIsNat1 h1)
-            (\u : U8 =>
-              matchList [Token] [Bool] rest false
-                (\h2 : Token => \rest2 : List Token =>
-                  if [Bool] (secondIsNat2 h2)
-                    (\u : U8 =>
-                      matchList [Token] [Bool] rest2 false
-                        (\h3 : Token => \rest3 : List Token =>
-                          if [Bool] (thirdIsEof h3)
-                            (\u : U8 =>
-                              matchList [Token] [Bool] rest3 true
-                                (\_ : Token => \_ : List Token => false))
-                            (\u : U8 => false)))
-                    (\u : U8 => false)))
-            (\u : U8 => false))
+      matchList
+        [Token]
+        [Bool]
+        tokens
+        false
+        (
+          \h1 : Token =>
+            \rest : List Token =>
+              if [Bool] (firstIsNat1 h1)
+                (
+                  \u : U8 =>
+                    matchList
+                      [Token]
+                      [Bool]
+                      rest
+                      false
+                      (
+                        \h2 : Token =>
+                          \rest2 : List Token =>
+                            if [Bool] (secondIsNat2 h2)
+                              (
+                                \u : U8 =>
+                                  matchList
+                                    [Token]
+                                    [Bool]
+                                    rest2
+                                    false
+                                    (
+                                      \h3 : Token =>
+                                        \rest3 : List Token =>
+                                          if [Bool] (thirdIsEof h3)
+                                            (
+                                              \u : U8 =>
+                                                matchList
+                                                  [Token]
+                                                  [Bool]
+                                                  rest3
+                                                  true
+                                                  (
+                                                    \_ : Token => \_ : List Token => false
+                                                  )
+                                            )
+                                            (\u : U8 => false)
+                                    )
+                              )
+                              (\u : U8 => false)
+                      )
+                )
+                (\u : U8 => false)
+        )
   }

--- a/test/compiler/inputs/unparseStage1/harness.trip
+++ b/test/compiler/inputs/unparseStage1/harness.trip
@@ -1,23 +1,47 @@
 module Test
+
 import Prelude List
+
 import Prelude U8
+
 import Prelude matchList
+
 import Prelude writeOne
+
 import Unparse Terminal
+
 import Unparse T_S
+
 import Unparse T_K
+
 import Unparse T_I
+
 import Unparse T_WriteOne
+
 import Unparse T_Byte
+
 import Unparse Comb
+
 import Unparse C_Term
+
 import Unparse C_App
+
 import Unparse unparseCombinator
 
-poly rec writeList = #R => \l : List => \k : R =>
-  matchList [U8] [R] l
-    k
-    (\h : U8 => \t : List => writeOne h [R] (\u : U8 => writeList [R] t k))
+poly rec writeList =
+  #R =>
+    \l : List =>
+      \k : R =>
+        matchList
+          [U8]
+          [R]
+          l
+          k
+          (
+            \h : U8 => \t : List => writeOne h [R] (\u : U8 => writeList [R] t k)
+          )
 
 export main
-poly main = writeList [U8] (__TRIP_EXPR__) #u8(0)
+
+poly main =
+  writeList [U8] __TRIP_EXPR__ #u8(0)

--- a/test/compiler/llvm/helloWorld.trip
+++ b/test/compiler/llvm/helloWorld.trip
@@ -1,22 +1,10 @@
 module Main
+
 import Prelude U8
+
 import Prelude writeOne
 
 export main
 
 poly main =
-  writeOne #u8(72) [U8] (\x0 : U8 =>
-    writeOne #u8(101) [U8] (\x1 : U8 =>
-      writeOne #u8(108) [U8] (\x2 : U8 =>
-        writeOne #u8(108) [U8] (\x3 : U8 =>
-          writeOne #u8(111) [U8] (\x4 : U8 =>
-            writeOne #u8(44) [U8] (\x5 : U8 =>
-              writeOne #u8(32) [U8] (\x6 : U8 =>
-                writeOne #u8(119) [U8] (\x7 : U8 =>
-                  writeOne #u8(111) [U8] (\x8 : U8 =>
-                    writeOne #u8(114) [U8] (\x9 : U8 =>
-                      writeOne #u8(108) [U8] (\x10 : U8 =>
-                        writeOne #u8(100) [U8] (\x11 : U8 =>
-                          writeOne #u8(33) [U8] (\x12 : U8 =>
-                            writeOne #u8(10) [U8] (\x13 : U8 =>
-                              x13))))))))))))))
+  writeOne #u8(72) [U8] (\x0 : U8 => writeOne #u8(101) [U8] (\x1 : U8 => writeOne #u8(108) [U8] (\x2 : U8 => writeOne #u8(108) [U8] (\x3 : U8 => writeOne #u8(111) [U8] (\x4 : U8 => writeOne #u8(44) [U8] (\x5 : U8 => writeOne #u8(32) [U8] (\x6 : U8 => writeOne #u8(119) [U8] (\x7 : U8 => writeOne #u8(111) [U8] (\x8 : U8 => writeOne #u8(114) [U8] (\x9 : U8 => writeOne #u8(108) [U8] (\x10 : U8 => writeOne #u8(100) [U8] (\x11 : U8 => writeOne #u8(33) [U8] (\x12 : U8 => writeOne #u8(10) [U8] (\x13 : U8 => x13))))))))))))))

--- a/test/evaluator/fixtures/arithmetic.trip
+++ b/test/evaluator/fixtures/arithmetic.trip
@@ -1,6 +1,10 @@
 module Main
+
 import Prelude U8
+
 import Prelude addU8
 
 export main
-poly main = addU8 #u8(39) #u8(3)
+
+poly main =
+  addU8 #u8(39) #u8(3)

--- a/test/evaluator/fixtures/b-law-composition.trip
+++ b/test/evaluator/fixtures/b-law-composition.trip
@@ -1,9 +1,16 @@
 module Main
+
 import Prelude U8
+
 import Prelude addU8
 
-poly outer = \x : U8 => addU8 #u8(3) x
-poly inner = \x : U8 => addU8 #u8(4) x
+poly outer =
+  \x : U8 => addU8 #u8(3) x
+
+poly inner =
+  \x : U8 => addU8 #u8(4) x
 
 export main
-poly main = outer (inner #u8(10))
+
+poly main =
+  outer (inner #u8(10))

--- a/test/evaluator/fixtures/b-law-order.trip
+++ b/test/evaluator/fixtures/b-law-order.trip
@@ -1,9 +1,16 @@
 module Main
+
 import Prelude U8
+
 import Prelude subU8
 
-poly outer = \x : U8 => subU8 #u8(10) x
-poly inner = \x : U8 => subU8 #u8(5) x
+poly outer =
+  \x : U8 => subU8 #u8(10) x
+
+poly inner =
+  \x : U8 => subU8 #u8(5) x
 
 export main
-poly main = outer (inner #u8(3))
+
+poly main =
+  outer (inner #u8(3))

--- a/test/evaluator/fixtures/c-law-flip-distinct.trip
+++ b/test/evaluator/fixtures/c-law-flip-distinct.trip
@@ -1,8 +1,13 @@
 module Main
+
 import Prelude U8
+
 import Prelude subU8
 
-poly flip_sub = \x : U8 => \y : U8 => subU8 y x
+poly flip_sub =
+  \x : U8 => \y : U8 => subU8 y x
 
 export main
-poly main = flip_sub #u8(10) #u8(20)
+
+poly main =
+  flip_sub #u8(10) #u8(20)

--- a/test/evaluator/fixtures/c-law-flip.trip
+++ b/test/evaluator/fixtures/c-law-flip.trip
@@ -1,8 +1,13 @@
 module Main
+
 import Prelude U8
+
 import Prelude subU8
 
-poly flip_sub = \x : U8 => \y : U8 => subU8 y x
+poly flip_sub =
+  \x : U8 => \y : U8 => subU8 y x
 
 export main
-poly main = flip_sub #u8(3) #u8(10)
+
+poly main =
+  flip_sub #u8(3) #u8(10)

--- a/test/evaluator/fixtures/identity-21.trip
+++ b/test/evaluator/fixtures/identity-21.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly id_u8 = \x : U8 => x
+poly id_u8 =
+  \x : U8 => x
 
 export main
-poly main = id_u8 #u8(21)
+
+poly main =
+  id_u8 #u8(21)

--- a/test/evaluator/fixtures/identity.trip
+++ b/test/evaluator/fixtures/identity.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly id_u8 = \x : U8 => x
+poly id_u8 =
+  \x : U8 => x
 
 export main
-poly main = id_u8 #u8(42)
+
+poly main =
+  id_u8 #u8(42)

--- a/test/evaluator/fixtures/k-combinator.trip
+++ b/test/evaluator/fixtures/k-combinator.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly k_u8 = \x : U8 => \y : U8 => x
+poly k_u8 =
+  \x : U8 => \y : U8 => x
 
 export main
-poly main = k_u8 #u8(42) #u8(99)
+
+poly main =
+  k_u8 #u8(42) #u8(99)

--- a/test/evaluator/fixtures/k-large-alt.trip
+++ b/test/evaluator/fixtures/k-large-alt.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly k_u8 = \x : U8 => \y : U8 => x
+poly k_u8 =
+  \x : U8 => \y : U8 => x
 
 export main
-poly main = k_u8 #u8(42) #u8(1)
+
+poly main =
+  k_u8 #u8(42) #u8(1)

--- a/test/evaluator/fixtures/k-small.trip
+++ b/test/evaluator/fixtures/k-small.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly k_u8 = \x : U8 => \y : U8 => x
+poly k_u8 =
+  \x : U8 => \y : U8 => x
 
 export main
-poly main = k_u8 #u8(1) #u8(0)
+
+poly main =
+  k_u8 #u8(1) #u8(0)

--- a/test/evaluator/fixtures/k-zero.trip
+++ b/test/evaluator/fixtures/k-zero.trip
@@ -1,7 +1,11 @@
 module Main
+
 import Prelude U8
 
-poly k_u8 = \x : U8 => \y : U8 => x
+poly k_u8 =
+  \x : U8 => \y : U8 => x
 
 export main
-poly main = k_u8 #u8(42) #u8(0)
+
+poly main =
+  k_u8 #u8(42) #u8(0)

--- a/test/evaluator/fixtures/write-a.trip
+++ b/test/evaluator/fixtures/write-a.trip
@@ -1,6 +1,10 @@
 module Main
+
 import Prelude writeOne
+
 import Prelude U8
 
 export main
-poly main = writeOne #u8(65) [U8] (\x : U8 => x)
+
+poly main =
+  writeOne #u8(65) [U8] (\x : U8 => x)

--- a/test/improvize/improvize.test.ts
+++ b/test/improvize/improvize.test.ts
@@ -1,0 +1,236 @@
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import { join } from "node:path";
+import {
+  discoverTripFiles,
+  formatTripSource,
+  lintTripSource,
+} from "../../lib/improvize/index.ts";
+import {
+  cleanupTempWorkspace,
+  createTempWorkspace,
+} from "../util/tripcHarness.ts";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { parseTripLang } from "../../lib/parser/tripLang.ts";
+import { workspaceRoot } from "../../lib/shared/workspaceRoot.ts";
+
+describe("improvize formatter", () => {
+  it("preserves comments while canonicalizing top-level layout", () => {
+    const input = `module M
+-- leading data
+data Maybe A = Nothing | Just A
+poly id = #A=>\\x:A=>x  -- identity
+`;
+
+    const result = formatTripSource(input);
+
+    assert.equal(
+      result.formatted,
+      `module M
+
+-- leading data
+data Maybe A =
+  | Nothing
+  | Just A
+
+poly id =
+  #A => \\x : A => x -- identity
+`,
+    );
+  });
+
+  it("is idempotent", () => {
+    const input = `module M
+data Result E T = Err E | Ok T
+poly main =
+  match x [Result E T] {
+    | Err e => e
+    | Ok t => t
+  }
+`;
+    const once = formatTripSource(input).formatted;
+    const twice = formatTripSource(once).formatted;
+    assert.equal(twice, once);
+  });
+
+  it("keeps parse-equivalent programs parseable", () => {
+    const input = `module M
+import Prelude U8
+export main
+poly main = #u8(1)
+`;
+    const formatted = formatTripSource(input).formatted;
+    assert.deepEqual(parseTripLang(formatted), parseTripLang(input));
+  });
+
+  it("is idempotent and parse-equivalent across the Trip corpus", async () => {
+    const files = await discoverTripFiles([workspaceRoot]);
+    const idempotenceFailures: string[] = [];
+    const parseFailures: string[] = [];
+    let parseChecked = 0;
+
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+      const once = formatTripSource(source).formatted;
+      const twice = formatTripSource(once).formatted;
+      if (twice !== once) {
+        idempotenceFailures.push(file);
+      }
+
+      let before: unknown;
+      try {
+        before = parseTripLang(source);
+      } catch {
+        continue;
+      }
+      parseChecked++;
+
+      try {
+        assert.deepEqual(parseTripLang(once), before);
+      } catch {
+        parseFailures.push(file);
+      }
+    }
+
+    assert.equal(idempotenceFailures.length, 0, idempotenceFailures.join("\n"));
+    assert.equal(parseFailures.length, 0, parseFailures.join("\n"));
+    assert.ok(files.length > 0);
+    assert.ok(parseChecked > 0);
+  });
+});
+
+describe("improvize linter", () => {
+  it("reports and fixes canonical byte literal spelling", () => {
+    const source = `module M
+poly main = 72
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.deepEqual(
+      result.diagnostics.map((diag) => diag.code),
+      ["trip-u8-literal"],
+    );
+    assert.match(result.fixed, /#u8\(72\)/);
+  });
+
+  it("reports semantic hints and applies conservative fixes", () => {
+    const source = `module M
+import Prelude and
+import Prelude true
+poly f = \\x : A => g x
+poly main = and true value
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-eta-reduce"),
+    );
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-bool-identity"),
+    );
+    assert.match(result.fixed, /poly f =\n  g\n/);
+    assert.match(result.fixed, /poly main =\n  value\n/);
+  });
+
+  it("keeps if simplification diagnostic-only", () => {
+    const source = `module M
+import Prelude if
+poly main = if [A] true t f
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-if-constant"),
+    );
+    assert.match(result.fixed, /if \[A\] true t f/);
+  });
+
+  it("reports and fixes pair types to syntactic sugar", () => {
+    const source = `module M
+poly x : Pair Bin Bin = y
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-pair-type"),
+    );
+    assert.match(result.fixed, /poly x : \(Bin, Bin\) =\s+y/);
+  });
+
+  it("reports and fixes MkPair to syntactic sugar", () => {
+    const source = `module M
+poly main = MkPair [Bin] [Bin] a b
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-pair-literal"),
+    );
+    assert.match(result.fixed, /\{Bin, Bin \| a, b\}/);
+  });
+
+  it("reports and fixes nested cons/nil to list literals", () => {
+    const source = `module M
+poly main = cons [Bin] a (cons [Bin] b (nil [Bin]))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-list-literal"),
+    );
+    assert.match(result.fixed, /\{Bin \| a b\}/);
+  });
+
+  it("reports and fixes U8 list to double-quoted string literals", () => {
+    const source = `module M
+poly main = cons [U8] 'h' (cons [U8] 'i' (nil [U8]))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-string-literal"),
+    );
+    assert.match(result.fixed, /"hi"/);
+  });
+
+  it("reports and fixes U8 list literals to double-quoted string literals", () => {
+    const source = `module M
+poly main = {U8 | 'h' 'e' 'l' 'l' 'o'}
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-string-literal"),
+    );
+    assert.match(result.fixed, /"hello"/);
+  });
+
+  it("reports and flattens append chains", () => {
+    const source = `module M
+poly main = append [Bin] {Bin | a} {Bin | b}
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-list-append"),
+    );
+    assert.match(result.fixed, /\{Bin \| a b\}/);
+  });
+});
+
+describe("improvize file discovery", () => {
+  it("recurses into trip files and skips generated directories", async () => {
+    const workspace = await createTempWorkspace("typed-ski-improvize-");
+    try {
+      await mkdir(join(workspace, "src"), { recursive: true });
+      await mkdir(join(workspace, "node_modules", "pkg"), {
+        recursive: true,
+      });
+      await writeFile(join(workspace, "src", "A.trip"), "module A\n", "utf8");
+      await writeFile(
+        join(workspace, "node_modules", "pkg", "B.trip"),
+        "module B\n",
+        "utf8",
+      );
+
+      const files = await discoverTripFiles([workspace]);
+      assert.deepEqual(
+        files.map((file) => file.slice(workspace.length + 1)),
+        [join("src", "A.trip")],
+      );
+    } finally {
+      await cleanupTempWorkspace(workspace);
+    }
+  });
+});

--- a/test/improvize/statistical.test.ts
+++ b/test/improvize/statistical.test.ts
@@ -1,0 +1,227 @@
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import {
+  tokenizeFormatting,
+  getVocabRep,
+  KneserNeyLM,
+  calculateCrossEntropy,
+  computeTokenScores,
+  getNormalizedScores,
+  getTrainedLMSync,
+  getStatisticalDiagnostics,
+} from "../../lib/improvize/statistical.ts";
+import { lintTripSource } from "../../lib/improvize/index.ts";
+import { parseTripLang } from "../../lib/parser/tripLang.ts";
+
+describe("statistical formatting tokenizer", () => {
+  it("retains all spacing, newlines, and generalizes identifiers", () => {
+    const source = "module M\n  poly id = x\n";
+    const tokens = tokenizeFormatting(source);
+
+    // Check that we got space and newline tokens
+    const spaceTokens = tokens.filter((t) => t.kind === "space");
+    const newlineTokens = tokens.filter((t) => t.kind === "newline");
+    assert.ok(spaceTokens.length > 0);
+    assert.ok(newlineTokens.length > 0);
+
+    const reps = tokens.map(getVocabRep);
+    assert.deepEqual(reps, [
+      "module",
+      "<space>",
+      "<ident>",
+      "<newline>",
+      "<spaces:2>",
+      "poly",
+      "<space>",
+      "<ident>",
+      "<space>",
+      "=",
+      "<space>",
+      "<ident>",
+      "<newline>",
+    ]);
+  });
+
+  it("shares nested comment and escaped string scanning with the formatter", () => {
+    const source =
+      'module M\r\n{- outer {- inner -} end -}\npoly s = "a\\"b" @\n';
+    const tokens = tokenizeFormatting(source);
+    const reps = tokens.map(getVocabRep);
+
+    assert.ok(reps.includes("<blockComment>"));
+    assert.ok(reps.includes("<string>"));
+    assert.ok(reps.includes("<unknown>"));
+    assert.equal(
+      tokens.find((token) => token.kind === "blockComment")?.text,
+      "{- outer {- inner -} end -}",
+    );
+    assert.equal(
+      tokens.find((token) => token.kind === "string")?.text,
+      '"a\\"b"',
+    );
+  });
+});
+
+describe("Kneser-Ney language model", () => {
+  it("computes sequence probabilities and smoothing backoff correctly", () => {
+    const sequences = [
+      ["poly", "<space>", "<ident>", "<space>", "=", "<space>", "<ident>"],
+      ["poly", "<space>", "<ident>", "<space>", "=", "<space>", "<number>"],
+    ];
+
+    const lm = new KneserNeyLM(8);
+    lm.train(sequences);
+
+    // Probability of space after poly should be very high
+    const probSpace = lm.getProbability("<space>", ["poly"]);
+    assert.ok(probSpace > 0.5);
+
+    // Probability of an unseen token in a context should back off and not be zero
+    const probUnseen = lm.getProbability("<newline>", ["poly"]);
+    assert.ok(probUnseen > 0);
+    assert.ok(probUnseen < 0.1);
+  });
+
+  it("evaluates file cross-entropy naturalness", () => {
+    const lm = getTrainedLMSync();
+
+    const cleanSource = "module M\n\nimport Prelude U8\n\npoly main = #u8(1)\n";
+    const anomalousSource = "module M import Prelude U8 poly main = #u8(1)";
+
+    const cleanTokens = tokenizeFormatting(cleanSource).map(getVocabRep);
+    const anomalousTokens =
+      tokenizeFormatting(anomalousSource).map(getVocabRep);
+
+    const cleanEntropy = calculateCrossEntropy(lm, cleanTokens);
+    const anomalousEntropy = calculateCrossEntropy(lm, anomalousTokens);
+
+    // Well-formatted canonical layout should have lower entropy (surprise) than squeezed layout
+    assert.ok(cleanEntropy < anomalousEntropy);
+  });
+});
+
+describe("ML-assisted linter and safe fixes", () => {
+  it("detects spacing errors and suggests safe, AST-equivalent fixes", () => {
+    const lm = getTrainedLMSync();
+
+    // Squeezing module and imports without expected double newlines before declarations
+    const anomalousSource = `module M
+import Prelude U8
+import Prelude List
+poly main =
+  let x = #u8(1) in
+  let y = #u8(2) in
+  x
+`;
+
+    const diagnostics = getStatisticalDiagnostics(anomalousSource, lm);
+    // Should flag formatting deviation
+    assert.ok(diagnostics.length > 0);
+    assert.equal(diagnostics[0]!.code, "trip-formatting-deviation");
+    assert.ok(diagnostics[0]!.fix);
+
+    // Safe fixer should correct it under lintTripSource
+    const result = lintTripSource(anomalousSource, { fix: true, lm });
+    assert.ok(result.changed);
+    // AST must remain identical
+    assert.deepEqual(
+      parseTripLang(result.fixed),
+      parseTripLang(anomalousSource),
+    );
+  });
+});
+
+describe("Kneser-Ney precomputed statistics", () => {
+  // Reference implementations: the pre-optimization vocabulary scans the O(1)
+  // getters replaced. Equivalence to these is the correctness contract.
+  const bruteContextCount = (lm: KneserNeyLM, ctx: string[]): number => {
+    const key = ctx.join("|");
+    let sum = 0;
+    for (const word of lm.vocab) {
+      sum += lm.counts[ctx.length + 1]!.get(`${key}|${word}`) || 0;
+    }
+    return sum;
+  };
+  const bruteFollowerCount = (lm: KneserNeyLM, ctx: string[]): number => {
+    const key = ctx.join("|");
+    let n = 0;
+    for (const word of lm.vocab) {
+      if (lm.counts[ctx.length + 1]!.has(`${key}|${word}`)) n++;
+    }
+    return n;
+  };
+  const slidingContexts = (seq: string[], maxLen: number): string[][] => {
+    const out: string[][] = [];
+    for (let len = 1; len <= maxLen; len++) {
+      for (let i = 0; i + len <= seq.length; i++) {
+        out.push(seq.slice(i, i + len));
+      }
+    }
+    return out;
+  };
+
+  it("getters equal the brute-force scan on a synthetic corpus", () => {
+    const sequences = [
+      // prettier-ignore
+      ["module", "<space>", "<ident>", "<newline>", "data", "<space>",
+       "<ident>", "<space>", "=", "<space>", "<ident>", "<space>", "|",
+       "<space>", "<ident>"],
+      ["poly", "<space>", "<ident>", "<space>", "=", "<space>", "<number>"],
+    ];
+    const lm = new KneserNeyLM(8);
+    lm.train(sequences);
+
+    let checked = 0;
+    for (const seq of sequences) {
+      for (const ctx of slidingContexts(seq, lm.maxOrder - 1)) {
+        assert.equal(lm.getContextCount(ctx), bruteContextCount(lm, ctx));
+        assert.equal(
+          lm.getUniqueFollowersCount(ctx),
+          bruteFollowerCount(lm, ctx),
+        );
+        checked++;
+      }
+    }
+    assert.ok(checked > 0);
+  });
+
+  it("getters equal the brute-force scan on the trained corpus (incl. | tokens)", () => {
+    const lm = getTrainedLMSync();
+    const sample = `module M
+
+data Maybe A =
+  | Nothing
+  | Just A
+
+poly main =
+  match x [Maybe A] {
+    | Nothing => zero
+    | Just a => a
+  }
+`;
+    const seq = tokenizeFormatting(sample).map(getVocabRep);
+    assert.ok(seq.includes("|"));
+
+    let checked = 0;
+    for (const ctx of slidingContexts(seq, lm.maxOrder - 1)) {
+      assert.equal(lm.getContextCount(ctx), bruteContextCount(lm, ctx));
+      assert.equal(
+        lm.getUniqueFollowersCount(ctx),
+        bruteFollowerCount(lm, ctx),
+      );
+      checked++;
+    }
+    assert.ok(checked > 0);
+  });
+});
+
+describe("trained LM memoization", () => {
+  it("caches the corpus-wide model and rebuilds only for leave-one-out", () => {
+    const a = getTrainedLMSync();
+    const b = getTrainedLMSync();
+    assert.equal(a, b); // same instance: the corpus-wide model is cached
+
+    const excluded = getTrainedLMSync("definitely-not-a-real-file.trip");
+    assert.notEqual(excluded, a); // an exclusion bypasses the cache
+  });
+});

--- a/test/inputs/avl/AvlBinBoolTreeTest.trip
+++ b/test/inputs/avl/AvlBinBoolTreeTest.trip
@@ -1,35 +1,56 @@
 module AvlBinBoolTreeTest
 
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Bin lteBin
+
 import Avl Avl
+
 import Avl empty
+
 import Avl insert
+
 import Avl lookup
+
 import Avl size
 
 export main
 
-poly boolToNat = \b : Bool => b [Nat] (succ zero) zero
+poly boolToNat =
+  \b : Bool => b [Nat] (succ zero) zero
 
-poly maybeBoolToNat = \m : Maybe Bool =>
-  match m [Nat] {
-    | None => zero
-    | Some b => boolToNat b
-  }
+poly maybeBoolToNat =
+  \m : Maybe Bool =>
+    match m [Nat] {
+      | None => zero
+      | Some b => boolToNat b
+    }
 
 poly main =
   let k1 = B1 BZ in
@@ -46,4 +67,6 @@ poly main =
   let missing = maybeBoolToNat (lookup [Bin] [Bool] lteBin BZ t4) in
   let sizeBefore = size [Bin] [Bool] t3 in
   let sizeAfter = size [Bin] [Bool] t4 in
-  add beforeReplace (add afterReplace (add gotK1 (add missing (add sizeBefore sizeAfter))))
+  add
+    beforeReplace
+    (add afterReplace (add gotK1 (add missing (add sizeBefore sizeAfter))))

--- a/test/inputs/avl/AvlDeleteTraversalTest.trip
+++ b/test/inputs/avl/AvlDeleteTraversalTest.trip
@@ -1,37 +1,61 @@
 module AvlDeleteTraversalTest
 
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat mul
+
 import Nat lte
+
 import Nat fromBin
+
 import Prelude List
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Prelude matchList
+
 import Avl empty
+
 import Avl insert
+
 import Avl delete
+
 import Avl lookup
+
 import Avl size
+
 import Avl toListKeys
 
 export main
 
-poly tenBin : Bin = B0 (B1 (B0 (B1 BZ)))
+poly tenBin : Bin =
+  B0 (B1 (B0 (B1 BZ)))
 
-poly natOrZero = \m : Maybe Nat =>
-  match m [Nat] {
-    | None => zero
-    | Some x => x
-  }
+poly natOrZero =
+  \m : Maybe Nat =>
+    match m [Nat] {
+      | None => zero
+      | Some x => x
+    }
 
-poly rec encode = \keys : List Nat =>
-  matchList [Nat] [Nat] keys zero
-    (\h : Nat => \t : List Nat => add h (mul (encode t) (fromBin tenBin)))
+poly rec encode =
+  \keys : List Nat =>
+    matchList
+      [Nat]
+      [Nat]
+      keys
+      zero
+      (\h : Nat => \t : List Nat => add h (mul (encode t) (fromBin tenBin)))
 
 poly main =
   let one = succ zero in

--- a/test/inputs/avl/AvlInsertTraversalTest.trip
+++ b/test/inputs/avl/AvlInsertTraversalTest.trip
@@ -1,29 +1,50 @@
 module AvlInsertTraversalTest
 
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat mul
+
 import Nat lte
+
 import Nat fromBin
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Prelude List
+
 import Prelude matchList
+
 import Avl empty
+
 import Avl insert
+
 import Avl toListKeys
 
 export main
 
-poly tenBin : Bin = B0 (B1 (B0 (B1 BZ)))
+poly tenBin : Bin =
+  B0 (B1 (B0 (B1 BZ)))
 
-poly rec encode = \keys : List Nat =>
-  matchList [Nat] [Nat] keys zero
-    (\h : Nat => \t : List Nat => add h (mul (encode t) (fromBin tenBin)))
+poly rec encode =
+  \keys : List Nat =>
+    matchList
+      [Nat]
+      [Nat]
+      keys
+      zero
+      (\h : Nat => \t : List Nat => add h (mul (encode t) (fromBin tenBin)))
 
 poly main =
   let one = succ zero in

--- a/test/inputs/avl/AvlNatTreeTest.trip
+++ b/test/inputs/avl/AvlNatTreeTest.trip
@@ -1,26 +1,39 @@
 module AvlNatTreeTest
 
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat lte
+
 import Prelude Maybe
+
 import Prelude Some
+
 import Prelude None
+
 import Avl Avl
+
 import Avl empty
+
 import Avl insert
+
 import Avl lookup
+
 import Avl size
 
 export main
 
-poly natOrZero = \m : Maybe Nat =>
-  match m [Nat] {
-    | None => zero
-    | Some x => x
-  }
+poly natOrZero =
+  \m : Maybe Nat =>
+    match m [Nat] {
+      | None => zero
+      | Some x => x
+    }
 
 poly main =
   let one = succ zero in

--- a/test/inputs/minicore/A.trip
+++ b/test/inputs/minicore/A.trip
@@ -1,5 +1,11 @@
 module A
+
 export Foo
+
 export main
-data Foo = Bar
-poly main = Bar
+
+data Foo =
+  | Bar
+
+poly main =
+  Bar

--- a/test/inputs/minicore/AmbiguousA.trip
+++ b/test/inputs/minicore/AmbiguousA.trip
@@ -1,3 +1,6 @@
 module AmbiguousA
+
 export Bar
-data K = Bar
+
+data K =
+  | Bar

--- a/test/inputs/minicore/AmbiguousB.trip
+++ b/test/inputs/minicore/AmbiguousB.trip
@@ -1,3 +1,6 @@
 module AmbiguousB
+
 export Bar
-data J = Bar
+
+data J =
+  | Bar

--- a/test/inputs/minicore/B.trip
+++ b/test/inputs/minicore/B.trip
@@ -1,3 +1,6 @@
 module B
+
 export Foo
-data Foo = Bar
+
+data Foo =
+  | Bar

--- a/test/inputs/minicore/LetScoping.trip
+++ b/test/inputs/minicore/LetScoping.trip
@@ -1,8 +1,13 @@
 module LetScoping
+
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 export main
+
 poly main =
   let x = succ zero in
   let x = succ x in

--- a/test/inputs/minicore/Shadowing.trip
+++ b/test/inputs/minicore/Shadowing.trip
@@ -1,11 +1,18 @@
 module Shadowing
+
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 export main
 
-poly inner = \g : Nat -> Nat => \x : Nat =>
-  let g = zero in
-  x
+poly inner =
+  \g : Nat -> Nat =>
+    \x : Nat =>
+      let g = zero in
+      x
 
-poly main = inner succ zero
+poly main =
+  inner succ zero

--- a/test/inputs/minicore/ShortCircuit.trip
+++ b/test/inputs/minicore/ShortCircuit.trip
@@ -1,13 +1,24 @@
 module ShortCircuit
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude and
+
 import Prelude or
+
 import Prelude not
+
 import Prelude U8
+
 export main
-poly fail = \u : U8 => not (fail u)
+
+poly fail =
+  \u : U8 => not (fail u)
+
 poly main =
   let a = and false (fail #u8(0)) in
   let b = or true (fail #u8(0)) in

--- a/test/inputs/minicore/SpecializationFailure.trip
+++ b/test/inputs/minicore/SpecializationFailure.trip
@@ -1,13 +1,24 @@
 module SpecializationFailure
+
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
+
 import Prelude Bool
+
 import Prelude true
+
 import Prelude if
+
 import Prelude U8
+
 export main
-poly high = \f : Nat -> Nat => f zero
+
+poly high =
+  \f : Nat -> Nat => f zero
+
 poly main =
   let x = zero in
   high x

--- a/test/linker/A.trip
+++ b/test/linker/A.trip
@@ -1,7 +1,11 @@
 module A
 
 export addA
+
 export main
 
-poly addA = #X => \x: X => \y: X => x
-poly main = addA
+poly addA =
+  #X => \x : X => \y : X => x
+
+poly main =
+  addA

--- a/test/linker/ALinkerTest.trip
+++ b/test/linker/ALinkerTest.trip
@@ -2,4 +2,5 @@ module A
 
 export addA
 
-poly addA = #X => \x: X => \y: X => x
+poly addA =
+  #X => \x : X => \y : X => x

--- a/test/linker/B.trip
+++ b/test/linker/B.trip
@@ -4,4 +4,5 @@ import A addA
 
 export main
 
-poly main = \x:Int => addA x x
+poly main =
+  \x : Int => addA x x

--- a/test/linker/cli_helper.trip
+++ b/test/linker/cli_helper.trip
@@ -2,4 +2,5 @@ module Helper
 
 export helper
 
-poly helper = #X => \x: X => x
+poly helper =
+  #X => \x : X => x

--- a/test/linker/complex.trip
+++ b/test/linker/complex.trip
@@ -2,4 +2,5 @@ module Complex
 
 export main
 
-poly main = #X => \x: X => \y: X => \z: X => x
+poly main =
+  #X => \x : X => \y : X => \z : X => x

--- a/test/linker/inputs/echoOne.trip
+++ b/test/linker/inputs/echoOne.trip
@@ -1,8 +1,10 @@
 module EchoOne
 
 import Prelude readOne
+
 import Prelude writeOne
 
 export main
 
-combinator main = , (C . I)
+combinator main =
+  , (C . I)

--- a/test/linker/inputs/literalMain.trip
+++ b/test/linker/inputs/literalMain.trip
@@ -3,23 +3,34 @@ module LiteralMain
 export main
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly thirteen : Bin = B1 (B0 (B1 (B1 BZ)))
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly main = binToChurch thirteen
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
+
+poly thirteen : Bin =
+  B1 (B0 (B1 (B1 BZ)))
+
+poly main =
+  binToChurch thirteen

--- a/test/linker/inputs/preludeArithmetic.trip
+++ b/test/linker/inputs/preludeArithmetic.trip
@@ -1,15 +1,25 @@
 module TestArithmetic
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat mul
+
 import Nat Nat
 
 export main
 
-poly one = succ zero
-poly two = succ one
-poly three = succ two
+poly one =
+  succ zero
 
-poly main = mul two three
+poly two =
+  succ one
+
+poly three =
+  succ two
+
+poly main =
+  mul two three

--- a/test/linker/inputs/preludeComplex.trip
+++ b/test/linker/inputs/preludeComplex.trip
@@ -1,17 +1,31 @@
 module TestComplexArithmetic
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat mul
+
 import Nat Nat
 
 export main
 
-poly one = succ zero
-poly two = succ one
-poly three = succ two
-poly four = succ three
-poly five = succ four
+poly one =
+  succ zero
 
-poly main = add (mul two three) (mul one four)
+poly two =
+  succ one
+
+poly three =
+  succ two
+
+poly four =
+  succ three
+
+poly five =
+  succ four
+
+poly main =
+  add (mul two three) (mul one four)

--- a/test/linker/inputs/preludeConflictingNat.trip
+++ b/test/linker/inputs/preludeConflictingNat.trip
@@ -4,7 +4,14 @@ export Nat
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly one = succ zero
-poly two = succ one
-poly three = succ two
-poly main = three
+poly one =
+  succ zero
+
+poly two =
+  succ one
+
+poly three =
+  succ two
+
+poly main =
+  three

--- a/test/linker/inputs/preludeDataPrelude.trip
+++ b/test/linker/inputs/preludeDataPrelude.trip
@@ -1,43 +1,71 @@
 module TestDataPrelude
 
 import Prelude List
+
 import Prelude nil
+
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin addBin
+
 import Prelude Pair
+
 import Prelude Err
+
 import Prelude Ok
+
 import Prelude MkPair
 
 export main
 
-poly zeroBin : Bin = BZ
-poly one : Bin = B1 BZ
-poly two : Bin = B0 (B1 BZ)
+poly zeroBin : Bin =
+  BZ
 
-poly errVal = Err [Bin] [Bin] zeroBin
-poly okVal = Ok [Bin] [Bin] two
-poly pair : (Bin, Bin) = {Bin, Bin | one, two}
+poly one : Bin =
+  B1 BZ
+
+poly two : Bin =
+  B0 (B1 BZ)
+
+poly errVal =
+  Err [Bin] [Bin] zeroBin
+
+poly okVal =
+  Ok [Bin] [Bin] two
+
+poly pair : (Bin, Bin) =
+  {Bin, Bin | one, two}
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly fromResult = \r : #R -> (Bin -> R) -> (Bin -> R) -> R =>
-  r [Bin] (\e : Bin => zeroBin) (\v : Bin => v)
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly sumPair = pair [Bin] (\a : Bin => \b : Bin => addBin a b)
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
 
-poly main = binToChurch (addBin sumPair (addBin (fromResult okVal) (fromResult errVal)))
+poly fromResult =
+  \r : #R -> (Bin -> R) -> (Bin -> R) -> R => r [Bin] (\e : Bin => zeroBin) (\v : Bin => v)
+
+poly sumPair =
+  pair [Bin] (\a : Bin => \b : Bin => addBin a b)
+
+poly main =
+  binToChurch (addBin sumPair (addBin (fromResult okVal) (fromResult errVal)))

--- a/test/linker/inputs/preludeListCombinators.trip
+++ b/test/linker/inputs/preludeListCombinators.trip
@@ -1,41 +1,75 @@
 module TestListCombinators
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin addBin
+
 import Bin incBin
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude List
+
 import Prelude map
+
 import Prelude append
+
 import Prelude foldl
+
 import Prelude matchList
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly zeroBin : Bin = BZ
-poly one : Bin = B1 BZ
-poly two : Bin = B0 (B1 BZ)
-poly three : Bin = B1 (B1 BZ)
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly list1 = {Bin | one two}
-poly list2 = {Bin | three}
-poly mapped = map [Bin] [Bin] incBin list1
-poly combined = append [Bin] mapped list2
-poly main = binToChurch (foldl [Bin] [Bin] addBin zeroBin combined)
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
+
+poly zeroBin : Bin =
+  BZ
+
+poly one : Bin =
+  B1 BZ
+
+poly two : Bin =
+  B0 (B1 BZ)
+
+poly three : Bin =
+  B1 (B1 BZ)
+
+poly list1 =
+  {Bin | one two}
+
+poly list2 =
+  {Bin | three}
+
+poly mapped =
+  map [Bin] [Bin] incBin list1
+
+poly combined =
+  append [Bin] mapped list2
+
+poly main =
+  binToChurch (foldl [Bin] [Bin] addBin zeroBin combined)

--- a/test/linker/inputs/preludeListHeadTail.trip
+++ b/test/linker/inputs/preludeListHeadTail.trip
@@ -1,34 +1,54 @@
 module TestList
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude head
+
 import Prelude tail
+
 import Prelude error
+
 import Prelude List
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly one : Bin = B1 BZ
-poly two : Bin = B0 (B1 BZ)
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly list = {Bin | one two}
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
 
-poly main = binToChurch (head [Bin] (tail [Bin] list))
+poly one : Bin =
+  B1 BZ
+
+poly two : Bin =
+  B0 (B1 BZ)
+
+poly list =
+  {Bin | one two}
+
+poly main =
+  binToChurch (head [Bin] (tail [Bin] list))

--- a/test/linker/inputs/preludeListPrefix.trip
+++ b/test/linker/inputs/preludeListPrefix.trip
@@ -1,46 +1,84 @@
 module TestListPrefix
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin addBin
+
 import Bin incBin
+
 import Bin isZeroBin
+
 import Prelude true
+
 import Prelude false
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude List
+
 import Prelude takeWhile
+
 import Prelude dropWhile
+
 import Prelude foldl
+
 import Prelude head
+
 import Prelude if
+
 import Prelude error
+
 import Prelude matchList
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly isLeadingZero = \n : Bin => isZeroBin n
-poly zeroBin : Bin = BZ
-poly one : Bin = B1 BZ
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly sample = {Bin | zeroBin zeroBin one}
-poly taken = takeWhile [Bin] isLeadingZero sample
-poly dropped = dropWhile [Bin] isLeadingZero sample
-poly count = foldl [Bin] [Bin] (\acc : Bin => \_ : Bin => incBin acc) zeroBin taken
-poly main = binToChurch (addBin count (head [Bin] dropped))
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
+
+poly isLeadingZero =
+  isZeroBin
+
+poly zeroBin : Bin =
+  BZ
+
+poly one : Bin =
+  B1 BZ
+
+poly sample =
+  {Bin | zeroBin zeroBin one}
+
+poly taken =
+  takeWhile [Bin] isLeadingZero sample
+
+poly dropped =
+  dropWhile [Bin] isLeadingZero sample
+
+poly count =
+  foldl [Bin] [Bin] (\acc : Bin => \_ : Bin => incBin acc) zeroBin taken
+
+poly main =
+  binToChurch (addBin count (head [Bin] dropped))

--- a/test/linker/inputs/preludeLiteralConsumer.trip
+++ b/test/linker/inputs/preludeLiteralConsumer.trip
@@ -4,4 +4,5 @@ import LiteralProvider lit
 
 export main
 
-poly main = lit
+poly main =
+  lit

--- a/test/linker/inputs/preludeLiteralProvider.trip
+++ b/test/linker/inputs/preludeLiteralProvider.trip
@@ -4,4 +4,5 @@ import Nat Nat
 
 export lit
 
-poly lit = 3
+poly lit =
+  #u8(3)

--- a/test/linker/inputs/preludeMatchList.trip
+++ b/test/linker/inputs/preludeMatchList.trip
@@ -1,34 +1,53 @@
 module TestMatchList
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude List
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly zeroBin : Bin = BZ
-poly fortyTwo : Bin = B0 (B1 (B0 (B1 (B0 (B1 BZ)))))
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly emptyResult = matchList [Bin] [Bin] {Bin |} zeroBin (\h : Bin => \t : List => h)
-poly consResult = matchList [Bin] [Bin] {Bin | fortyTwo} zeroBin
-  (\h : Bin => \t : List => h)
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
 
-poly main = binToChurch consResult
+poly zeroBin : Bin =
+  BZ
+
+poly fortyTwo : Bin =
+  B0 (B1 (B0 (B1 (B0 (B1 BZ)))))
+
+poly emptyResult =
+  matchList [Bin] [Bin] {Bin |} zeroBin (\h : Bin => \t : List => h)
+
+poly consResult =
+  matchList [Bin] [Bin] {Bin | fortyTwo} zeroBin (\h : Bin => \t : List => h)
+
+poly main =
+  binToChurch consResult

--- a/test/linker/inputs/preludeMult.trip
+++ b/test/linker/inputs/preludeMult.trip
@@ -1,14 +1,23 @@
 module TestMultiplication
 
 import Nat zero
+
 import Nat succ
+
 import Nat mul
+
 import Nat Nat
 
 export main
 
-poly one = succ zero
-poly two = succ one
-poly three = succ two
+poly one =
+  succ zero
 
-poly main = mul two three
+poly two =
+  succ one
+
+poly three =
+  succ two
+
+poly main =
+  mul two three

--- a/test/linker/inputs/preludeSimple.trip
+++ b/test/linker/inputs/preludeSimple.trip
@@ -1,13 +1,20 @@
 module TestSimple
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat Nat
 
 export main
 
-poly one = succ zero
-poly two = succ one
+poly one =
+  succ zero
 
-poly main = add one one
+poly two =
+  succ one
+
+poly main =
+  add one one

--- a/test/linker/inputs/stringLengthMatchList.trip
+++ b/test/linker/inputs/stringLengthMatchList.trip
@@ -1,36 +1,67 @@
 module TestStringLength
 
 import Prelude Bin
+
 import Prelude BZ
+
 import Prelude B0
+
 import Prelude B1
+
 import Bin incBin
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude matchList
+
 import Prelude List
 
 export main
 
 type Church = #X -> (X -> X) -> X -> X
 
-poly zero : Church = #X => \s : X -> X => \z : X => z
-poly succ : Church = \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
-poly dbl : Church = \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
+poly zero : Church =
+  #X => \s : X -> X => \z : X => z
 
-poly rec binToChurch = \b : Bin =>
-  match b [Church] {
-    | BZ => zero
-    | B0 rest => dbl (binToChurch rest)
-    | B1 rest => succ (dbl (binToChurch rest))
-  }
+poly succ : Church =
+  \n : Church => #X => \s : X -> X => \z : X => s (n [X] s z)
 
-poly zeroBin : Bin = BZ
+poly dbl : Church =
+  \n : Church => #X => \s : X -> X => \z : X => n [X] s (n [X] s z)
 
-poly length2 = \xs : List =>
-  matchList [Bin] [Bin] xs zeroBin
-    (\h : Bin => \t : List =>
-      incBin (matchList [Bin] [Bin] t zeroBin
-        (\h2 : Bin => \t2 : List => incBin zeroBin)))
+poly rec binToChurch =
+  \b : Bin =>
+    match b [Church] {
+      | BZ => zero
+      | B0 rest => dbl (binToChurch rest)
+      | B1 rest => succ (dbl (binToChurch rest))
+    }
 
-poly main = binToChurch (length2 "hi")
+poly zeroBin : Bin =
+  BZ
+
+poly length2 =
+  \xs : List =>
+    matchList
+      [Bin]
+      [Bin]
+      xs
+      zeroBin
+      (
+        \h : Bin =>
+          \t : List =>
+            incBin
+              (
+                matchList
+                  [Bin]
+                  [Bin]
+                  t
+                  zeroBin
+                  (\h2 : Bin => \t2 : List => incBin zeroBin)
+              )
+      )
+
+poly main =
+  binToChurch (length2 "hi")

--- a/test/linker/inputs/testArithmetic.trip
+++ b/test/linker/inputs/testArithmetic.trip
@@ -1,13 +1,20 @@
 module Test
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat Nat
 
 export main
 
-poly two = succ (succ zero)
-poly three = succ two
+poly two =
+  succ (succ zero)
 
-poly main = add two three
+poly three =
+  succ two
+
+poly main =
+  add two three

--- a/test/linker/inputs/testLists.trip
+++ b/test/linker/inputs/testLists.trip
@@ -1,20 +1,34 @@
 module Test
 
 import Nat zero
+
 import Nat succ
+
 import Nat add
+
 import Nat Nat
+
 import Prelude List
+
 import Prelude nil
+
 import Prelude cons
+
 import Prelude foldl
 
 export main
 
-poly one = succ zero
-poly two = succ one
-poly three = succ two
+poly one =
+  succ zero
 
-poly list = {Nat | one two three}
+poly two =
+  succ one
 
-poly main = foldl [Nat] [Nat] add zero list
+poly three =
+  succ two
+
+poly list =
+  {Nat | one two three}
+
+poly main =
+  foldl [Nat] [Nat] add zero list

--- a/test/linker/inputs/testLogic.trip
+++ b/test/linker/inputs/testLogic.trip
@@ -1,11 +1,16 @@
 module Test
 
 import Prelude Bool
+
 import Prelude true
+
 import Prelude false
+
 import Prelude and
+
 import Prelude or
 
 export main
 
-poly main = and true (or false true)
+poly main =
+  and true (true)

--- a/test/linker/int_complex.trip
+++ b/test/linker/int_complex.trip
@@ -2,4 +2,5 @@ module Complex
 
 export main
 
-poly main = #X => \x: X => \y: X => \z: X => x
+poly main =
+  #X => \x : X => \y : X => \z : X => x

--- a/test/linker/int_exec_wrapper.trip
+++ b/test/linker/int_exec_wrapper.trip
@@ -2,4 +2,5 @@ module ExecWrapper
 
 export main
 
-poly main = #X => \x: X => x
+poly main =
+  #X => \x : X => x

--- a/test/linker/int_invalid.trip
+++ b/test/linker/int_invalid.trip
@@ -2,4 +2,5 @@ module Invalid
 
 export main
 
-poly main = \x:Int => \y:Int => x + y
+poly main =
+  \x : Int => \y : Int => x + y

--- a/test/linker/int_large.trip
+++ b/test/linker/int_large.trip
@@ -2,4 +2,10 @@ module Large
 
 export main
 
-poly main = #X => \x: X => \y: X => \z: X => \w: X => \v: X => \u: X => \t: X => \s: X => \r: X => \q: X => x
+poly main =
+  #X =>
+    \x : X =>
+      \y : X =>
+        \z : X =>
+          \w : X =>
+            \v : X => \u : X => \t : X => \s : X => \r : X => \q : X => x

--- a/test/linker/int_mod_a.trip
+++ b/test/linker/int_mod_a.trip
@@ -2,4 +2,5 @@ module ModuleA
 
 export addA
 
-poly addA = #X => \x: X => \y: X => x
+poly addA =
+  #X => \x : X => \y : X => x

--- a/test/linker/int_mod_b.trip
+++ b/test/linker/int_mod_b.trip
@@ -2,4 +2,5 @@ module ModuleB
 
 export main
 
-poly main = #X => \x: X => x
+poly main =
+  #X => \x : X => x

--- a/test/linker/int_noMain.trip
+++ b/test/linker/int_noMain.trip
@@ -2,4 +2,5 @@ module NoMain
 
 export other
 
-poly other = \x: Int => x
+poly other =
+  \x : Int => x

--- a/test/linker/int_simple.trip
+++ b/test/linker/int_simple.trip
@@ -2,4 +2,5 @@ module Simple
 
 export main
 
-poly main = #X => \x: X => x
+poly main =
+  #X => \x : X => x

--- a/test/linker/linkerRec.trip
+++ b/test/linker/linkerRec.trip
@@ -1,9 +1,13 @@
 module Rec
 
 export loop
+
 export main
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly rec loop = \n:Nat => loop n
-poly main = loop
+poly rec loop =
+  loop
+
+poly main =
+  loop

--- a/test/linker/linkerRecOnly.trip
+++ b/test/linker/linkerRecOnly.trip
@@ -4,4 +4,5 @@ export main
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly rec main = \n:Nat => main n
+poly rec main =
+  main

--- a/test/linker/recursive_adt.trip
+++ b/test/linker/recursive_adt.trip
@@ -1,25 +1,34 @@
 module RecursiveAdt
 
 import Nat Nat
+
 import Nat fromBin
 
 export Tree
+
 export Leaf
+
 export Node
+
 export makeLeaf
+
 export makeNode
+
 export getValue
 
 data Tree =
   | Leaf Nat
   | Node Tree Tree
 
-poly makeLeaf = \n : Nat => Leaf n
+poly makeLeaf =
+  Leaf
 
-poly makeNode = \left : Tree => \right : Tree => Node left right
+poly makeNode =
+  \left : Tree => \right : Tree => Node left right
 
-poly getValue = \t : Tree =>
-  match t [Nat] {
-    | Leaf n => n
-    | Node _ _ => fromBin 0
-  }
+poly getValue =
+  \t : Tree =>
+    match t [Nat] {
+      | Leaf n => n
+      | Node _ _ => fromBin #u8(0)
+    }

--- a/test/linker/snat_like.trip
+++ b/test/linker/snat_like.trip
@@ -1,20 +1,29 @@
 module SNatLike
 
 import Nat Nat
+
 import Nat add
+
 import Nat succ
+
 import Nat zero
 
 export SNat
+
 export SZ
+
 export SS
+
 export toSNat
+
 export fromSNat
 
 data SNat =
   | SZ
   | SS SNat
 
-poly toSNat = \n : Nat => n [SNat] (\x : SNat => SS x) SZ
+poly toSNat =
+  \n : Nat => n [SNat] (SS) SZ
 
-poly fromSNat = \s : SNat => s [Nat] (\n : Nat => succ n) zero
+poly fromSNat =
+  \s : SNat => s [Nat] (succ) zero

--- a/test/linker/test_recursive.trip
+++ b/test/linker/test_recursive.trip
@@ -1,14 +1,22 @@
 module TestRecursive
 
 import RecursiveAdt Tree
+
 import RecursiveAdt Leaf
+
 import RecursiveAdt Node
+
 import RecursiveAdt makeLeaf
+
 import RecursiveAdt makeNode
+
 import RecursiveAdt getValue
+
 import Nat Nat
+
 import Nat fromBin
 
 export main
 
-poly main = getValue (makeNode (makeLeaf (fromBin 1)) (makeLeaf (fromBin 2)))
+poly main =
+  getValue (makeNode (makeLeaf (fromBin #u8(1))) (makeLeaf (fromBin #u8(2))))

--- a/test/linker/test_snat.trip
+++ b/test/linker/test_snat.trip
@@ -1,14 +1,22 @@
 module TestSNat
 
 import SNatLike SNat
+
 import SNatLike SZ
+
 import SNatLike SS
+
 import SNatLike toSNat
+
 import SNatLike fromSNat
+
 import Nat Nat
+
 import Nat zero
+
 import Nat succ
 
 export main
 
-poly main = fromSNat (SS (SS SZ))
+poly main =
+  fromSNat (SS (SS SZ))

--- a/test/meta/inputs/adtMaybe.trip
+++ b/test/meta/inputs/adtMaybe.trip
@@ -2,13 +2,22 @@ module AdtMaybe
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly zero = #X => \s : X -> X => \z : X => z
-poly succ = \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
-poly one = succ zero
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-data Maybe A = Nothing | Just A
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly fromMaybe = #A => \d : A => \m : #R -> R -> (A -> R) -> R =>
-  m [A] d (\x : A => x)
+poly one =
+  succ zero
 
-poly main = fromMaybe [Nat] zero (Just [Nat] (succ one))
+data Maybe A =
+  | Nothing
+  | Just A
+
+poly fromMaybe =
+  #A =>
+    \d : A => \m : #R -> R -> (A -> R) -> R => m [A] d (\x : A => x)
+
+poly main =
+  fromMaybe [Nat] zero (Just [Nat] (succ one))

--- a/test/meta/inputs/adtResult.trip
+++ b/test/meta/inputs/adtResult.trip
@@ -1,15 +1,27 @@
 module AdtResult
 
 type Nat = #X -> (X -> X) -> X -> X
+
 type Bool = #B -> B -> B -> B
 
-poly zero = #X => \s : X -> X => \z : X => z
-poly succ = \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
-poly one = succ zero
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-data Result E T = Err E | Ok T
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly fromResult = #E => #T => \d : T => \r : #R -> (E -> R) -> (T -> R) -> R =>
-  r [T] (\_ : E => d) (\x : T => x)
+poly one =
+  succ zero
 
-poly main = fromResult [Bool] [Nat] zero (Ok [Bool] [Nat] (succ one))
+data Result E T =
+  | Err E
+  | Ok T
+
+poly fromResult =
+  #E =>
+    #T =>
+      \d : T =>
+        \r : #R -> (E -> R) -> (T -> R) -> R => r [T] (\_ : E => d) (\x : T => x)
+
+poly main =
+  fromResult [Bool] [Nat] zero (Ok [Bool] [Nat] (succ one))

--- a/test/meta/inputs/condSucc.trip
+++ b/test/meta/inputs/condSucc.trip
@@ -1,24 +1,32 @@
 module CondSucc
 
-type Nat  = #X -> (X -> X) -> X -> X
+type Nat = #X -> (X -> X) -> X -> X
+
 type Bool = #B -> B -> B -> B
 
-poly zero  = #X => \s : X -> X => \z : X => z
-poly succ  = \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-poly one   = succ zero
-poly two   = succ one
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly true  = #B => \t : B => \f : B => t
-poly false = #B => \t : B => \f : B => f
+poly one =
+  succ zero
+
+poly two =
+  succ one
+
+poly true =
+  #B => \t : B => \f : B => t
+
+poly false =
+  #B => \t : B => \f : B => f
 
 poly cond =
-  #X =>
-    \b : Bool =>
-    \t : X =>
-    \f : X =>
-      b [X] t f
+  #X => \b : Bool => \t : X => \f : X => b [X] t f
 
-poly pickNat = cond [Nat] false (succ two) one
+poly pickNat =
+  cond [Nat] false (succ two) one
 
-poly main = succ (succ pickNat)
+poly main =
+  succ (succ pickNat)

--- a/test/meta/inputs/mul.trip
+++ b/test/meta/inputs/mul.trip
@@ -2,23 +2,32 @@ module MulModule
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly zero = #X => \s : X -> X => \z : X => z
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-poly succ = \n : Nat =>
-              #a => \s : a -> a => \z : a =>
-                s (n [a] s z)
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly one   = succ zero
-poly two   = succ one
-poly three = succ two
-poly four  = succ three
-poly five  = succ four
+poly one =
+  succ zero
+
+poly two =
+  succ one
+
+poly three =
+  succ two
+
+poly four =
+  succ three
+
+poly five =
+  succ four
 
 poly mul =
-  \m : Nat => \n : Nat =>
-    #a => \s : a -> a => \z : a =>
-      m [a] (n [a] s) z
+  \m : Nat => \n : Nat => #a => \s : a -> a => \z : a => m [a] (n [a] s) z
 
-poly six = mul two three
+poly six =
+  mul two three
 
-poly twentyFour = mul (mul two three) four
+poly twentyFour =
+  mul (mul two three) four

--- a/test/meta/inputs/nestedTypeApps.trip
+++ b/test/meta/inputs/nestedTypeApps.trip
@@ -1,9 +1,20 @@
 module NestedTypeApps
 
-type Nat = #X->(X->X)->(X->X)
-type Bool = #B->(B->(B->B))
-poly true = #B=>\t:B=>\f:B=>t
-poly false = #B=>\t:B=>\f:B=>f
-poly zero = #X=>\s:(X->X)=>\z:X=>z
-poly succ = \n:Nat=>#X=>\s:(X->X)=>\z:X=>(s (n[X] s z))
-poly pred = \n:Nat=>(n[Bool] \b:Bool=>false true)
+type Nat = #X -> (X -> X) -> (X -> X)
+
+type Bool = #B -> (B -> (B -> B))
+
+poly true =
+  #B => \t : B => \f : B => t
+
+poly false =
+  #B => \t : B => \f : B => f
+
+poly zero =
+  #X => \s : (X -> X) => \z : X => z
+
+poly succ =
+  \n : Nat => #X => \s : (X -> X) => \z : X => (s (n [X] s z))
+
+poly pred =
+  \n : Nat => (n [Bool] \b : Bool => false true)

--- a/test/meta/inputs/polyFact.trip
+++ b/test/meta/inputs/polyFact.trip
@@ -2,37 +2,49 @@ module PolyFact
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly zero = #X => \s: X -> X => \z : X => z
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
 poly succ =
-  \n : Nat =>
-    #a => \s : a -> a => \z : a =>
-      s (n [a] s z)
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly pair = #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
+poly pair =
+  #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
 
-poly fst = #A => #B => \p : #Y -> (A->B->Y)->Y =>
-  p [A] (\x:A => \y:B => x)
+poly fst =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [A] (\x : A => \y : B => x)
 
-poly snd = #A => #B => \p : #Y -> (A->B->Y)->Y =>
-  p [B] (\x:A => \y:B => y)
+poly snd =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [B] (\x : A => \y : B => y)
 
 poly mul =
-  \m : Nat => \n : Nat =>
-    #a => \s : a -> a => \z : a =>
-      m [a] (n [a] s) z
+  \m : Nat => \n : Nat => #a => \s : a -> a => \z : a => m [a] (n [a] s) z
 
-poly one = succ zero
+poly one =
+  succ zero
 
-poly fact = \n : Nat =>
-  fst Nat Nat
-    (n [#Y -> (Nat -> Nat -> Y) -> Y]
-      (\p : #Y -> (Nat -> Nat -> Y) -> Y =>
-        pair Nat Nat
-          (mul (fst Nat Nat p) (snd Nat Nat p))
-          (succ (snd Nat Nat p))
+poly fact =
+  \n : Nat =>
+    fst
+      Nat
+      Nat
+      (
+        n
+          [#Y -> (Nat -> Nat -> Y) -> Y]
+          (
+            \p : #Y -> (Nat -> Nat -> Y) -> Y =>
+              pair
+                Nat
+                Nat
+                (mul (fst Nat Nat p) (snd Nat Nat p))
+                (succ (snd Nat Nat p))
+          )
+          (pair Nat Nat one one)
       )
-      (pair Nat Nat one one)
-    )
 
-poly main = fact (succ (succ (succ (succ zero))))
+poly main =
+  fact (succ (succ (succ (succ zero))))

--- a/test/meta/inputs/pred.trip
+++ b/test/meta/inputs/pred.trip
@@ -2,42 +2,62 @@ module Pred
 
 type Nat = #X -> (X -> X) -> X -> X
 
-poly zero  = #X => \s : X -> X => \z : X => z
-poly succ  = \n : Nat =>
-               #a => \s : a -> a => \z : a =>
-                 s (n[a] s z)
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-poly one   = succ zero
-poly two   = succ one
-poly three = succ two
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly pair = #A => #B =>
-              \a : A => \b : B =>
-              #Y => \k : A -> B -> Y =>
-                k a b
+poly one =
+  succ zero
 
-poly fst = #A => #B =>
-             \p : #Y -> (A -> B -> Y) -> Y =>
-               p [A] (\x : A => \y : B => x)
+poly two =
+  succ one
 
-poly snd = #A => #B =>
-             \p : #Y -> (A -> B -> Y) -> Y =>
-               p [B] (\x : A => \y : B => y)
+poly three =
+  succ two
 
-poly pred = \n : Nat =>
-  fst Nat Nat
-    ( n [#Y -> (Nat -> Nat -> Y) -> Y]
-      ( \p : #Y -> (Nat -> Nat -> Y) -> Y =>
-          pair Nat Nat
-            (snd Nat Nat p)
-            (succ (snd Nat Nat p))
+poly pair =
+  #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
+
+poly fst =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [A] (\x : A => \y : B => x)
+
+poly snd =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [B] (\x : A => \y : B => y)
+
+poly pred =
+  \n : Nat =>
+    fst
+      Nat
+      Nat
+      (
+        n
+          [#Y -> (Nat -> Nat -> Y) -> Y]
+          (
+            \p : #Y -> (Nat -> Nat -> Y) -> Y => pair Nat Nat (snd Nat Nat p) (succ (snd Nat Nat p))
+          )
+          (pair Nat Nat zero zero)
       )
-      (pair Nat Nat zero zero)
-    )
 
-poly testPred1 = pred one
-poly testPred3 = pred three
-poly testPair = pair Nat Nat two three
-poly testFst  = fst Nat Nat testPair
-poly testSnd  = snd Nat Nat testPair
-poly main = succ (pred three)
+poly testPred1 =
+  pred one
+
+poly testPred3 =
+  pred three
+
+poly testPair =
+  pair Nat Nat two three
+
+poly testFst =
+  fst Nat Nat testPair
+
+poly testSnd =
+  snd Nat Nat testPair
+
+poly main =
+  succ (pred three)

--- a/test/meta/inputs/recFact.trip
+++ b/test/meta/inputs/recFact.trip
@@ -3,71 +3,75 @@ module RecFact
 type Nat = #X -> (X -> X) -> X -> X
 
 poly succ =
-  \n : Nat =>
-    #a => \s : a -> a => \z : a =>
-      s (n [a] s z)
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
 
-poly zero = #X => \s: X -> X => \z : X => z
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-poly one = succ zero
+poly one =
+  succ zero
 
-poly two = succ one
+poly two =
+  succ one
 
-poly five = succ (succ (succ two))
+poly five =
+  succ (succ (succ two))
 
-poly BZ = zero
-poly B0 = \n:Nat => mul two n
-poly B1 = \n:Nat => succ (mul two n)
+poly BZ =
+  zero
+
+poly B0 =
+  \n : Nat => mul two n
+
+poly B1 =
+  \n : Nat => succ (mul two n)
 
 type Bool = #B -> B -> B -> B
 
-poly true = #B => \t:B => \f:B => t
+poly true =
+  #B => \t : B => \f : B => t
 
-poly false = #B => \t:B => \f:B => f
+poly false =
+  #B => \t : B => \f : B => f
 
 poly cond =
-  #X =>
-    \b : Bool =>
-    \t : X =>
-    \f : X =>
-      b [X] t f
+  #X => \b : Bool => \t : X => \f : X => b [X] t f
 
 poly mul =
-  \m : Nat => \n : Nat =>
-    #a => \s : a -> a => \z : a =>
-      m [a] (n [a] s) z
+  \m : Nat => \n : Nat => #a => \s : a -> a => \z : a => m [a] (n [a] s) z
 
 poly isZero =
+  \n : Nat => n [Bool] (\b : Bool => false) true
+
+poly pair =
+  #A => #B => \a : A => \b : B => #Y => \k : A -> B -> Y => k a b
+
+poly fst =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [A] (\x : A => \y : B => x)
+
+poly snd =
+  #A =>
+    #B =>
+      \p : #Y -> (A -> B -> Y) -> Y => p [B] (\x : A => \y : B => y)
+
+poly pred =
   \n : Nat =>
-    n [Bool]
-     (\b : Bool => false)
-     true
-
-poly pair = #A => #B => \a :
-  A => \b : B => #Y => \k :
-  A -> B -> Y => k a b
-
-poly fst = #A => #B => \p : #Y -> (A -> B -> Y) -> Y =>
-  p [A] (\x : A => \y : B => x)
-
-poly snd = #A => #B => \p : #Y -> (A -> B -> Y) -> Y =>
-  p [B] (\x : A => \y : B => y)
-
-poly pred = \n : Nat =>
-  fst Nat Nat
-    ( n [#Y -> (Nat -> Nat -> Y) -> Y]
-        ( \p : #Y -> (Nat -> Nat -> Y) -> Y =>
-            pair Nat Nat
-              (snd Nat Nat p)
-              (succ (snd Nat Nat p))
-        )
-        (pair Nat Nat zero zero)
-    )
+    fst
+      Nat
+      Nat
+      (
+        n
+          [#Y -> (Nat -> Nat -> Y) -> Y]
+          (
+            \p : #Y -> (Nat -> Nat -> Y) -> Y => pair Nat Nat (snd Nat Nat p) (succ (snd Nat Nat p))
+          )
+          (pair Nat Nat zero zero)
+      )
 
 poly rec fact : Nat -> Nat =
-  \n : Nat =>
-    cond
-      [Nat] (isZero n) one
-        (mul n (fact (pred n)))
+  \n : Nat => cond [Nat] (isZero n) one (mul n (fact (pred n)))
 
-poly main : Nat = fact five
+poly main : Nat =
+  fact five

--- a/test/meta/inputs/resultMatch.trip
+++ b/test/meta/inputs/resultMatch.trip
@@ -1,27 +1,46 @@
 module ResultMatch
 
 type Nat = #X -> (X -> X) -> X -> X
+
 type Bool = #B -> B -> B -> B
 
-poly zero = #X => \s : X -> X => \z : X => z
-poly succ = \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
-poly one = succ zero
-poly two = succ one
-poly true = #B => \t : B => \f : B => t
-poly false = #B => \t : B => \f : B => f
+poly zero =
+  #X => \s : X -> X => \z : X => z
 
-data Result E T = Err E | Ok T
+poly succ =
+  \n : Nat => #a => \s : a -> a => \z : a => s (n [a] s z)
+
+poly one =
+  succ zero
+
+poly two =
+  succ one
+
+poly true =
+  #B => \t : B => \f : B => t
+
+poly false =
+  #B => \t : B => \f : B => f
+
+data Result E T =
+  | Err E
+  | Ok T
 
 poly fromResult =
-  #E => #T =>
-  \default : T =>
-  \res : #R -> (E -> R) -> (T -> R) -> R =>
-    match res [T] {
-      | Err e => default
-      | Ok val => val
-    }
+  #E =>
+    #T =>
+      \default : T =>
+        \res : #R -> (E -> R) -> (T -> R) -> R =>
+          match res [T] {
+            | Err e => default
+            | Ok val => val
+          }
 
-poly testOk = fromResult [Bool] [Nat] zero (Ok [Bool] [Nat] two)
-poly testErr = fromResult [Bool] [Nat] zero (Err [Bool] [Nat] false)
+poly testOk =
+  fromResult [Bool] [Nat] zero (Ok [Bool] [Nat] two)
 
-poly main = testOk
+poly testErr =
+  fromResult [Bool] [Nat] zero (Err [Bool] [Nat] false)
+
+poly main =
+  testOk

--- a/test/parser/inputs/church.trip
+++ b/test/parser/inputs/church.trip
@@ -1,11 +1,15 @@
 module Church
 
-type Nat = #X->(X->X)->X->X
+type Nat = #X -> (X -> X) -> X -> X
 
-poly id = #A=>\x:A=>x
+poly id =
+  #A => \x : A => x
 
-combinator complex = S(K(SII))(S(S(KS)K)(K(SII)))
+combinator complex =
+  S (K (SII)) (S (S (KS) K) (K (SII)))
 
-poly two : Nat = succ (succ zero)
+poly two : Nat =
+  succ (succ zero)
 
-poly main : Nat = two
+poly main : Nat =
+  two

--- a/test/parser/inputs/combinatorY.trip
+++ b/test/parser/inputs/combinatorY.trip
@@ -1,3 +1,4 @@
 module CombinatorY
 
-combinator Y = S(K(SII))(S(S(KS)K)(K(SII)))
+combinator Y =
+  S (K (SII)) (S (S (KS) K) (K (SII)))

--- a/test/parser/inputs/comments.trip
+++ b/test/parser/inputs/comments.trip
@@ -1,20 +1,22 @@
 -- Church numerals, with Haskell-style comments sprinkled throughout.
 -- This file is the comment-laden twin of church.trip and must parse to the
 -- exact same AST.
-
-module Church  -- the module name
+module Church
 
 {- Nat is the usual Church encoding of the naturals.
    Block comments may span multiple lines, and they {- nest -} too. -}
-type Nat = #X->(X->X)->X->X  -- forall X. (X -> X) -> X -> X
+type Nat = #X -> (X -> X) -> X -> X
 
-poly id = #A=>\x:A=>x  -- polymorphic identity
+poly id =
+  #A => \x : A => x -- polymorphic identity
 
 -- complex is the body of the Y combinator, written in raw SKI:
-combinator complex = S(K(SII))(S(S(KS)K)(K(SII)))  -- trailing line comment
+combinator complex =
+  S (K (SII)) (S (S (KS) K) (K (SII))) -- trailing line comment
 
-poly two : Nat = succ (succ zero) {- inline block comment -}
+poly two : Nat =
+  succ (succ zero) {- inline block comment -}
 
 {- almost done -}
-poly main : Nat = two
--- a trailing comment with no newline after it
+poly main : Nat =
+  two -- a trailing comment with no newline after it

--- a/test/parser/inputs/dataMaybe.trip
+++ b/test/parser/inputs/dataMaybe.trip
@@ -1,2 +1,5 @@
 module DataMaybe
-data Maybe A = Nothing | Just A
+
+data Maybe A =
+  | Nothing
+  | Just A

--- a/test/parser/inputs/moduleCombo.trip
+++ b/test/parser/inputs/moduleCombo.trip
@@ -1,3 +1,5 @@
 module MyModule
+
 import Foo bar
+
 export Baz

--- a/test/parser/inputs/polyId.trip
+++ b/test/parser/inputs/polyId.trip
@@ -1,3 +1,4 @@
 module PolyId
 
-poly id = #a => \x:a => x
+poly id =
+  #a => \x : a => x

--- a/test/parser/inputs/polyRec.trip
+++ b/test/parser/inputs/polyRec.trip
@@ -1,2 +1,4 @@
 module PolyRec
-poly rec fact = \n : Nat => fact n
+
+poly rec fact =
+  \n : Nat => fact n

--- a/test/parser/inputs/polyWithType.trip
+++ b/test/parser/inputs/polyWithType.trip
@@ -1,7 +1,10 @@
 module PolyWithType
 
-poly id : #a->a->a = #a => \x:a => x
+poly id : #a -> a -> a =
+  #a => \x : a => x
 
-poly const : #a->#b->a->b->a = #a => #b => \x:a => \y:b => x
+poly const : #a -> #b -> a -> b -> a =
+  #a => #b => \x : a => \y : b => x
 
-poly id_no_type = #a => \x:a => x
+poly id_no_type =
+  #a => \x : a => x

--- a/test/parser/inputs/typeNat.trip
+++ b/test/parser/inputs/typeNat.trip
@@ -1,3 +1,3 @@
 module TypeNat
 
-type Nat = #X->(X->X)->X->X
+type Nat = #X -> (X -> X) -> X -> X

--- a/test/parser/inputs/typedInc.trip
+++ b/test/parser/inputs/typedInc.trip
@@ -1,3 +1,4 @@
 module TypedInc
 
-poly inc : Int->Int = \x:Int => plus x 1
+poly inc : Int -> Int =
+  \x : Int => plus x 1

--- a/test/parser/inputs/typedNoType.trip
+++ b/test/parser/inputs/typedNoType.trip
@@ -1,3 +1,4 @@
 module TypedNoType
 
-poly id = \x:Int => x
+poly id =
+  \x : Int => x

--- a/test/test.trip
+++ b/test/test.trip
@@ -1,3 +1,6 @@
 module Test
+
 export id
-poly id = #a => \x:a => x
+
+poly id =
+  #a => \x : a => x

--- a/test/util/inputs/includeNat.trip
+++ b/test/util/inputs/includeNat.trip
@@ -1,6 +1,10 @@
 module Main
+
 import Nat succ
+
 import Nat zero
+
 export main
 
-poly main = succ (succ zero)
+poly main =
+  succ (succ zero)


### PR DESCRIPTION
Add the improvize formatter/linter CLI with shared TripLang scanning, statistical diagnostics, safe lint fixes, and corpus formatting updates.

Also bump the package minor version and keep CLI/path packaging tests aligned with the new tool.