### PR TITLE
add cond, lint for it, lint

### DIFF
--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -135,7 +135,7 @@ data AnfProgram =
   | MkAnfProgram (List AnfFunc) (List U8)
 
 poly tempPrefix =
-  {U8 | '_' '_' 't'}
+  "__t"
 
 poly freshName =
   \counter : Bin => append [U8] tempPrefix (binToDigits counter)
@@ -171,12 +171,12 @@ poly wrapValue =
                 (AE_Var nm)
             | PVal => MkNormResult state binds value
             | PTail =>
-              MkNormResult state (nil [Binding]) (applyBindings binds value)
+              MkNormResult state ({Binding |}) (applyBindings binds value)
           }
 
 poly trivialAt =
   \state : Bin =>
-    \atom : AnfExpr => \pos : Pos => MkNormResult state (nil [Binding]) atom
+    \atom : AnfExpr => \pos : Pos => MkNormResult state ({Binding |}) atom
 
 poly rec atomizeArgs =
   \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
@@ -187,7 +187,7 @@ poly rec atomizeArgs =
             [MiniExpr]
             [AtomList]
             args
-            (MkAtomList state accBinds (nil [AnfExpr]))
+            (MkAtomList state accBinds ({AnfExpr |}))
             (
               \h : MiniExpr =>
                 \t : List MiniExpr =>
@@ -213,7 +213,7 @@ poly rec normArms =
             [MiniExpr]
             [ArmsRes]
             arms
-            (MkArmsRes state (nil [AnfExpr]))
+            (MkArmsRes state ({AnfExpr |}))
             (
               \h : MiniExpr =>
                 \t : List MiniExpr =>
@@ -234,14 +234,14 @@ poly rec norm =
           | ME_Native t => trivialAt state (AE_Native t) pos
           | ME_Lam n body =>
             match (norm state body PTail) [NormResult] {
-              | MkNormResult s1 _ bExpr => wrapValue s1 (nil [Binding]) (AE_Lam n bExpr) pos
+              | MkNormResult s1 _ bExpr => wrapValue s1 ({Binding |}) (AE_Lam n bExpr) pos
             }
           | ME_Call f args =>
-            match (atomizeArgs norm state args (nil [Binding])) [NormResult] {
+            match (atomizeArgs norm state args ({Binding |})) [NormResult] {
               | MkAtomList s1 binds atoms => wrapValue s1 binds (AE_Call f atoms) pos
             }
           | ME_Con tag total arity fields =>
-            match (atomizeArgs norm state fields (nil [Binding])) [NormResult] {
+            match (atomizeArgs norm state fields ({Binding |})) [NormResult] {
               | MkAtomList s1 binds atoms =>
                 wrapValue s1 binds (AE_Con tag total arity atoms) pos
             }
@@ -260,7 +260,7 @@ poly rec norm =
                       | PTail =>
                         MkNormResult
                           s2
-                          (nil [Binding])
+                          ({Binding |})
                           (
                             applyBindings
                               valBinds
@@ -272,7 +272,7 @@ poly rec norm =
           | ME_Match scrut arms =>
             match (norm state scrut PAtom) [NormResult] {
               | MkNormResult s1 scrBinds scrAtom =>
-                match (normArms norm s1 arms (nil [AnfExpr])) [NormResult] {
+                match (normArms norm s1 arms ({AnfExpr |})) [NormResult] {
                   | MkArmsRes s2 normedArms =>
                     wrapValue s2 scrBinds (AE_Case scrAtom normedArms) pos
                 }
@@ -291,7 +291,7 @@ poly rec normalizeFuncs =
       [MiniFunc]
       [List AnfFunc]
       funcs
-      (nil [AnfFunc])
+      ({AnfFunc |})
       (
         \h : MiniFunc =>
           \t : List MiniFunc =>

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -92,23 +92,23 @@ data EmitRes =
   | MkEmitRes Bin (List (List U8)) (List U8)
 
 poly rec lookupEnv =
-  \env : List (Pair (List U8) (List U8)) =>
+  \env : List (((List U8), (List U8))) =>
     \name : List U8 =>
       matchList
-        [Pair (List U8) (List U8)]
+        [((List U8), (List U8))]
         [Maybe (List U8)]
         env
         (None [List U8])
         (
-          \h : Pair (List U8) (List U8) =>
-            \t : List (Pair (List U8) (List U8)) =>
+          \h : ((List U8), (List U8)) =>
+            \t : List (((List U8), (List U8))) =>
               if [Maybe (List U8)] (eqListU8 (fst [List U8] [List U8] h) name)
                 (\u : U8 => Some [List U8] (snd [List U8] [List U8] h))
                 (\u : U8 => lookupEnv t name)
         )
 
 poly atomOperand =
-  \env : List (Pair (List U8) (List U8)) =>
+  \env : List (((List U8), (List U8))) =>
     \e : AnfExpr =>
       match e [Result (List U8) (List U8)] {
         | AE_Var n =>
@@ -127,14 +127,14 @@ poly atomOperand =
       }
 
 poly rec emitArgsString =
-  \env : List (Pair (List U8) (List U8)) =>
+  \env : List (((List U8), (List U8))) =>
     \args : List AnfExpr =>
       \leading : Bool =>
         matchList
           [AnfExpr]
           [Result (List U8) (List U8)]
           args
-          (Ok [List U8] [List U8] (nil [U8]))
+          (Ok [List U8] [List U8] (""))
           (
             \h : AnfExpr =>
               \t : List AnfExpr =>
@@ -150,7 +150,7 @@ poly rec emitArgsString =
           )
 
 poly rec emitExpr =
-  \env : List (Pair (List U8) (List U8)) =>
+  \env : List (((List U8), (List U8))) =>
     \counter : Bin =>
       \instrs : List (List U8) =>
         \e : AnfExpr =>
@@ -191,8 +191,8 @@ poly rec emitExpr =
                       emitExpr
                         (
                           cons
-                            [Pair (List U8) (List U8)]
-                            (MkPair [List U8] [List U8] name vop)
+                            [((List U8), (List U8))]
+                            ({List U8, List U8 | name, vop})
                             env
                         )
                         c1
@@ -209,7 +209,7 @@ poly rec paramDeclsString =
         [List U8]
         [List U8]
         params
-        (nil [U8])
+        ("")
         (
           \h : List U8 =>
             \t : List (List U8) =>
@@ -221,15 +221,15 @@ poly rec paramEnv =
   \params : List (List U8) =>
     matchList
       [List U8]
-      [List (Pair (List U8) (List U8))]
+      [List (((List U8), (List U8)))]
       params
-      (nil [Pair (List U8) (List U8)])
+      ({Pair (List U8) (List U8) |})
       (
         \h : List U8 =>
           \t : List (List U8) =>
             cons
-              [Pair (List U8) (List U8)]
-              (MkPair [List U8] [List U8] h (append [U8] "%" h))
+              [((List U8), (List U8))]
+              ({List U8, List U8 | h, (append [U8] "%" h)})
               (paramEnv t)
       )
 
@@ -247,12 +247,12 @@ poly emitFunc =
   \fn : AnfFunc =>
     match fn [Result (List U8) (List U8)] {
       | MkAnfFunc name params body =>
-        match (emitExpr (paramEnv params) BZ (nil [List U8]) body) [Result (List U8) (List U8)] {
+        match (emitExpr (paramEnv params) BZ ({List U8 |}) body) [Result (List U8) (List U8)] {
           | Err e => Err [List U8] [List U8] e
           | Ok res =>
             match res [Result (List U8) (List U8)] {
               | MkEmitRes c instrs op =>
-                let instrText = joinLines (nil [U8]) instrs in
+                let instrText = joinLines ("") instrs in
                 Ok
                   [List U8]
                   [List U8]
@@ -302,7 +302,7 @@ poly rec emitFuncs =
       [AnfFunc]
       [Result (List U8) (List U8)]
       fns
-      (Ok [List U8] [List U8] (nil [U8]))
+      (Ok [List U8] [List U8] (""))
       (
         \h : AnfFunc =>
           \t : List AnfFunc =>

--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -240,64 +240,53 @@ poly rec lteListU8 =
 
 poly resolveNativeName =
   \name : List U8 =>
-    if [Maybe Lower] (eqListU8 name ".")
-      (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-      (
-        \u : U8 =>
-          if [Maybe Lower] (eqListU8 name ",")
-            (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-            (
-              \u : U8 =>
-                if [Maybe Lower] (eqListU8 name "writeOne")
-                  (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-                  (
-                    \u : U8 =>
-                      if [Maybe Lower] (eqListU8 name "readOne")
-                        (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-                        (
-                          \u : U8 =>
-                            if [Maybe Lower] (eqListU8 name "addU8")
-                              (\u : U8 => Some [Lower] (L_Native T_AddU8))
-                              (
-                                \u : U8 =>
-                                  if [Maybe Lower] (eqListU8 name "subU8")
-                                    (\u : U8 => Some [Lower] (L_Native T_SubU8))
-                                    (
-                                      \u : U8 =>
-                                        if [Maybe Lower] (eqListU8 name "divU8")
-                                          (
-                                            \u : U8 => Some [Lower] (L_Native T_DivU8)
-                                          )
-                                          (
-                                            \u : U8 =>
-                                              if [Maybe Lower] (eqListU8 name "modU8")
-                                                (
-                                                  \u : U8 => Some [Lower] (L_Native T_ModU8)
-                                                )
-                                                (
-                                                  \u : U8 =>
-                                                    if [Maybe Lower] (eqListU8 name "eqU8")
-                                                      (
-                                                        \u : U8 => Some [Lower] (L_Native T_EqU8)
-                                                      )
-                                                      (
-                                                        \u : U8 =>
-                                                          if [Maybe Lower] (eqListU8 name "ltU8")
-                                                            (
-                                                              \u : U8 => Some [Lower] (L_Native T_LtU8)
-                                                            )
-                                                            (
-                                                              \u : U8 => None [Lower]
-                                                            )
-                                                      )
-                                                )
-                                          )
-                                    )
-                              )
-                        )
-                  )
-            )
-      )
+    cond
+      [Maybe Lower]
+      {|
+        (eqListU8 name ".") =>
+        Some
+        [Lower]
+        (L_Native T_WriteOne) |
+        (eqListU8 name ",") =>
+        Some
+        [Lower]
+        (L_Native T_ReadOne) |
+        (eqListU8 name "writeOne") =>
+        Some
+        [Lower]
+        (L_Native T_WriteOne) |
+        (eqListU8 name "readOne") =>
+        Some
+        [Lower]
+        (L_Native T_ReadOne) |
+        (eqListU8 name "addU8") =>
+        Some
+        [Lower]
+        (L_Native T_AddU8) |
+        (eqListU8 name "subU8") =>
+        Some
+        [Lower]
+        (L_Native T_SubU8) |
+        (eqListU8 name "divU8") =>
+        Some
+        [Lower]
+        (L_Native T_DivU8) |
+        (eqListU8 name "modU8") =>
+        Some
+        [Lower]
+        (L_Native T_ModU8) |
+        (eqListU8 name "eqU8") =>
+        Some
+        [Lower]
+        (L_Native T_EqU8) |
+        (eqListU8 name "ltU8") =>
+        Some
+        [Lower]
+        (L_Native T_LtU8) |
+        otherwise =>
+        None
+        [Lower]
+      }
 
 poly unboundNameError =
   \name : List U8 => append [U8] "Unbound variable: " name
@@ -318,7 +307,7 @@ poly rec trimLeadingZeros =
       [U8]
       [List U8]
       digits
-      (nil [U8])
+      ("")
       (
         \h : U8 =>
           \t : List U8 =>
@@ -386,9 +375,9 @@ poly rec div2DigitsAcc =
         \accRev : List U8 =>
           matchList
             [U8]
-            [Pair (List U8) U8]
+            [((List U8), U8)]
             digits
-            (MkPair [List U8] [U8] (reverse [U8] accRev) carry)
+            ({List U8, U8 | (reverse [U8] accRev), carry})
             (
               \h : U8 =>
                 \t : List U8 =>
@@ -401,12 +390,12 @@ poly rec div2DigitsAcc =
             )
 
 poly div2Digits =
-  \digits : List U8 => div2DigitsAcc digits #u8(0) false (nil [U8])
+  \digits : List U8 => div2DigitsAcc digits #u8(0) false ("")
 
 poly rec collectBits =
   \digits : List U8 =>
     \acc : List U8 =>
-      match (div2Digits digits) [Pair (List U8) U8] {
+      match (div2Digits digits) [((List U8), U8)] {
         | MkPair quotient remainder =>
           let nextAcc = cons [U8] remainder acc in
           matchList
@@ -459,8 +448,7 @@ poly rec buildBinLiteralCoreAcc =
         )
 
 poly buildBinLiteralCore =
-  \digits : List U8 =>
-    buildBinLiteralCoreAcc (collectBits digits (nil [U8])) binZeroCore
+  \digits : List U8 => buildBinLiteralCoreAcc (collectBits digits ("")) binZeroCore
 
 poly natToCore =
   \digits : List U8 =>
@@ -503,15 +491,15 @@ poly resolveCoreName =
 
 poly rec findCtorInfoInArms =
   \dEnv : DataEnv =>
-    \arms : List (Pair Pattern Expr) =>
+    \arms : List ((Pattern, Expr)) =>
       matchList
-        [Pair Pattern Expr]
+        [(Pattern, Expr)]
         [Maybe CtorInfo]
         arms
         (None [CtorInfo])
         (
-          \h : Pair Pattern Expr =>
-            \t : List (Pair Pattern Expr) =>
+          \h : (Pattern, Expr) =>
+            \t : List ((Pattern, Expr)) =>
               match (fst [Pattern] [Expr] h) [Maybe CtorInfo] {
                 | P_Ctor name args =>
                   match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Maybe CtorInfo] {
@@ -523,24 +511,18 @@ poly rec findCtorInfoInArms =
 
 poly rec findArmByName =
   \name : List U8 =>
-    \arms : List (Pair Pattern Expr) =>
+    \arms : List ((Pattern, Expr)) =>
       matchList
-        [Pair Pattern Expr]
-        [Pair Pattern Expr]
+        [(Pattern, Expr)]
+        [(Pattern, Expr)]
         arms
+        ({Pattern, Expr | (P_Ctor name (nil [List U8])), (E_Var "MISSING_ARM")})
         (
-          MkPair
-            [Pattern]
-            [Expr]
-            (P_Ctor name (nil [List U8]))
-            (E_Var "MISSING_ARM")
-        )
-        (
-          \h : Pair Pattern Expr =>
-            \t : List (Pair Pattern Expr) =>
-              match (fst [Pattern] [Expr] h) [Pair Pattern Expr] {
+          \h : (Pattern, Expr) =>
+            \t : List ((Pattern, Expr)) =>
+              match (fst [Pattern] [Expr] h) [(Pattern, Expr)] {
                 | P_Ctor cName args =>
-                  if [Pair Pattern Expr] (eqListU8 name cName)
+                  if [(Pattern, Expr)] (eqListU8 name cName)
                     (\u : U8 => h)
                     (\u : U8 => findArmByName name t)
               }
@@ -548,17 +530,17 @@ poly rec findArmByName =
 
 poly rec sortArms =
   \expectedNames : List (List U8) =>
-    \arms : List (Pair Pattern Expr) =>
+    \arms : List ((Pattern, Expr)) =>
       matchList
         [List U8]
-        [List (Pair Pattern Expr)]
+        [List ((Pattern, Expr))]
         expectedNames
-        (nil [Pair Pattern Expr])
+        ({Pair Pattern Expr |})
         (
           \name : List U8 =>
             \tNames : List (List U8) =>
               let arm = findArmByName name arms in
-              cons [Pair Pattern Expr] arm (sortArms tNames arms)
+              cons [(Pattern, Expr)] arm (sortArms tNames arms)
         )
 
 poly rec wrapInLambdas =
@@ -585,15 +567,15 @@ poly rec prependAll =
 poly rec elaborateArms =
   \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
     \dEnv : DataEnv =>
-      \arms : List (Pair Pattern Expr) =>
+      \arms : List ((Pattern, Expr)) =>
         matchList
-          [Pair Pattern Expr]
+          [(Pattern, Expr)]
           [Result (List U8) (List Core)]
           arms
-          (Ok [List U8] [List Core] (nil [Core]))
+          (Ok [List U8] [List Core] ({Core |}))
           (
-            \h : Pair Pattern Expr =>
-              \t : List (Pair Pattern Expr) =>
+            \h : (Pattern, Expr) =>
+              \t : List ((Pattern, Expr)) =>
                 match h [Result (List U8) (List Core)] {
                   | MkPair pat body =>
                     match pat [Result (List U8) (List Core)] {
@@ -619,7 +601,7 @@ poly elaborateMatchWith =
   \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
     \dEnv : DataEnv =>
       \scrut : Expr =>
-        \arms : List (Pair Pattern Expr) =>
+        \arms : List ((Pattern, Expr)) =>
           match (elaborate dEnv scrut) [Result (List U8) Core] {
             | Err e => Err [List U8] [Core] e
             | Ok coreScrut =>
@@ -699,18 +681,18 @@ poly rec checkedLengthU8 =
 
 poly rec populateDataEnv =
   \adtName : List U8 =>
-    \ctors : List (Pair (List U8) U8) =>
+    \ctors : List (((List U8), U8)) =>
       \total : U8 =>
         \idx : U8 =>
           \datEnv : DataEnv =>
             matchList
-              [Pair (List U8) U8]
+              [((List U8), U8)]
               [DataEnv]
               ctors
               datEnv
               (
-                \h : Pair (List U8) U8 =>
-                  \t : List (Pair (List U8) U8) =>
+                \h : ((List U8), U8) =>
+                  \t : List (((List U8), U8)) =>
                     let ctorName = fst [List U8] [U8] h in
                     let arity = snd [List U8] [U8] h in
                     let info = MkCtorInfo idx total arity adtName in
@@ -727,15 +709,15 @@ poly rec populateDataEnv =
               )
 
 poly rec getCtorNames =
-  \ctors : List (Pair (List U8) U8) =>
+  \ctors : List (((List U8), U8)) =>
     matchList
-      [Pair (List U8) U8]
+      [((List U8), U8)]
       [List (List U8)]
       ctors
-      (nil [List U8])
+      ({List U8 |})
       (
-        \h : Pair (List U8) U8 =>
-          \t : List (Pair (List U8) U8) => cons [List U8] (fst [List U8] [U8] h) (getCtorNames t)
+        \h : ((List U8), U8) =>
+          \t : List (((List U8), U8)) => cons [List U8] (fst [List U8] [U8] h) (getCtorNames t)
       )
 
 poly rec filterElaboratableDecls =
@@ -744,7 +726,7 @@ poly rec filterElaboratableDecls =
       [Decl]
       [List Decl]
       decls
-      (nil [Decl])
+      ({Decl |})
       (
         \h : Decl =>
           \t : List Decl =>
@@ -771,7 +753,7 @@ poly elaborateElaboratableDecl =
               match (elaborateExpr dEnv body) [Result (List U8) State] {
                 | Err e => Err [List U8] [State] e
                 | Ok core =>
-                  let finalLow = if [Lower] isRec (\u : U8 => applyFixpoint (coreToLower globals (nil [List U8]) recName core)) (\u : U8 => coreToLower globals (nil [List U8]) recName core) in
+                  let finalLow = if [Lower] isRec (\u : U8 => applyFixpoint (coreToLower globals ({List U8 |}) recName core)) (\u : U8 => coreToLower globals ({List U8 |}) recName core) in
                   Ok
                     [List U8]
                     [State]
@@ -790,7 +772,7 @@ poly elaborateElaboratableDecl =
                     )
               }
             | D_Data name ctors =>
-              match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) State] {
+              match (checkedLengthU8 [((List U8), U8)] ctors #u8(0)) [Result (List U8) State] {
                 | Err e => Err [List U8] [State] e
                 | Ok total =>
                   let nextDEnv = populateDataEnv name ctors total #u8(0) dEnv in
@@ -842,36 +824,36 @@ poly rec elaborateToCoreRec =
     \decls : List Decl =>
       matchList
         [Decl]
-        [Result (List U8) (List (Pair (List U8) Core))]
+        [Result (List U8) (List (((List U8), Core)))]
         decls
-        (Ok [List U8] [List (Pair (List U8) Core)] (nil [Pair (List U8) Core]))
+        (Ok [List U8] [List (((List U8), Core))] ({Pair (List U8) Core |}))
         (
           \h : Decl =>
             \t : List Decl =>
-              match h [Result (List U8) (List (Pair (List U8) Core))] {
+              match h [Result (List U8) (List (((List U8), Core)))] {
                 | D_Def kind isRec name body =>
-                  match (elaborateExpr dEnv body) [Result (List U8) (List (Pair (List U8) Core))] {
-                    | Err e => Err [List U8] [List (Pair (List U8) Core)] e
+                  match (elaborateExpr dEnv body) [Result (List U8) (List (((List U8), Core)))] {
+                    | Err e => Err [List U8] [List (((List U8), Core))] e
                     | Ok core =>
-                      match (elaborateToCoreRec dEnv t) [Result (List U8) (List (Pair (List U8) Core))] {
-                        | Err e2 => Err [List U8] [List (Pair (List U8) Core)] e2
+                      match (elaborateToCoreRec dEnv t) [Result (List U8) (List (((List U8), Core)))] {
+                        | Err e2 => Err [List U8] [List (((List U8), Core))] e2
                         | Ok rest =>
                           Ok
                             [List U8]
-                            [List (Pair (List U8) Core)]
+                            [List (((List U8), Core))]
                             (
                               cons
-                                [Pair (List U8) Core]
-                                (MkPair [List U8] [Core] name core)
+                                [((List U8), Core)]
+                                ({List U8, Core | name, core})
                                 rest
                             )
                       }
                   }
                 | D_Data name ctors =>
-                  match (checkedLengthU8 [Pair (List U8) U8] ctors #u8(0)) [Result (List U8) (List (Pair (List U8) Core))] {
-                    | Err e => Err [List U8] [List (Pair (List U8) Core)] e
+                  match (checkedLengthU8 [((List U8), U8)] ctors #u8(0)) [Result (List U8) (List (((List U8), Core)))] {
+                    | Err e => Err [List U8] [List (((List U8), Core))] e
                     | Ok total =>
-                      match (populateDataEnv name ctors total #u8(0) dEnv) [Result (List U8) (List (Pair (List U8) Core))] {
+                      match (populateDataEnv name ctors total #u8(0) dEnv) [Result (List U8) (List (((List U8), Core)))] {
                         | MkDataEnv cEnv aEnv =>
                           let adtInfo = MkADTInfo (getCtorNames ctors) in
                           let nextDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv) in

--- a/bootstrap/src/bundleInventory.trip
+++ b/bootstrap/src/bundleInventory.trip
@@ -110,15 +110,15 @@ export main
 
 poly rec lookupMod =
   \key : List U8 =>
-    \table : List (Pair (List U8) (List Decl)) =>
+    \table : List (((List U8), (List Decl))) =>
       matchList
-        [(Pair (List U8) (List Decl))]
+        [(((List U8), (List Decl)))]
         [Maybe (List Decl)]
         table
         (None [List Decl])
         (
-          \h : (Pair (List U8) (List Decl)) =>
-            \t : List (Pair (List U8) (List Decl)) =>
+          \h : (((List U8), (List Decl))) =>
+            \t : List (((List U8), (List Decl))) =>
               if [Maybe (List Decl)] (eqListU8 (fst [List U8] [List Decl] h) key)
                 (\u : U8 => Some [List Decl] (snd [List U8] [List Decl] h))
                 (\u : U8 => lookupMod key t)
@@ -126,15 +126,15 @@ poly rec lookupMod =
 
 poly rec lookupExp =
   \key : List U8 =>
-    \table : List (Pair (List U8) (List (List U8))) =>
+    \table : List (((List U8), (List (List U8)))) =>
       matchList
-        [(Pair (List U8) (List (List U8)))]
+        [(((List U8), (List (List U8))))]
         [Maybe (List (List U8))]
         table
         (None [List (List U8)])
         (
-          \h : (Pair (List U8) (List (List U8))) =>
-            \t : List (Pair (List U8) (List (List U8))) =>
+          \h : (((List U8), (List (List U8)))) =>
+            \t : List (((List U8), (List (List U8)))) =>
               if [Maybe (List (List U8))] (eqListU8 (fst [List U8] [List (List U8)] h) key)
                 (
                   \u : U8 => Some [List (List U8)] (snd [List U8] [List (List U8)] h)
@@ -144,21 +144,21 @@ poly rec lookupExp =
 
 poly rec removeExpEntry =
   \k : List U8 =>
-    \tbl : List (Pair (List U8) (List (List U8))) =>
+    \tbl : List (((List U8), (List (List U8)))) =>
       matchList
-        [(Pair (List U8) (List (List U8)))]
-        [List (Pair (List U8) (List (List U8)))]
+        [(((List U8), (List (List U8))))]
+        [List (((List U8), (List (List U8))))]
         tbl
-        (nil [(Pair (List U8) (List (List U8)))])
+        ({(Pair (List U8) (List (List U8))) |})
         (
-          \hh : (Pair (List U8) (List (List U8))) =>
-            \tt : List (Pair (List U8) (List (List U8))) =>
-              if [List (Pair (List U8) (List (List U8)))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
+          \hh : (((List U8), (List (List U8)))) =>
+            \tt : List (((List U8), (List (List U8)))) =>
+              if [List (((List U8), (List (List U8))))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
                 (\u : U8 => tt)
                 (
                   \u : U8 =>
                     cons
-                      [(Pair (List U8) (List (List U8)))]
+                      [(((List U8), (List (List U8))))]
                       hh
                       (removeExpEntry k tt)
                 )
@@ -167,18 +167,18 @@ poly rec removeExpEntry =
 poly rec updateGlobalTable =
   \exports : List (List U8) =>
     \modName : List U8 =>
-      \table : List (Pair (List U8) (List (List U8))) =>
+      \table : List (((List U8), (List (List U8)))) =>
         matchList
           [List U8]
-          [List (Pair (List U8) (List (List U8)))]
+          [List (((List U8), (List (List U8))))]
           exports
           table
           (
             \h : List U8 =>
               \t : List (List U8) =>
                 let current = lookupExp h table in
-                let nextList = match current [List (List U8)] {| None => cons [List U8] modName (nil [List U8]) | Some mods => append [List U8] mods (cons [List U8] modName (nil [List U8]))} in
-                let nextTable = cons [(Pair (List U8) (List (List U8)))] (MkPair [List U8] [List (List U8)] h nextList) (removeExpEntry h table) in
+                let nextList = match current [List (List U8)] {| None => {List U8 | modName} | Some mods => append [List U8] mods ({List U8 | modName})} in
+                let nextTable = cons [(((List U8), (List (List U8))))] ({List U8, List (List U8) | h, nextList}) (removeExpEntry h table) in
                 updateGlobalTable t modName nextTable
           )
 
@@ -207,55 +207,53 @@ poly rec collectModuleExports =
 
 poly rec populateInventoryAcc =
   \mods : List ModuleRecord =>
-    \modTable : List (Pair (List U8) (List Decl)) =>
-      \expTable : List (Pair (List U8) (List (List U8))) =>
+    \modTable : List (((List U8), (List Decl))) =>
+      \expTable : List (((List U8), (List (List U8)))) =>
         matchList
           [ModuleRecord]
-          [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))]
+          [Result (List U8) (((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8))))))]
           mods
           (
             Ok
               [List U8]
-              [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+              [((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8)))))]
               (
-                MkPair
-                  [List (Pair (List U8) (List Decl))]
-                  [List (Pair (List U8) (List (List U8)))]
-                  modTable
+                {List (Pair (List U8) (List Decl)), List (Pair (List U8) (List (List U8))) |
+                  modTable,
                   expTable
+                }
               )
           )
           (
             \h : ModuleRecord =>
               \t : List ModuleRecord =>
-                match h [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                match h [Result (List U8) (((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8))))))] {
                   | MkModuleRecord name _ source =>
-                    match (tokenize source) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                    match (tokenize source) [Result (List U8) (((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8))))))] {
                       | Err e =>
                         Err
                           [List U8]
-                          [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+                          [((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8)))))]
                           "Parse error"
                       | Ok toks =>
-                        match (parseProgram toks) [Result (List U8) (Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8)))))] {
+                        match (parseProgram toks) [Result (List U8) (((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8))))))] {
                           | Err e =>
                             Err
                               [List U8]
-                              [Pair (List (Pair (List U8) (List Decl))) (List (Pair (List U8) (List (List U8))))]
+                              [((List (Pair (List U8) (List Decl))), (List (Pair (List U8) (List (List U8)))))]
                               "Parse error"
                           | Ok decls =>
-                            let exports = collectModuleExports decls (nil [List U8]) in
+                            let exports = collectModuleExports decls ({List U8 |}) in
                             populateInventoryAcc
                               t
                               (
                                 append
-                                  [(Pair (List U8) (List Decl))]
+                                  [(((List U8), (List Decl)))]
                                   modTable
                                   (
-                                    cons
-                                      [(Pair (List U8) (List Decl))]
+                                    {(Pair (List U8) (List Decl)) |
                                       (MkPair [List U8] [List Decl] name decls)
-                                      (nil [(Pair (List U8) (List Decl))])
+                                    }
                                   )
                               )
                               (updateGlobalTable exports name expTable)
@@ -266,8 +264,8 @@ poly rec populateInventoryAcc =
 
 poly populateInventory =
   \mods : List ModuleRecord =>
-    \modTable : List (Pair (List U8) (List Decl)) =>
-      \expTable : List (Pair (List U8) (List (List U8))) => populateInventoryAcc mods modTable expTable
+    \modTable : List (((List U8), (List Decl))) =>
+      \expTable : List (((List U8), (List (List U8)))) => populateInventoryAcc mods modTable expTable
 
 poly rec symbolInList =
   \symbolName : List U8 =>
@@ -288,25 +286,25 @@ poly rec symbolInList =
 poly isExported =
   \modName : List U8 =>
     \symbolName : List U8 =>
-      \modTable : List (Pair (List U8) (List Decl)) =>
+      \modTable : List (((List U8), (List Decl))) =>
         match (lookupMod modName modTable) [Bool] {
           | None => false
           | Some decls =>
-            let exports = collectModuleExports decls (nil [List U8]) in
+            let exports = collectModuleExports decls ({List U8 |}) in
             symbolInList symbolName exports
         }
 
 poly rec ctorNameInList =
   \name : List U8 =>
-    \cs : List (Pair (List U8) U8) =>
+    \cs : List (((List U8), U8)) =>
       matchList
-        [(Pair (List U8) U8)]
+        [(((List U8), U8))]
         [Bool]
         cs
         false
         (
-          \h : (Pair (List U8) U8) =>
-            \t : List (Pair (List U8) U8) =>
+          \h : (((List U8), U8)) =>
+            \t : List (((List U8), U8)) =>
               if [Bool] (eqListU8 (fst [List U8] [U8] h) name)
                 (\u : U8 => true)
                 (\u : U8 => ctorNameInList name t)
@@ -332,7 +330,7 @@ poly rec isDefined =
 poly emitImportStatus =
   \from : List U8 =>
     \symbol : List U8 =>
-      \modTable : List (Pair (List U8) (List Decl)) =>
+      \modTable : List (((List U8), (List Decl))) =>
         match (lookupMod from modTable) [List U8] {
           | None => "MISSING_MODULE"
           | Some decls =>
@@ -343,7 +341,7 @@ poly emitImportStatus =
 
 poly emitExportStatus =
   \symbol : List U8 =>
-    \expTable : List (Pair (List U8) (List (List U8))) =>
+    \expTable : List (((List U8), (List (List U8)))) =>
       \decls : List Decl =>
         match (lookupExp symbol expTable) [List U8] {
           | None => "OK"
@@ -388,7 +386,7 @@ poly rec filterDeclsAcc =
           )
 
 poly filterDecls =
-  \kind : U8 => \decls : List Decl => filterDeclsAcc kind decls (nil [Decl])
+  \kind : U8 => \decls : List Decl => filterDeclsAcc kind decls ({Decl |})
 
 poly rec countList =
   #A =>
@@ -403,7 +401,7 @@ poly rec countList =
 
 poly rec emitImportsSummary =
   \decls : List Decl =>
-    \modTable : List (Pair (List U8) (List Decl)) =>
+    \modTable : List (((List U8), (List Decl))) =>
       matchList
         [Decl]
         [List U8]
@@ -460,7 +458,7 @@ poly rec emitImportsSummary =
 
 poly rec emitExportsSummary =
   \decls : List Decl =>
-    \expTable : List (Pair (List U8) (List (List U8))) =>
+    \expTable : List (((List U8), (List (List U8)))) =>
       \allDecls : List Decl =>
         matchList
           [Decl]
@@ -507,15 +505,15 @@ poly rec emitExportsSummary =
           )
 
 poly rec emitCtors =
-  \cs : List (Pair (List U8) U8) =>
+  \cs : List (((List U8), U8)) =>
     matchList
-      [(Pair (List U8) U8)]
+      [(((List U8), U8))]
       [List U8]
       cs
       ""
       (
-        \h : (Pair (List U8) U8) =>
-          \t : List (Pair (List U8) U8) =>
+        \h : (((List U8), U8)) =>
+          \t : List (((List U8), U8)) =>
             append
               [U8]
               "ctor "
@@ -670,8 +668,8 @@ poly rec getDeclared =
 poly emitModuleInventory =
   \name : List U8 =>
     \decls : List Decl =>
-      \modTable : List (Pair (List U8) (List Decl)) =>
-        \expTable : List (Pair (List U8) (List (List U8))) =>
+      \modTable : List (((List U8), (List Decl))) =>
+        \expTable : List (((List U8), (List (List U8)))) =>
           let declared = getDeclared decls in
           let imps = filterDecls #u8(1) decls in
           let exps = filterDecls #u8(2) decls in
@@ -786,8 +784,8 @@ poly emitModuleInventory =
 
 poly rec emitInventorySummary =
   \mods : List ModuleRecord =>
-    \modTable : List (Pair (List U8) (List Decl)) =>
-      \expTable : List (Pair (List U8) (List (List U8))) =>
+    \modTable : List (((List U8), (List Decl))) =>
+      \expTable : List (((List U8), (List (List U8)))) =>
         matchList
           [ModuleRecord]
           [List U8]
@@ -820,7 +818,7 @@ poly main =
       | Ok bundle =>
         match bundle [U8] {
           | MkBundleSummary entry target wrapper modsCountDigits mods =>
-            match (populateInventory mods (nil [(Pair (List U8) (List Decl))]) (nil [(Pair (List U8) (List (List U8)))])) [U8] {
+            match (populateInventory mods ({(Pair (List U8) (List Decl)) |}) ({(Pair (List U8) (List (List U8))) |})) [U8] {
               | Err e => writeAll (append [U8] "ERR:" (append [U8] e "\n"))
               | Ok inv =>
                 match inv [U8] {

--- a/bootstrap/src/bundleParseSummary.trip
+++ b/bootstrap/src/bundleParseSummary.trip
@@ -470,7 +470,7 @@ poly rec emitImportsAcc =
         )
 
 poly emitImports =
-  \decls : List Decl => emitImportsAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitImportsAcc (reverse [Decl] decls) ("")
 
 poly rec emitExportsAcc =
   \decls : List Decl =>
@@ -499,29 +499,29 @@ poly rec emitExportsAcc =
         )
 
 poly emitExports =
-  \decls : List Decl => emitExportsAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitExportsAcc (reverse [Decl] decls) ("")
 
 poly emitCtor =
-  \ctor : Pair (List U8) U8 =>
+  \ctor : ((List U8), U8) =>
     let name = fst [List U8] [U8] ctor in
     let arity = snd [List U8] [U8] ctor in
     emitNameCountLine prefixCtor name arity
 
 poly rec emitCtorsAcc =
-  \ctors : List (Pair (List U8) U8) =>
+  \ctors : List (((List U8), U8)) =>
     \acc : List U8 =>
       matchList
-        [Pair (List U8) U8]
+        [((List U8), U8)]
         [List U8]
         ctors
         acc
         (
-          \h : Pair (List U8) U8 =>
-            \t : List (Pair (List U8) U8) => emitCtorsAcc t (append [U8] (emitCtor h) acc)
+          \h : ((List U8), U8) =>
+            \t : List (((List U8), U8)) => emitCtorsAcc t (append [U8] (emitCtor h) acc)
         )
 
 poly emitCtors =
-  \ctors : List (Pair (List U8) U8) => emitCtorsAcc (reverse [Pair (List U8) U8] ctors) (nil [U8])
+  \ctors : List (((List U8), U8)) => emitCtorsAcc (reverse [((List U8), U8)] ctors) ("")
 
 poly rec emitDataDefsAcc =
   \decls : List Decl =>
@@ -552,7 +552,7 @@ poly rec emitDataDefsAcc =
         )
 
 poly emitDataDefs =
-  \decls : List Decl => emitDataDefsAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitDataDefsAcc (reverse [Decl] decls) ("")
 
 poly rec emitTypesAcc =
   \decls : List Decl =>
@@ -581,7 +581,7 @@ poly rec emitTypesAcc =
         )
 
 poly emitTypes =
-  \decls : List Decl => emitTypesAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitTypesAcc (reverse [Decl] decls) ("")
 
 poly rec emitOpaquesAcc =
   \decls : List Decl =>
@@ -610,7 +610,7 @@ poly rec emitOpaquesAcc =
         )
 
 poly emitOpaques =
-  \decls : List Decl => emitOpaquesAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitOpaquesAcc (reverse [Decl] decls) ("")
 
 poly rec emitNativesAcc =
   \decls : List Decl =>
@@ -639,7 +639,7 @@ poly rec emitNativesAcc =
         )
 
 poly emitNatives =
-  \decls : List Decl => emitNativesAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitNativesAcc (reverse [Decl] decls) ("")
 
 poly rec emitPolyDefsAcc =
   \decls : List Decl =>
@@ -673,7 +673,7 @@ poly rec emitPolyDefsAcc =
         )
 
 poly emitPolyDefs =
-  \decls : List Decl => emitPolyDefsAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitPolyDefsAcc (reverse [Decl] decls) ("")
 
 poly rec emitCombinatorDefsAcc =
   \decls : List Decl =>
@@ -712,7 +712,7 @@ poly rec emitCombinatorDefsAcc =
         )
 
 poly emitCombinatorDefs =
-  \decls : List Decl => emitCombinatorDefsAcc (reverse [Decl] decls) (nil [U8])
+  \decls : List Decl => emitCombinatorDefsAcc (reverse [Decl] decls) ("")
 
 poly parseModuleSource =
   \bundleName : List U8 =>
@@ -777,7 +777,7 @@ poly rec emitParsedModules =
       [ModuleRecord]
       [Result (List U8) (List U8)]
       recs
-      (Ok [List U8] [List U8] (nil [U8]))
+      (Ok [List U8] [List U8] (""))
       (
         \h : ModuleRecord =>
           \t : List ModuleRecord =>

--- a/bootstrap/src/bundleSummary.trip
+++ b/bootstrap/src/bundleSummary.trip
@@ -205,24 +205,32 @@ poly rec readLineAcc =
         [U8]
         [Result (List U8) Line]
         input
-        (Ok [List U8] [Line] (MkLine (reverse [U8] acc) (nil [U8])))
+        (Ok [List U8] [Line] (MkLine (reverse [U8] acc) ("")))
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Result (List U8) Line] (not (isAscii h))
-                (\u : U8 => Err [List U8] [Line] "non-ascii byte")
-                (
-                  \u : U8 =>
-                    if [Result (List U8) Line] (eqU8 h '\n')
-                      (
-                        \u : U8 => Ok [List U8] [Line] (MkLine (reverse [U8] acc) t)
-                      )
-                      (\u : U8 => readLineAcc t (cons [U8] h acc))
-                )
+              cond
+                [Result (List U8) Line]
+                {|
+                  (not (isAscii h)) =>
+                  Err
+                  [List U8]
+                  [Line]
+                  "non-ascii byte" |
+                  (eqU8 h '\n') =>
+                  Ok
+                  [List U8]
+                  [Line]
+                  (MkLine (reverse [U8] acc) t) |
+                  otherwise =>
+                  readLineAcc
+                  t
+                  (cons [U8] h acc)
+                }
         )
 
 poly readLine =
-  \input : List U8 => readLineAcc input (nil [U8])
+  \input : List U8 => readLineAcc input ("")
 
 poly rec stripPrefix =
   \prefix : List U8 =>
@@ -279,7 +287,7 @@ poly rec readWordAcc =
         [U8]
         [Word]
         input
-        (MkWord (reverse [U8] acc) (nil [U8]))
+        (MkWord (reverse [U8] acc) (""))
         (
           \h : U8 =>
             \t : List U8 =>
@@ -289,53 +297,34 @@ poly rec readWordAcc =
         )
 
 poly readWord =
-  \input : List U8 => readWordAcc input (nil [U8])
+  \input : List U8 => readWordAcc input ("")
 
 poly rec decimalDigitValue =
   \digit : U8 =>
-    if [Bin] (eqU8 digit '0')
-      (\u : U8 => BZ)
-      (
-        \u : U8 =>
-          if [Bin] (eqU8 digit '1')
-            (\u : U8 => binOne)
-            (
-              \u : U8 =>
-                if [Bin] (eqU8 digit '2')
-                  (\u : U8 => binTwo)
-                  (
-                    \u : U8 =>
-                      if [Bin] (eqU8 digit '3')
-                        (\u : U8 => binThree)
-                        (
-                          \u : U8 =>
-                            if [Bin] (eqU8 digit '4')
-                              (\u : U8 => binFour)
-                              (
-                                \u : U8 =>
-                                  if [Bin] (eqU8 digit '5')
-                                    (\u : U8 => binFive)
-                                    (
-                                      \u : U8 =>
-                                        if [Bin] (eqU8 digit '6')
-                                          (\u : U8 => binSix)
-                                          (
-                                            \u : U8 =>
-                                              if [Bin] (eqU8 digit '7')
-                                                (\u : U8 => binSeven)
-                                                (
-                                                  \u : U8 =>
-                                                    if [Bin] (eqU8 digit '8')
-                                                      (\u : U8 => binEight)
-                                                      (\u : U8 => binNine)
-                                                )
-                                          )
-                                    )
-                              )
-                        )
-                  )
-            )
-      )
+    cond
+      [Bin]
+      {|
+        (eqU8 digit '0') =>
+        BZ |
+        (eqU8 digit '1') =>
+        binOne |
+        (eqU8 digit '2') =>
+        binTwo |
+        (eqU8 digit '3') =>
+        binThree |
+        (eqU8 digit '4') =>
+        binFour |
+        (eqU8 digit '5') =>
+        binFive |
+        (eqU8 digit '6') =>
+        binSix |
+        (eqU8 digit '7') =>
+        binSeven |
+        (eqU8 digit '8') =>
+        binEight |
+        otherwise =>
+        binNine
+      }
 
 poly rec parseDecimalAcc =
   \digits : List U8 =>
@@ -368,19 +357,25 @@ poly parseDecimal =
       (
         \h : U8 =>
           \t : List U8 =>
-            if [Result (List U8) Bin] (eqU8 h '0')
-              (
-                \u : U8 =>
-                  if [Result (List U8) Bin] (listIsEmpty [U8] t)
-                    (\u : U8 => Ok [List U8] [Bin] BZ)
-                    (\u : U8 => Err [List U8] [Bin] "non-canonical decimal")
-              )
-              (
-                \u : U8 =>
-                  if [Result (List U8) Bin] (isDigit h)
-                    (\u : U8 => parseDecimalAcc t (decimalDigitValue h))
-                    (\u : U8 => Err [List U8] [Bin] "bad decimal")
-              )
+            cond
+              [Result (List U8) Bin]
+              {|
+                (eqU8 h '0') =>
+                if
+                [Result (List U8) Bin]
+                (listIsEmpty [U8] t)
+                (\u : U8 => Ok [List U8] [Bin] BZ)
+                (\u : U8 => Err [List U8] [Bin] "non-canonical decimal") |
+                (isDigit h) =>
+                parseDecimalAcc
+                t
+                (decimalDigitValue h) |
+                otherwise =>
+                Err
+                [List U8]
+                [Bin]
+                "bad decimal"
+              }
       )
 
 poly parseModuleHeader =
@@ -439,7 +434,7 @@ poly rec consumeSourceAcc =
           )
 
 poly consumeSource =
-  \count : Bin => \input : List U8 => consumeSourceAcc count input (nil [U8])
+  \count : Bin => \input : List U8 => consumeSourceAcc count input ("")
 
 poly declaredModuleName =
   \source : List U8 =>
@@ -460,35 +455,57 @@ poly declaredModuleName =
 
 poly parseTarget =
   \value : List U8 =>
-    if [Result (List U8) (List U8)] (eqListU8 value "generic")
-      (\u : U8 => Ok [List U8] [List U8] value)
-      (
-        \u : U8 =>
-          if [Result (List U8) (List U8)] (eqListU8 value "x86_64-unknown-linux-gnu")
-            (\u : U8 => Ok [List U8] [List U8] value)
-            (
-              \u : U8 =>
-                if [Result (List U8) (List U8)] (eqListU8 value "arm64-apple-darwin")
-                  (\u : U8 => Ok [List U8] [List U8] value)
-                  (
-                    \u : U8 =>
-                      if [Result (List U8) (List U8)] (eqListU8 value "x86_64-pc-windows-msvc")
-                        (\u : U8 => Ok [List U8] [List U8] value)
-                        (\u : U8 => Err [List U8] [List U8] "bad target")
-                  )
-            )
-      )
+    cond
+      [Result (List U8) (List U8)]
+      {|
+        (eqListU8 value "generic") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        (eqListU8 value "x86_64-unknown-linux-gnu") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        (eqListU8 value "arm64-apple-darwin") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        (eqListU8 value "x86_64-pc-windows-msvc") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        otherwise =>
+        Err
+        [List U8]
+        [List U8]
+        "bad target"
+      }
 
 poly parseWrapper =
   \value : List U8 =>
-    if [Result (List U8) (List U8)] (eqListU8 value "none")
-      (\u : U8 => Ok [List U8] [List U8] value)
-      (
-        \u : U8 =>
-          if [Result (List U8) (List U8)] (eqListU8 value "enabled")
-            (\u : U8 => Ok [List U8] [List U8] value)
-            (\u : U8 => Err [List U8] [List U8] "bad wrapper")
-      )
+    cond
+      [Result (List U8) (List U8)]
+      {|
+        (eqListU8 value "none") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        (eqListU8 value "enabled") =>
+        Ok
+        [List U8]
+        [List U8]
+        value |
+        otherwise =>
+        Err
+        [List U8]
+        [List U8]
+        "bad wrapper"
+      }
 
 poly rec parseModules =
   \remaining : List U8 =>
@@ -686,7 +703,7 @@ poly parseBundleSummary =
                                                                                 match (parseDecimal modsCountDigits) [Result (List U8) BundleSummary] {
                                                                                   | Err e => Err [List U8] [BundleSummary] e
                                                                                   | Ok modsCount =>
-                                                                                    match (parseModules afterModules modsCount entry (None [List U8]) false (nil [ModuleRecord])) [Result (List U8) BundleSummary] {
+                                                                                    match (parseModules afterModules modsCount entry (None [List U8]) false ({ModuleRecord |})) [Result (List U8) BundleSummary] {
                                                                                       | Err e => Err [List U8] [BundleSummary] e
                                                                                       | Ok parsed =>
                                                                                         match parsed [Result (List U8) BundleSummary] {
@@ -744,7 +761,7 @@ poly rec emitModuleSummaries =
       [ModuleRecord]
       [List U8]
       mods
-      (nil [U8])
+      ("")
       (
         \h : ModuleRecord =>
           \t : List ModuleRecord => append [U8] (emitModuleSummary h) (emitModuleSummaries t)

--- a/bootstrap/src/coreToLower.trip
+++ b/bootstrap/src/coreToLower.trip
@@ -168,64 +168,73 @@ poly rec lookupLocal =
 
 poly resolveNativeName =
   \name : List U8 =>
-    if [Maybe Lower] (eqListU8 name ".")
-      (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-      (
-        \u : U8 =>
-          if [Maybe Lower] (eqListU8 name ",")
-            (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-            (
-              \u : U8 =>
-                if [Maybe Lower] (eqListU8 name "writeOne")
-                  (\u : U8 => Some [Lower] (L_Native T_WriteOne))
-                  (
-                    \u : U8 =>
-                      if [Maybe Lower] (eqListU8 name "readOne")
-                        (\u : U8 => Some [Lower] (L_Native T_ReadOne))
-                        (
-                          \u : U8 =>
-                            if [Maybe Lower] (eqListU8 name "addU8")
-                              (\u : U8 => Some [Lower] (L_Native T_AddU8))
-                              (
-                                \u : U8 =>
-                                  if [Maybe Lower] (eqListU8 name "subU8")
-                                    (\u : U8 => Some [Lower] (L_Native T_SubU8))
-                                    (
-                                      \u : U8 =>
-                                        if [Maybe Lower] (eqListU8 name "divU8")
-                                          (
-                                            \u : U8 => Some [Lower] (L_Native T_DivU8)
-                                          )
-                                          (
-                                            \u : U8 =>
-                                              if [Maybe Lower] (eqListU8 name "modU8")
-                                                (
-                                                  \u : U8 => Some [Lower] (L_Native T_ModU8)
-                                                )
-                                                (
-                                                  \u : U8 =>
-                                                    if [Maybe Lower] (eqListU8 name "eqU8")
-                                                      (
-                                                        \u : U8 => Some [Lower] (L_Native T_EqU8)
-                                                      )
-                                                      (
-                                                        \u : U8 =>
-                                                          if [Maybe Lower] (eqListU8 name "ltU8")
-                                                            (
-                                                              \u : U8 => Some [Lower] (L_Native T_LtU8)
-                                                            )
-                                                            (
-                                                              \u : U8 => None [Lower]
-                                                            )
-                                                      )
-                                                )
-                                          )
-                                    )
-                              )
-                        )
-                  )
-            )
-      )
+    cond
+      [Maybe Lower]
+      {|
+        eqListU8
+        name
+        "." =>
+        Some
+        [Lower]
+        (L_Native T_WriteOne) |
+        eqListU8
+        name
+        "," =>
+        Some
+        [Lower]
+        (L_Native T_ReadOne) |
+        eqListU8
+        name
+        "writeOne" =>
+        Some
+        [Lower]
+        (L_Native T_WriteOne) |
+        eqListU8
+        name
+        "readOne" =>
+        Some
+        [Lower]
+        (L_Native T_ReadOne) |
+        eqListU8
+        name
+        "addU8" =>
+        Some
+        [Lower]
+        (L_Native T_AddU8) |
+        eqListU8
+        name
+        "subU8" =>
+        Some
+        [Lower]
+        (L_Native T_SubU8) |
+        eqListU8
+        name
+        "divU8" =>
+        Some
+        [Lower]
+        (L_Native T_DivU8) |
+        eqListU8
+        name
+        "modU8" =>
+        Some
+        [Lower]
+        (L_Native T_ModU8) |
+        eqListU8
+        name
+        "eqU8" =>
+        Some
+        [Lower]
+        (L_Native T_EqU8) |
+        eqListU8
+        name
+        "ltU8" =>
+        Some
+        [Lower]
+        (L_Native T_LtU8) |
+        otherwise =>
+        None
+        [Lower]
+      }
 
 poly rec applyScottArgs =
   \func : Lower =>

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -62,18 +62,18 @@ data MiniExpr =
   | ME_Match MiniExpr (List MiniExpr)
 
 poly anonName =
-  {U8 | '_'}
+  "_"
 
 poly rec collectSpine =
   \expr : Core =>
     \acc : List Core =>
-      match expr [Pair Core (List Core)] {
-        | Cr_Var name => MkPair [Core] [List Core] expr acc
+      match expr [(Core, (List Core))] {
+        | Cr_Var name => {Core, List Core | expr, acc}
         | Cr_App f x => collectSpine f (cons [Core] x acc)
-        | Cr_Lam n b => MkPair [Core] [List Core] expr acc
-        | Cr_Native t => MkPair [Core] [List Core] expr acc
-        | Cr_Ctor t n a => MkPair [Core] [List Core] expr acc
-        | Cr_Match s arms => MkPair [Core] [List Core] expr acc
+        | Cr_Lam n b => {Core, List Core | expr, acc}
+        | Cr_Native t => {Core, List Core | expr, acc}
+        | Cr_Ctor t n a => {Core, List Core | expr, acc}
+        | Cr_Match s arms => {Core, List Core | expr, acc}
       }
 
 poly rec mapWith =
@@ -83,7 +83,7 @@ poly rec mapWith =
         [Core]
         [List MiniExpr]
         exprs
-        (nil [MiniExpr])
+        ({MiniExpr |})
         (\h : Core => \t : List Core => cons [MiniExpr] (f h) (mapWith f t))
 
 poly rec applyAnon =
@@ -105,9 +105,9 @@ poly rec coreToMini =
       | Cr_Var name => ME_Var name
       | Cr_Lam name body => ME_Lam name (coreToMini body)
       | Cr_Native t => ME_Native t
-      | Cr_Ctor tag total arity => ME_Con tag total arity (nil [MiniExpr])
+      | Cr_Ctor tag total arity => ME_Con tag total arity ({MiniExpr |})
       | Cr_App lf rg =>
-        match (collectSpine (Cr_App lf rg) (nil [Core])) [MiniExpr] {
+        match (collectSpine (Cr_App lf rg) ({Core |})) [MiniExpr] {
           | MkPair head args =>
             let miniArgs = mapWith coreToMini args in
             match head [MiniExpr] {

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -78,20 +78,20 @@ export main
 
 poly compileToComb =
   \source : List U8 =>
-    match (tokenize source) [Result (List U8) (List (Pair (List U8) Comb))] {
+    match (tokenize source) [Result (List U8) (List (((List U8), Comb)))] {
       | Err e =>
-        Err [List U8] [List (Pair (List U8) Comb)] "Lex error"
+        Err [List U8] [List (((List U8), Comb))] "Lex error"
       | Ok toks =>
-        match (parseProgram toks) [Result (List U8) (List (Pair (List U8) Comb))] {
+        match (parseProgram toks) [Result (List U8) (List (((List U8), Comb)))] {
           | Err e =>
-            Err [List U8] [List (Pair (List U8) Comb)] "Parse error"
+            Err [List U8] [List (((List U8), Comb))] "Parse error"
           | Ok decls =>
-            match (elaborateProgram (empty [List U8] [Lower]) decls) [Result (List U8) (List (Pair (List U8) Comb))] {
-              | Err e => Err [List U8] [List (Pair (List U8) Comb)] e
+            match (elaborateProgram (empty [List U8] [Lower]) decls) [Result (List U8) (List (((List U8), Comb)))] {
+              | Err e => Err [List U8] [List (((List U8), Comb))] e
               | Ok globals =>
                 let entries = toListEntries [List U8] [Lower] globals in
-                let results = map [Pair (List U8) Lower] [Pair (List U8) Comb] (\entry : Pair (List U8) Lower => MkPair [List U8] [Comb] (fst [List U8] [Lower] entry) (lowerToComb (snd [List U8] [Lower] entry))) entries in
-                Ok [List U8] [List (Pair (List U8) Comb)] results
+                let results = map [((List U8), Lower)] [((List U8), Comb)] (\entry : ((List U8), Lower) => {List U8, Comb | (fst [List U8] [Lower] entry), (lowerToComb (snd [List U8] [Lower] entry))}) entries in
+                Ok [List U8] [List (((List U8), Comb))] results
             }
         }
     }

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -384,9 +384,16 @@ poly tokenTaggedTextRec =
 
 poly tokenTaggedText =
   \tag : U8 =>
-    if [List U8] (eqU8 tag #u8(16))
-      (\u : U8 => "poly")
-      (\u : U8 => tokenTaggedTextRec tag)
+    cond
+      [List U8]
+      {|
+        (eqU8 tag #u8(16)) =>
+        "poly" |
+        (eqU8 tag #u8(32)) =>
+        "cond" |
+        otherwise =>
+        tokenTaggedTextRec tag
+      }
 
 poly tokenText =
   \tok : Token =>
@@ -520,6 +527,7 @@ poly keywordWords =
     "combinator"
     "type"
     "data"
+    "cond"
   }
 
 poly rec anyEqWord =

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -309,7 +309,7 @@ poly tokenTaggedTextData =
   \tag : U8 =>
     if [List U8] (eqU8 tag #u8(28))
       (\u : U8 => "data")
-      (\u : U8 => nil [U8])
+      (\u : U8 => "")
 
 poly tokenTaggedTextType =
   \tag : U8 =>
@@ -388,14 +388,14 @@ poly tokenText =
     match tok [List U8] {
       | T_Tagged tag => tokenTaggedText tag
       | T_Ident str => str
-      | T_Nat n => nil [U8]
+      | T_Nat n => ""
     }
 
 poly tokenNatValue =
   \tok : Token =>
     match tok [List U8] {
-      | T_Tagged tag => nil [U8]
-      | T_Ident str => nil [U8]
+      | T_Tagged tag => ""
+      | T_Ident str => ""
       | T_Nat digits => digits
     }
 
@@ -446,56 +446,50 @@ poly u8_rbrace : U8 =
 
 poly isSpaceU8 =
   \c : U8 =>
-    if [Bool] (eqU8 c u8_space)
-      (\u : U8 => true)
-      (
-        \u : U8 =>
-          if [Bool] (eqU8 c u8_newline)
-            (\u : U8 => true)
-            (
-              \u : U8 =>
-                if [Bool] (eqU8 c u8_cr)
-                  (\u : U8 => true)
-                  (
-                    \u : U8 =>
-                      if [Bool] (eqU8 c u8_tab)
-                        (\u : U8 => true)
-                        (\u : U8 => false)
-                  )
-            )
-      )
+    cond
+      [Bool]
+      {|
+        (eqU8 c u8_space) =>
+        true |
+        (eqU8 c u8_newline) =>
+        true |
+        (eqU8 c u8_cr) =>
+        true |
+        (eqU8 c u8_tab) =>
+        true |
+        otherwise =>
+        false
+      }
 
 poly isDigitU8 =
   \c : U8 =>
-    if [Bool] (ltU8 c #u8(48))
-      (\u : U8 => false)
-      (
-        \u : U8 =>
-          if [Bool] (ltU8 c #u8(58))
-            (\u : U8 => true)
-            (\u : U8 => false)
-      )
+    cond
+      [Bool]
+      {|
+        (ltU8 c #u8(48)) =>
+        false |
+        (ltU8 c #u8(58)) =>
+        true |
+        otherwise =>
+        false
+      }
 
 poly isAlphaU8 =
   \c : U8 =>
-    if [Bool] (ltU8 c #u8(65))
-      (\u : U8 => false)
-      (
-        \u : U8 =>
-          if [Bool] (ltU8 c #u8(91))
-            (\u : U8 => true)
-            (
-              \u : U8 =>
-                if [Bool] (ltU8 c #u8(97))
-                  (\u : U8 => false)
-                  (
-                    \u : U8 =>
-                      if [Bool] (ltU8 c #u8(123))
-                        (\u : U8 => true)
-                        (\u : U8 => false)
-                  )
-            )
-      )
+    cond
+      [Bool]
+      {|
+        (ltU8 c #u8(65)) =>
+        false |
+        (ltU8 c #u8(91)) =>
+        true |
+        (ltU8 c #u8(97)) =>
+        false |
+        (ltU8 c #u8(123)) =>
+        true |
+        otherwise =>
+        false
+      }
 
 poly isIdentCharU8 =
   \c : U8 => or (isAlphaU8 c) (or (isDigitU8 c) (eqU8 c u8_underscore))
@@ -562,25 +556,31 @@ poly keywordTokenFromWordL =
 
 poly keywordTokenFromWordI =
   \word : List U8 =>
-    if [Token] (eqListU8 word "in")
-      (\u : U8 => T_KwIn)
-      (
-        \u : U8 =>
-          if [Token] (eqListU8 word "import")
-            (\u : U8 => T_KwImport)
-            (\u : U8 => T_Ident word)
-      )
+    cond
+      [Token]
+      {|
+        (eqListU8 word "in") =>
+        T_KwIn |
+        (eqListU8 word "import") =>
+        T_KwImport |
+        otherwise =>
+        T_Ident
+        word
+      }
 
 poly keywordTokenFromWordM =
   \word : List U8 =>
-    if [Token] (eqListU8 word "match")
-      (\u : U8 => T_KwMatch)
-      (
-        \u : U8 =>
-          if [Token] (eqListU8 word "module")
-            (\u : U8 => T_KwModule)
-            (\u : U8 => T_Ident word)
-      )
+    cond
+      [Token]
+      {|
+        (eqListU8 word "match") =>
+        T_KwMatch |
+        (eqListU8 word "module") =>
+        T_KwModule |
+        otherwise =>
+        T_Ident
+        word
+      }
 
 poly keywordTokenFromWordN =
   \word : List U8 =>
@@ -694,95 +694,73 @@ poly keywordTokenFromWord =
       (
         \h : U8 =>
           \t : List U8 =>
-            if [Token] (eqU8 h 'p')
-              (\u : U8 => keywordTokenFromWordP word)
-              (
-                \u : U8 =>
-                  if [Token] (eqU8 h 'r')
-                    (\u : U8 => keywordTokenFromWordR word)
-                    (
-                      \u : U8 =>
-                        if [Token] (eqU8 h 'l')
-                          (\u : U8 => keywordTokenFromWordL word)
-                          (
-                            \u : U8 =>
-                              if [Token] (eqU8 h 'i')
-                                (\u : U8 => keywordTokenFromWordI word)
-                                (
-                                  \u : U8 =>
-                                    if [Token] (eqU8 h 'm')
-                                      (\u : U8 => keywordTokenFromWordM word)
-                                      (
-                                        \u : U8 =>
-                                          if [Token] (eqU8 h 'n')
-                                            (
-                                              \u : U8 => keywordTokenFromWordN word
-                                            )
-                                            (
-                                              \u : U8 =>
-                                                if [Token] (eqU8 h 'o')
-                                                  (
-                                                    \u : U8 => keywordTokenFromWordO word
-                                                  )
-                                                  (
-                                                    \u : U8 =>
-                                                      if [Token] (eqU8 h 'e')
-                                                        (
-                                                          \u : U8 => keywordTokenFromWordE word
-                                                        )
-                                                        (
-                                                          \u : U8 =>
-                                                            if [Token] (eqU8 h 't')
-                                                              (
-                                                                \u : U8 => keywordTokenFromWordT word
-                                                              )
-                                                              (
-                                                                \u : U8 =>
-                                                                  if [Token] (eqU8 h 'c')
-                                                                    (
-                                                                      \u : U8 => keywordTokenFromWordC word
-                                                                    )
-                                                                    (
-                                                                      \u : U8 =>
-                                                                        if [Token] (eqU8 h 'd')
-                                                                          (
-                                                                            \u : U8 => keywordTokenFromWordData word
-                                                                          )
-                                                                          (
-                                                                            \u : U8 => T_Ident word
-                                                                          )
-                                                                    )
-                                                              )
-                                                        )
-                                                  )
-                                            )
-                                      )
-                                )
-                          )
-                    )
-              )
+            cond
+              [Token]
+              {|
+                (eqU8 h 'p') =>
+                keywordTokenFromWordP
+                word |
+                (eqU8 h 'r') =>
+                keywordTokenFromWordR
+                word |
+                (eqU8 h 'l') =>
+                keywordTokenFromWordL
+                word |
+                (eqU8 h 'i') =>
+                keywordTokenFromWordI
+                word |
+                (eqU8 h 'm') =>
+                keywordTokenFromWordM
+                word |
+                (eqU8 h 'n') =>
+                keywordTokenFromWordN
+                word |
+                (eqU8 h 'o') =>
+                keywordTokenFromWordO
+                word |
+                (eqU8 h 'e') =>
+                keywordTokenFromWordE
+                word |
+                (eqU8 h 't') =>
+                keywordTokenFromWordT
+                word |
+                (eqU8 h 'c') =>
+                keywordTokenFromWordC
+                word |
+                (eqU8 h 'd') =>
+                keywordTokenFromWordData
+                word |
+                otherwise =>
+                T_Ident
+                word
+              }
       )
 
 poly simpleTokenFromU8Hash =
   \c : U8 =>
-    if [Maybe Token] (eqU8 c '#')
-      (\u : U8 => Some [Token] T_Hash)
-      (
-        \u : U8 =>
-          if [Maybe Token] (eqU8 c '|')
-            (\u : U8 => Some [Token] T_Pipe)
-            (
-              \u : U8 =>
-                if [Maybe Token] (eqU8 c '.')
-                  (\u : U8 => Some [Token] T_Dot)
-                  (
-                    \u : U8 =>
-                      if [Maybe Token] (eqU8 c ',')
-                        (\u : U8 => Some [Token] T_Comma)
-                        (\u : U8 => None [Token])
-                  )
-            )
-      )
+    cond
+      [Maybe Token]
+      {|
+        (eqU8 c '#') =>
+        Some
+        [Token]
+        T_Hash |
+        (eqU8 c '|') =>
+        Some
+        [Token]
+        T_Pipe |
+        (eqU8 c '.') =>
+        Some
+        [Token]
+        T_Dot |
+        (eqU8 c ',') =>
+        Some
+        [Token]
+        T_Comma |
+        otherwise =>
+        None
+        [Token]
+      }
 
 poly simpleTokenFromU8Colon =
   \c : U8 =>
@@ -798,36 +776,57 @@ poly simpleTokenFromU8Backslash =
 
 poly simpleTokenFromU8Bracket =
   \c : U8 =>
-    if [Maybe Token] (eqU8 c '[')
-      (\u : U8 => Some [Token] T_LBracket)
-      (
-        \u : U8 =>
-          if [Maybe Token] (eqU8 c ']')
-            (\u : U8 => Some [Token] T_RBracket)
-            (\u : U8 => simpleTokenFromU8Backslash c)
-      )
+    cond
+      [Maybe Token]
+      {|
+        (eqU8 c '[') =>
+        Some
+        [Token]
+        T_LBracket |
+        (eqU8 c ']') =>
+        Some
+        [Token]
+        T_RBracket |
+        otherwise =>
+        simpleTokenFromU8Backslash
+        c
+      }
 
 poly simpleTokenFromU8Brace =
   \c : U8 =>
-    if [Maybe Token] (eqU8 c '{')
-      (\u : U8 => Some [Token] T_LBrace)
-      (
-        \u : U8 =>
-          if [Maybe Token] (eqU8 c '}')
-            (\u : U8 => Some [Token] T_RBrace)
-            (\u : U8 => simpleTokenFromU8Bracket c)
-      )
+    cond
+      [Maybe Token]
+      {|
+        (eqU8 c '{') =>
+        Some
+        [Token]
+        T_LBrace |
+        (eqU8 c '}') =>
+        Some
+        [Token]
+        T_RBrace |
+        otherwise =>
+        simpleTokenFromU8Bracket
+        c
+      }
 
 poly simpleTokenFromU8 =
   \c : U8 =>
-    if [Maybe Token] (eqU8 c '(')
-      (\u : U8 => Some [Token] T_LParen)
-      (
-        \u : U8 =>
-          if [Maybe Token] (eqU8 c ')')
-            (\u : U8 => Some [Token] T_RParen)
-            (\u : U8 => simpleTokenFromU8Brace c)
-      )
+    cond
+      [Maybe Token]
+      {|
+        (eqU8 c '(') =>
+        Some
+        [Token]
+        T_LParen |
+        (eqU8 c ')') =>
+        Some
+        [Token]
+        T_RParen |
+        otherwise =>
+        simpleTokenFromU8Brace
+        c
+      }
 
 poly mapResult =
   #A =>
@@ -840,32 +839,32 @@ poly mapResult =
           }
 
 poly simpleTokensU8 =
-  {Pair U8 Token |
-    (MkPair [U8] [Token] '(' T_LParen)
-    (MkPair [U8] [Token] ')' T_RParen)
-    (MkPair [U8] [Token] '{' T_LBrace)
-    (MkPair [U8] [Token] '}' T_RBrace)
-    (MkPair [U8] [Token] '[' T_LBracket)
-    (MkPair [U8] [Token] ']' T_RBracket)
-    (MkPair [U8] [Token] '\\' T_Backslash)
-    (MkPair [U8] [Token] ':' T_Colon)
-    (MkPair [U8] [Token] '#' T_Hash)
-    (MkPair [U8] [Token] '|' T_Pipe)
-    (MkPair [U8] [Token] '.' T_Dot)
-    (MkPair [U8] [Token] ',' T_Comma)
+  {(U8, Token) |
+    ({U8, Token | '(', T_LParen})
+    ({U8, Token | ')', T_RParen})
+    ({U8, Token | '{', T_LBrace})
+    ({U8, Token | '}', T_RBrace})
+    ({U8, Token | '[', T_LBracket})
+    ({U8, Token | ']', T_RBracket})
+    ({U8, Token | '\\', T_Backslash})
+    ({U8, Token | ':', T_Colon})
+    ({U8, Token | '#', T_Hash})
+    ({U8, Token | '|', T_Pipe})
+    ({U8, Token | '.', T_Dot})
+    ({U8, Token | ',', T_Comma})
   }
 
 poly rec lookupTokenU8 =
   \c : U8 =>
-    \list : List (Pair U8 Token) =>
+    \list : List ((U8, Token)) =>
       matchList
-        [Pair U8 Token]
+        [(U8, Token)]
         [Maybe Token]
         list
         (None [Token])
         (
-          \h : Pair U8 Token =>
-            \t : List (Pair U8 Token) =>
+          \h : (U8, Token) =>
+            \t : List ((U8, Token)) =>
               if [Maybe Token] (eqU8 c (fst [U8] [Token] h))
                 (\u : U8 => Some [Token] (snd [U8] [Token] h))
                 (\u : U8 => lookupTokenU8 c t)
@@ -876,15 +875,15 @@ poly rec consumeIdent =
     \input : List U8 =>
       matchList
         [U8]
-        [Pair (List U8) (List U8)]
+        [((List U8), (List U8))]
         input
-        (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
+        ({List U8, List U8 | (reverse [U8] acc), (nil [U8])})
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Pair (List U8) (List U8)] (isIdentCharU8 h)
+              if [((List U8), (List U8))] (isIdentCharU8 h)
                 (\u : U8 => consumeIdent (cons [U8] h acc) t)
-                (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
+                (\u : U8 => {List U8, List U8 | (reverse [U8] acc), input})
         )
 
 poly rec consumeDigits =
@@ -892,15 +891,15 @@ poly rec consumeDigits =
     \input : List U8 =>
       matchList
         [U8]
-        [Pair (List U8) (List U8)]
+        [((List U8), (List U8))]
         input
-        (MkPair [List U8] [List U8] (reverse [U8] acc) (nil [U8]))
+        ({List U8, List U8 | (reverse [U8] acc), (nil [U8])})
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Pair (List U8) (List U8)] (isDigitU8 h)
+              if [((List U8), (List U8))] (isDigitU8 h)
                 (\u : U8 => consumeDigits (cons [U8] h acc) t)
-                (\u : U8 => MkPair [List U8] [List U8] (reverse [U8] acc) input)
+                (\u : U8 => {List U8, List U8 | (reverse [U8] acc), input})
         )
 
 poly rec consumeString =
@@ -908,70 +907,63 @@ poly rec consumeString =
     \input : List U8 =>
       matchList
         [U8]
-        [Result ParseError (Pair (List U8) (List U8))]
+        [Result ParseError (((List U8), (List U8)))]
         input
-        (Err [ParseError] [Pair (List U8) (List U8)] (MkParseError (nil [U8])))
+        (Err [ParseError] [((List U8), (List U8))] (MkParseError ("")))
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Result ParseError (Pair (List U8) (List U8))] (eqU8 h u8_quote)
+              if [Result ParseError (((List U8), (List U8)))] (eqU8 h u8_quote)
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
-                      [Pair (List U8) (List U8)]
-                      (MkPair [List U8] [List U8] (reverse [U8] acc) t)
+                      [((List U8), (List U8))]
+                      ({List U8, List U8 | (reverse [U8] acc), t})
                 )
                 (\u : U8 => consumeString (cons [U8] h acc) t)
         )
 
 poly escapedCharValue =
   \c : U8 =>
-    if [U8] (eqU8 c u8_n)
-      (\u : U8 => u8_newline)
-      (
-        \u : U8 =>
-          if [U8] (eqU8 c u8_r)
-            (\u : U8 => u8_cr)
-            (
-              \u : U8 =>
-                if [U8] (eqU8 c 't')
-                  (\u : U8 => u8_tab)
-                  (
-                    \u : U8 =>
-                      if [U8] (eqU8 c u8_quote)
-                        (\u : U8 => u8_quote)
-                        (
-                          \u : U8 =>
-                            if [U8] (eqU8 c u8_squote)
-                              (\u : U8 => u8_squote)
-                              (\u : U8 => c)
-                        )
-                  )
-            )
-      )
+    cond
+      [U8]
+      {|
+        (eqU8 c u8_n) =>
+        u8_newline |
+        (eqU8 c u8_r) =>
+        u8_cr |
+        (eqU8 c 't') =>
+        u8_tab |
+        (eqU8 c u8_quote) =>
+        u8_quote |
+        (eqU8 c u8_squote) =>
+        u8_squote |
+        otherwise =>
+        c
+      }
 
 poly charLiteralError =
-  Err [ParseError] [Pair U8 (List U8)] (MkParseError (nil [U8]))
+  Err [ParseError] [(U8, (List U8))] (MkParseError (""))
 
 poly finishCharLiteral =
   \value : U8 =>
     \input : List U8 =>
       matchList
         [U8]
-        [Result ParseError (Pair U8 (List U8))]
+        [Result ParseError ((U8, (List U8)))]
         input
         charLiteralError
         (
           \close : U8 =>
             \rest : List U8 =>
-              if [Result ParseError (Pair U8 (List U8))] (eqU8 close u8_squote)
+              if [Result ParseError ((U8, (List U8)))] (eqU8 close u8_squote)
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
-                      [Pair U8 (List U8)]
-                      (MkPair [U8] [List U8] value rest)
+                      [(U8, (List U8))]
+                      ({U8, List U8 | value, rest})
                 )
                 (\u : U8 => charLiteralError)
         )
@@ -980,18 +972,18 @@ poly consumeCharLiteral =
   \input : List U8 =>
     matchList
       [U8]
-      [Result ParseError (Pair U8 (List U8))]
+      [Result ParseError ((U8, (List U8)))]
       input
       charLiteralError
       (
         \h : U8 =>
           \t : List U8 =>
-            if [Result ParseError (Pair U8 (List U8))] (eqU8 h u8_backslash)
+            if [Result ParseError ((U8, (List U8)))] (eqU8 h u8_backslash)
               (
                 \u : U8 =>
                   matchList
                     [U8]
-                    [Result ParseError (Pair U8 (List U8))]
+                    [Result ParseError ((U8, (List U8)))]
                     t
                     charLiteralError
                     (
@@ -1010,7 +1002,7 @@ poly rec dropLineComment =
       [U8]
       [List U8]
       input
-      (nil [U8])
+      ("")
       (
         \h : U8 =>
           \t : List U8 =>
@@ -1030,24 +1022,27 @@ poly rec skipBlockComment =
       [U8]
       [Result ParseError (List U8)]
       input
-      (Err [ParseError] [List U8] (MkParseError (nil [U8])))
+      (Err [ParseError] [List U8] (MkParseError ("")))
       (
         \h : U8 =>
           \t : List U8 =>
-            if [Result ParseError (List U8)] (and (eqU8 h u8_lbrace) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_dash h2)))
-              (
-                \u : U8 =>
-                  match (skipBlockComment (tail [U8] t)) [Result ParseError (List U8)] {
-                    | Err e => Err [ParseError] [List U8] e
-                    | Ok afterInner => skipBlockComment afterInner
-                  }
-              )
-              (
-                \u : U8 =>
-                  if [Result ParseError (List U8)] (and (eqU8 h u8_dash) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_rbrace h2)))
-                    (\u : U8 => Ok [ParseError] [List U8] (tail [U8] t))
-                    (\u : U8 => skipBlockComment t)
-              )
+            cond
+              [Result ParseError (List U8)]
+              {|
+                (and (eqU8 h u8_lbrace) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_dash h2))) =>
+                match
+                (skipBlockComment (tail [U8] t))
+                [Result ParseError (List U8)]
+                {| Err e => Err [ParseError] [List U8] e | Ok afterInner => skipBlockComment afterInner} |
+                (and (eqU8 h u8_dash) (matchList [U8] [Bool] t false (\h2 : U8 => \t2 : List U8 => eqU8 u8_rbrace h2))) =>
+                Ok
+                [ParseError]
+                [List U8]
+                (tail [U8] t) |
+                otherwise =>
+                skipBlockComment
+                t
+              }
       )
 
 poly rec tokenizeAcc =
@@ -1061,156 +1056,72 @@ poly rec tokenizeAcc =
         (
           \c : U8 =>
             \cs : List U8 =>
-              if [Result ParseError (List Token)] (isSpaceU8 c)
-                (\u : U8 => tokenizeAcc cs accRev)
-                (
-                  \u : U8 =>
-                    if [Result ParseError (List Token)] (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
-                      (\u : U8 => tokenizeAcc (dropLineComment cs) accRev)
-                      (
-                        \u : U8 =>
-                          if [Result ParseError (List Token)] (and (eqU8 c u8_lbrace) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h)))
-                            (
-                              \u : U8 =>
-                                match (skipBlockComment (tail [U8] cs)) [Result ParseError (List Token)] {
-                                  | Err e => Err [ParseError] [List Token] e
-                                  | Ok rest => tokenizeAcc rest accRev
-                                }
-                            )
-                            (
-                              \u : U8 =>
-                                if [Result ParseError (List Token)] (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
-                                  (
-                                    \u : U8 =>
-                                      let rest = tail [U8] cs in
-                                      tokenizeAcc
-                                        rest
-                                        (cons [Token] T_Arrow accRev)
-                                  )
-                                  (
-                                    \u : U8 =>
-                                      if [Result ParseError (List Token)] (and (eqU8 c u8_eq) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h)))
-                                        (
-                                          \u : U8 =>
-                                            let rest = tail [U8] cs in
-                                            tokenizeAcc
-                                              rest
-                                              (cons [Token] T_FatArrow accRev)
-                                        )
-                                        (
-                                          \u : U8 =>
-                                            match (simpleTokenFromU8 c) [Result ParseError (List Token)] {
-                                              | None =>
-                                                if [Result ParseError (List Token)] (or (isAlphaU8 c) (eqU8 c u8_underscore))
-                                                  (
-                                                    \u : U8 =>
-                                                      match (consumeIdent (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
-                                                        | MkPair taken remaining =>
-                                                          let tok = keywordTokenFromWord taken in
-                                                          tokenizeAcc
-                                                            remaining
-                                                            (
-                                                              cons
-                                                                [Token]
-                                                                tok
-                                                                accRev
-                                                            )
-                                                      }
-                                                  )
-                                                  (
-                                                    \u : U8 =>
-                                                      if [Result ParseError (List Token)] (isDigitU8 c)
-                                                        (
-                                                          \u : U8 =>
-                                                            match (consumeDigits (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
-                                                              | MkPair taken remaining =>
-                                                                tokenizeAcc
-                                                                  remaining
-                                                                  (
-                                                                    cons
-                                                                      [Token]
-                                                                      (
-                                                                        T_Nat
-                                                                          taken
-                                                                      )
-                                                                      accRev
-                                                                  )
-                                                            }
-                                                        )
-                                                        (
-                                                          \u : U8 =>
-                                                            if [Result ParseError (List Token)] (eqU8 c u8_quote)
-                                                              (
-                                                                \u : U8 =>
-                                                                  match (consumeString (nil [U8]) cs) [Result ParseError (List Token)] {
-                                                                    | Err e => Err [ParseError] [List Token] e
-                                                                    | Ok strRes =>
-                                                                      let str = fst [List U8] [List U8] strRes in
-                                                                      let remaining = snd [List U8] [List U8] strRes in
-                                                                      tokenizeAcc
-                                                                        remaining
-                                                                        (
-                                                                          cons
-                                                                            [Token]
-                                                                            (
-                                                                              T_Ident
-                                                                                str
-                                                                            )
-                                                                            accRev
-                                                                        )
-                                                                  }
-                                                              )
-                                                              (
-                                                                \u : U8 =>
-                                                                  if [Result ParseError (List Token)] (eqU8 c u8_squote)
-                                                                    (
-                                                                      \u : U8 =>
-                                                                        match (consumeCharLiteral cs) [Result ParseError (List Token)] {
-                                                                          | Err e => Err [ParseError] [List Token] e
-                                                                          | Ok charRes =>
-                                                                            let value = fst [U8] [List U8] charRes in
-                                                                            let remaining = snd [U8] [List U8] charRes in
-                                                                            tokenizeAcc
-                                                                              remaining
-                                                                              (
-                                                                                cons
-                                                                                  [Token]
-                                                                                  (
-                                                                                    T_Nat
-                                                                                      (
-                                                                                        u8ToDigits
-                                                                                          value
-                                                                                      )
-                                                                                  )
-                                                                                  accRev
-                                                                              )
-                                                                        }
-                                                                    )
-                                                                    (
-                                                                      \u : U8 =>
-                                                                        if [Result ParseError (List Token)] (eqU8 c u8_eq)
-                                                                          (
-                                                                            \u : U8 => tokenizeAcc cs (cons [Token] T_Eq accRev)
-                                                                          )
-                                                                          (
-                                                                            \u : U8 => Err [ParseError] [List Token] (MkParseError (nil [U8]))
-                                                                          )
-                                                                    )
-                                                              )
-                                                        )
-                                                  )
-                                              | Some tok => tokenizeAcc cs (cons [Token] tok accRev)
-                                            }
-                                        )
-                                  )
-                            )
-                      )
-                )
+              cond
+                [Result ParseError (List Token)]
+                {|
+                  (isSpaceU8 c) =>
+                  tokenizeAcc
+                  cs
+                  accRev |
+                  (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h))) =>
+                  tokenizeAcc
+                  (dropLineComment cs)
+                  accRev |
+                  (and (eqU8 c u8_lbrace) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_dash h))) =>
+                  match
+                  (skipBlockComment (tail [U8] cs))
+                  [Result ParseError (List Token)]
+                  {| Err e => Err [ParseError] [List Token] e | Ok rest => tokenizeAcc rest accRev} |
+                  (and (eqU8 c u8_dash) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h))) =>
+                  let
+                  rest =
+                  tail
+                  [U8]
+                  cs
+                  in
+                  tokenizeAcc
+                  rest
+                  (cons [Token] T_Arrow accRev) |
+                  (and (eqU8 c u8_eq) (matchList [U8] [Bool] cs false (\h : U8 => \t : List U8 => eqU8 u8_gt h))) =>
+                  let
+                  rest =
+                  tail
+                  [U8]
+                  cs
+                  in
+                  tokenizeAcc
+                  rest
+                  (cons [Token] T_FatArrow accRev) |
+                  otherwise =>
+                  match
+                  (simpleTokenFromU8 c)
+                  [Result ParseError (List Token)]
+                  {|
+                    None =>
+                    if
+                    [Result ParseError (List Token)]
+                    (or (isAlphaU8 c) (eqU8 c u8_underscore))
+                    (
+                      \u : U8 =>
+                        match (consumeIdent (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {
+                          | MkPair taken remaining =>
+                            let tok = keywordTokenFromWord taken in
+                            tokenizeAcc remaining (cons [Token] tok accRev)
+                        }
+                    )
+                    (\u : U8 => if [Result ParseError (List Token)] (isDigitU8 c) (\u : U8 => match (consumeDigits (cons [U8] c (nil [U8])) cs) [Result ParseError (List Token)] {| MkPair taken remaining => tokenizeAcc remaining (cons [Token] (T_Nat taken) accRev)}) (\u : U8 => if [Result ParseError (List Token)] (eqU8 c u8_quote) (\u : U8 => match (consumeString (nil [U8]) cs) [Result ParseError (List Token)] {| Err e => Err [ParseError] [List Token] e | Ok strRes => let str = fst [List U8] [List U8] strRes in let remaining = snd [List U8] [List U8] strRes in tokenizeAcc remaining (cons [Token] (T_Ident str) accRev)}) (\u : U8 => if [Result ParseError (List Token)] (eqU8 c u8_squote) (\u : U8 => match (consumeCharLiteral cs) [Result ParseError (List Token)] {| Err e => Err [ParseError] [List Token] e | Ok charRes => let value = fst [U8] [List U8] charRes in let remaining = snd [U8] [List U8] charRes in tokenizeAcc remaining (cons [Token] (T_Nat (u8ToDigits value)) accRev)}) (\u : U8 => if [Result ParseError (List Token)] (eqU8 c u8_eq) (\u : U8 => tokenizeAcc cs (cons [Token] T_Eq accRev)) (\u : U8 => Err [ParseError] [List Token] (MkParseError (nil [U8]))))))) |
+                    Some
+                    tok =>
+                    tokenizeAcc
+                    cs
+                    (cons [Token] tok accRev)
+                  }
+                }
         )
 
 poly tokenize =
   \input : List U8 =>
-    match (tokenizeAcc input (nil [Token])) [Result ParseError (List Token)] {
+    match (tokenizeAcc input ({Token |})) [Result ParseError (List Token)] {
       | Err e => Err [ParseError] [List Token] e
       | Ok revWithEnd =>
         Ok

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -132,6 +132,8 @@ export T_KwType
 
 export T_KwData
 
+export T_KwCond
+
 export T_Ident
 
 export T_Nat
@@ -293,6 +295,9 @@ poly T_KwType : Token =
 
 poly T_KwData : Token =
   T_Tagged #u8(28)
+
+poly T_KwCond : Token =
+  T_Tagged #u8(32)
 
 poly T_EOF : Token =
   T_Tagged #u8(31)
@@ -608,9 +613,17 @@ poly keywordTokenFromWordT =
 
 poly keywordTokenFromWordC =
   \word : List U8 =>
-    if [Token] (eqListU8 word "combinator")
-      (\u : U8 => T_KwCombinator)
-      (\u : U8 => T_Ident word)
+    cond
+      [Token]
+      {|
+        (eqListU8 word "combinator") =>
+        T_KwCombinator |
+        (eqListU8 word "cond") =>
+        T_KwCond |
+        otherwise =>
+        T_Ident
+        word
+      }
 
 poly keywordTokenFromWordData =
   \word : List U8 =>

--- a/bootstrap/src/llvm.trip
+++ b/bootstrap/src/llvm.trip
@@ -117,34 +117,47 @@ poly singletonU8 =
 
 poly u8ToDigits =
   \n : U8 =>
-    if [List U8] (ltU8 n #u8(10))
-      (\u : U8 => singletonU8 (digitToAscii n))
-      (
-        \u : U8 =>
-          if [List U8] (ltU8 n #u8(100))
-            (
-              \u : U8 =>
-                cons
-                  [U8]
-                  (digitToAscii (divU8 n #u8(10)))
-                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
-            )
-            (
-              \u : U8 =>
-                let hundreds = divU8 n #u8(100) in
-                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-                let ones = modU8 n #u8(10) in
-                cons
-                  [U8]
-                  (digitToAscii hundreds)
-                  (
-                    cons
-                      [U8]
-                      (digitToAscii tens)
-                      (singletonU8 (digitToAscii ones))
-                  )
-            )
-      )
+    cond
+      [List U8]
+      {|
+        (ltU8 n #u8(10)) =>
+        singletonU8
+        (digitToAscii n) |
+        (ltU8 n #u8(100)) =>
+        cons
+        [U8]
+        (digitToAscii (divU8 n #u8(10)))
+        (singletonU8 (digitToAscii (modU8 n #u8(10)))) |
+        otherwise =>
+        let
+        hundreds =
+        divU8
+        n
+        #
+        u8
+        (100)
+        in
+        let
+        tens =
+        modU8
+        (divU8 n #u8(10))
+        #
+        u8
+        (10)
+        in
+        let
+        ones =
+        modU8
+        n
+        #
+        u8
+        (10)
+        in
+        cons
+        [U8]
+        (digitToAscii hundreds)
+        (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+      }
 
 poly digitValue =
   \c : U8 => modU8 c #u8(16)

--- a/bootstrap/src/lowering.trip
+++ b/bootstrap/src/lowering.trip
@@ -262,41 +262,28 @@ poly selectOuter6 =
 
 poly rec selectOuter =
   \arity : U8 =>
-    if [Comb] (eqU8 arity #u8(0))
-      (\u : U8 => combI)
-      (
-        \u : U8 =>
-          if [Comb] (eqU8 arity #u8(1))
-            (\u : U8 => combI)
-            (
-              \u : U8 =>
-                if [Comb] (eqU8 arity #u8(2))
-                  (\u : U8 => selectOuter2)
-                  (
-                    \u : U8 =>
-                      if [Comb] (eqU8 arity #u8(3))
-                        (\u : U8 => selectOuter3)
-                        (
-                          \u : U8 =>
-                            if [Comb] (eqU8 arity #u8(4))
-                              (\u : U8 => selectOuter4)
-                              (
-                                \u : U8 =>
-                                  if [Comb] (eqU8 arity #u8(5))
-                                    (\u : U8 => selectOuter5)
-                                    (
-                                      \u : U8 =>
-                                        if [Comb] (eqU8 arity #u8(6))
-                                          (\u : U8 => selectOuter6)
-                                          (
-                                            \u : U8 => C_App (C_App combB (selectOuter (subU8 arity #u8(1)))) combK
-                                          )
-                                    )
-                              )
-                        )
-                  )
-            )
-      )
+    cond
+      [Comb]
+      {|
+        (eqU8 arity #u8(0)) =>
+        combI |
+        (eqU8 arity #u8(1)) =>
+        combI |
+        (eqU8 arity #u8(2)) =>
+        selectOuter2 |
+        (eqU8 arity #u8(3)) =>
+        selectOuter3 |
+        (eqU8 arity #u8(4)) =>
+        selectOuter4 |
+        (eqU8 arity #u8(5)) =>
+        selectOuter5 |
+        (eqU8 arity #u8(6)) =>
+        selectOuter6 |
+        otherwise =>
+        C_App
+        (C_App combB (selectOuter (subU8 arity #u8(1))))
+        combK
+      }
 
 poly rec emitBulkB =
   \depth : U8 =>
@@ -349,32 +336,47 @@ poly emitBulkC =
 poly emitBulk =
   \kind : U8 =>
     \depth : U8 =>
-      if [Comb] (eqU8 kind #u8(0))
-        (\u : U8 => emitBulkS depth)
-        (
-          \u : U8 =>
-            if [Comb] (eqU8 kind #u8(1))
-              (\u : U8 => emitBulkB depth)
-              (\u : U8 => emitBulkC depth)
-        )
+      cond
+        [Comb]
+        {|
+          (eqU8 kind #u8(0)) =>
+          emitBulkS
+          depth |
+          (eqU8 kind #u8(1)) =>
+          emitBulkB
+          depth |
+          otherwise =>
+          emitBulkC
+          depth
+        }
 
 poly rec dropArity =
   \count : U8 =>
-    if [Comb] (eqU8 count #u8(0))
-      (\u : U8 => combI)
-      (
-        \u : U8 =>
-          if [Comb] (eqU8 count #u8(1))
-            (\u : U8 => combK)
-            (
-              \u : U8 =>
-                let half = dropArity (divU8 count #u8(2)) in
-                let doubled = C_App (C_App combB half) half in
-                if [Comb] (eqU8 (modU8 count #u8(2)) #u8(0))
-                  (\u : U8 => doubled)
-                  (\u : U8 => C_App combBK doubled)
-            )
-      )
+    cond
+      [Comb]
+      {|
+        (eqU8 count #u8(0)) =>
+        combI |
+        (eqU8 count #u8(1)) =>
+        combK |
+        otherwise =>
+        let
+        half =
+        dropArity
+        (divU8 count #u8(2))
+        in
+        let
+        doubled =
+        C_App
+        (C_App combB half)
+        half
+        in
+        if
+        [Comb]
+        (eqU8 (modU8 count #u8(2)) #u8(0))
+        (\u : U8 => doubled)
+        (\u : U8 => C_App combBK doubled)
+      }
 
 poly liftArity =
   \expr : Comb =>
@@ -391,63 +393,50 @@ poly zip =
         | MkRes n exprA =>
           match r [Res] {
             | MkRes m exprB =>
-              if [Res] (and (eqU8 n #u8(0)) (eqU8 m #u8(0)))
-                (\u : U8 => MkRes #u8(0) (C_App exprA exprB))
-                (
-                  \u : U8 =>
-                    if [Res] (eqU8 n #u8(0))
-                      (
-                        \u : U8 => MkRes m (C_App (C_App (emitBulk #u8(1) m) exprA) exprB)
-                      )
-                      (
-                        \u : U8 =>
-                          if [Res] (eqU8 m #u8(0))
-                            (
-                              \u : U8 => MkRes n (C_App (C_App (emitBulk #u8(2) n) exprA) exprB)
-                            )
-                            (
-                              \u : U8 =>
-                                if [Res] (eqU8 n m)
-                                  (
-                                    \u : U8 => MkRes n (C_App (C_App (emitBulk #u8(0) n) exprA) exprB)
-                                  )
-                                  (
-                                    \u : U8 =>
-                                      if [Res] (ltU8 n m)
-                                        (
-                                          \u : U8 =>
-                                            let liftedA = liftArity exprA n m in
-                                            MkRes
-                                              m
-                                              (
-                                                C_App
-                                                  (
-                                                    C_App
-                                                      (emitBulk #u8(0) m)
-                                                      liftedA
-                                                  )
-                                                  exprB
-                                              )
-                                        )
-                                        (
-                                          \u : U8 =>
-                                            let liftedB = liftArity exprB m n in
-                                            MkRes
-                                              n
-                                              (
-                                                C_App
-                                                  (
-                                                    C_App
-                                                      (emitBulk #u8(0) n)
-                                                      exprA
-                                                  )
-                                                  liftedB
-                                              )
-                                        )
-                                  )
-                            )
-                      )
-                )
+              cond
+                [Res]
+                {|
+                  (and (eqU8 n #u8(0)) (eqU8 m #u8(0))) =>
+                  MkRes
+                  #
+                  u8
+                  (0)
+                  (C_App exprA exprB) |
+                  (eqU8 n #u8(0)) =>
+                  MkRes
+                  m
+                  (C_App (C_App (emitBulk #u8(1) m) exprA) exprB) |
+                  (eqU8 m #u8(0)) =>
+                  MkRes
+                  n
+                  (C_App (C_App (emitBulk #u8(2) n) exprA) exprB) |
+                  (eqU8 n m) =>
+                  MkRes
+                  n
+                  (C_App (C_App (emitBulk #u8(0) n) exprA) exprB) |
+                  (ltU8 n m) =>
+                  let
+                  liftedA =
+                  liftArity
+                  exprA
+                  n
+                  m
+                  in
+                  MkRes
+                  m
+                  (C_App (C_App (emitBulk #u8(0) m) liftedA) exprB) |
+                  otherwise =>
+                  let
+                  liftedB =
+                  liftArity
+                  exprB
+                  m
+                  n
+                  in
+                  MkRes
+                  n
+                  (C_App (C_App (emitBulk #u8(0) n) exprA) liftedB)
+                }
           }
       }
 

--- a/bootstrap/src/miniCore.trip
+++ b/bootstrap/src/miniCore.trip
@@ -86,22 +86,17 @@ data MiniProgram =
 
 poly rec peelLams =
   \expr : Core =>
-    match expr [Pair (List (List U8)) Core] {
-      | Cr_Var n =>
-        MkPair [List (List U8)] [Core] (nil [List U8]) expr
-      | Cr_App a b =>
-        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+    match expr [((List (List U8)), Core)] {
+      | Cr_Var n => {List (List U8), Core | (nil [List U8]), expr}
+      | Cr_App a b => {List (List U8), Core | (nil [List U8]), expr}
       | Cr_Lam name body =>
-        match (peelLams body) [Pair (List (List U8)) Core] {
+        match (peelLams body) [((List (List U8)), Core)] {
           | MkPair ps inner =>
-            MkPair [List (List U8)] [Core] (cons [List U8] name ps) inner
+            {List (List U8), Core | (cons [List U8] name ps), inner}
         }
-      | Cr_Native t =>
-        MkPair [List (List U8)] [Core] (nil [List U8]) expr
-      | Cr_Ctor t n a =>
-        MkPair [List (List U8)] [Core] (nil [List U8]) expr
-      | Cr_Match s arms =>
-        MkPair [List (List U8)] [Core] (nil [List U8]) expr
+      | Cr_Native t => {List (List U8), Core | (nil [List U8]), expr}
+      | Cr_Ctor t n a => {List (List U8), Core | (nil [List U8]), expr}
+      | Cr_Match s arms => {List (List U8), Core | (nil [List U8]), expr}
     }
 
 poly rec listAnyLam =
@@ -127,15 +122,15 @@ poly rec exprHasLam =
     }
 
 poly rec buildFuncs =
-  \defs : List (Pair (List U8) Core) =>
+  \defs : List (((List U8), Core)) =>
     matchList
-      [Pair (List U8) Core]
+      [((List U8), Core)]
       [Result (List U8) (List MiniFunc)]
       defs
-      (Ok [List U8] [List MiniFunc] (nil [MiniFunc]))
+      (Ok [List U8] [List MiniFunc] ({MiniFunc |}))
       (
-        \h : Pair (List U8) Core =>
-          \t : List (Pair (List U8) Core) =>
+        \h : ((List U8), Core) =>
+          \t : List (((List U8), Core)) =>
             let name = fst [List U8] [Core] h in
             let core = snd [List U8] [Core] h in
             match (peelLams core) [Result (List U8) (List MiniFunc)] {
@@ -164,7 +159,7 @@ poly rec buildFuncs =
       )
 
 poly buildMiniProgram =
-  \defs : List (Pair (List U8) Core) =>
+  \defs : List (((List U8), Core)) =>
     \entry : List U8 =>
       match (buildFuncs defs) [Result (List U8) MiniProgram] {
         | Err e => Err [List U8] [MiniProgram] e

--- a/bootstrap/src/miniVerify.trip
+++ b/bootstrap/src/miniVerify.trip
@@ -82,38 +82,51 @@ poly digitToAscii =
   \d : U8 => addU8 d #u8(48)
 
 poly singletonU8 =
-  \b : U8 => cons [U8] b (nil [U8])
+  \b : U8 => {U8 | b}
 
 poly u8ToDigits =
   \n : U8 =>
-    if [List U8] (ltU8 n #u8(10))
-      (\u : U8 => singletonU8 (digitToAscii n))
-      (
-        \u : U8 =>
-          if [List U8] (ltU8 n #u8(100))
-            (
-              \u : U8 =>
-                cons
-                  [U8]
-                  (digitToAscii (divU8 n #u8(10)))
-                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
-            )
-            (
-              \u : U8 =>
-                let hundreds = divU8 n #u8(100) in
-                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-                let ones = modU8 n #u8(10) in
-                cons
-                  [U8]
-                  (digitToAscii hundreds)
-                  (
-                    cons
-                      [U8]
-                      (digitToAscii tens)
-                      (singletonU8 (digitToAscii ones))
-                  )
-            )
-      )
+    cond
+      [List U8]
+      {|
+        (ltU8 n #u8(10)) =>
+        singletonU8
+        (digitToAscii n) |
+        (ltU8 n #u8(100)) =>
+        cons
+        [U8]
+        (digitToAscii (divU8 n #u8(10)))
+        (singletonU8 (digitToAscii (modU8 n #u8(10)))) |
+        otherwise =>
+        let
+        hundreds =
+        divU8
+        n
+        #
+        u8
+        (100)
+        in
+        let
+        tens =
+        modU8
+        (divU8 n #u8(10))
+        #
+        u8
+        (10)
+        in
+        let
+        ones =
+        modU8
+        n
+        #
+        u8
+        (10)
+        in
+        cons
+        [U8]
+        (digitToAscii hundreds)
+        (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+      }
 
 poly rec renderList =
   \f : AnfExpr -> List U8 =>
@@ -122,7 +135,7 @@ poly rec renderList =
         [AnfExpr]
         [List U8]
         es
-        (nil [U8])
+        ("")
         (
           \h : AnfExpr =>
             \t : List AnfExpr => append [U8] (cons [U8] ' ' (f h)) (renderList f t)
@@ -134,7 +147,7 @@ poly rec renderParams =
       [List U8]
       [List U8]
       ps
-      (nil [U8])
+      ("")
       (
         \h : List U8 =>
           \t : List (List U8) => append [U8] (cons [U8] ' ' h) (renderParams t)
@@ -243,7 +256,7 @@ poly rec unparseAnfFuncs =
       [AnfFunc]
       [List U8]
       fns
-      (nil [U8])
+      ("")
       (
         \h : AnfFunc =>
           \t : List AnfFunc => append [U8] (unparseAnfFunc h) (unparseAnfFuncs t)

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -433,15 +433,14 @@ poly rec collectDecls =
                                   [ImportInfo]
                                   imps
                                   (
-                                    cons
-                                      [ImportInfo]
+                                    {ImportInfo |
                                       (
                                         MkImportInfo
                                           moduleName
                                           fromName
                                           symbolName
                                       )
-                                      (nil [ImportInfo])
+                                    }
                                   )
                               )
                               exps
@@ -464,10 +463,9 @@ poly rec collectDecls =
                                   [ExportInfo]
                                   exps
                                   (
-                                    cons
-                                      [ExportInfo]
+                                    {ExportInfo |
                                       (MkExportInfo moduleName name)
-                                      (nil [ExportInfo])
+                                    }
                                   )
                               )
                               defs
@@ -491,10 +489,9 @@ poly rec collectDecls =
                                   [DefinitionInfo]
                                   defs
                                   (
-                                    cons
-                                      [DefinitionInfo]
+                                    {DefinitionInfo |
                                       (MkDefinitionInfo moduleName name "data")
-                                      (nil [DefinitionInfo])
+                                    }
                                   )
                               )
                               (
@@ -502,10 +499,9 @@ poly rec collectDecls =
                                   [DataTypeInfo]
                                   dataTypes
                                   (
-                                    cons
-                                      [DataTypeInfo]
+                                    {DataTypeInfo |
                                       (MkDataTypeInfo qName name nextTypeId)
-                                      (nil [DataTypeInfo])
+                                    }
                                   )
                               )
                               opaques
@@ -526,10 +522,9 @@ poly rec collectDecls =
                                   [DefinitionInfo]
                                   defs
                                   (
-                                    cons
-                                      [DefinitionInfo]
+                                    {DefinitionInfo |
                                       (MkDefinitionInfo moduleName name "type")
-                                      (nil [DefinitionInfo])
+                                    }
                                   )
                               )
                               dataTypes
@@ -551,15 +546,14 @@ poly rec collectDecls =
                                   [DefinitionInfo]
                                   defs
                                   (
-                                    cons
-                                      [DefinitionInfo]
+                                    {DefinitionInfo |
                                       (
                                         MkDefinitionInfo
                                           moduleName
                                           name
                                           "opaque"
                                       )
-                                      (nil [DefinitionInfo])
+                                    }
                                   )
                               )
                               dataTypes
@@ -568,10 +562,9 @@ poly rec collectDecls =
                                   [OpaqueInfo]
                                   opaques
                                   (
-                                    cons
-                                      [OpaqueInfo]
+                                    {OpaqueInfo |
                                       (MkOpaqueInfo moduleName name)
-                                      (nil [OpaqueInfo])
+                                    }
                                   )
                               )
                               natives
@@ -591,15 +584,14 @@ poly rec collectDecls =
                                   [DefinitionInfo]
                                   defs
                                   (
-                                    cons
-                                      [DefinitionInfo]
+                                    {DefinitionInfo |
                                       (
                                         MkDefinitionInfo
                                           moduleName
                                           name
                                           "native"
                                       )
-                                      (nil [DefinitionInfo])
+                                    }
                                   )
                               )
                               dataTypes
@@ -609,10 +601,9 @@ poly rec collectDecls =
                                   [NativeInfo]
                                   natives
                                   (
-                                    cons
-                                      [NativeInfo]
+                                    {NativeInfo |
                                       (MkNativeInfo moduleName name)
-                                      (nil [NativeInfo])
+                                    }
                                   )
                               )
                               nextTypeId
@@ -631,15 +622,14 @@ poly rec collectDecls =
                                   [DefinitionInfo]
                                   defs
                                   (
-                                    cons
-                                      [DefinitionInfo]
+                                    {DefinitionInfo |
                                       (
                                         MkDefinitionInfo
                                           moduleName
                                           name
                                           (defKindName kind)
                                       )
-                                      (nil [DefinitionInfo])
+                                    }
                                   )
                               )
                               dataTypes
@@ -672,7 +662,7 @@ poly rec parseModulesAcc =
                         | MkModuleInfo modName decls =>
                           match state [Result (List U8) BuildState] {
                             | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
-                              let withMod = MkBuildState (append [ModuleInfo] mods (cons [ModuleInfo] modInfo (nil [ModuleInfo]))) imps exps defs dataTypes opaques natives nextTypeId in
+                              let withMod = MkBuildState (append [ModuleInfo] mods ({ModuleInfo | modInfo})) imps exps defs dataTypes opaques natives nextTypeId in
                               parseModulesAcc
                                 t
                                 (collectDecls modName decls withMod)
@@ -683,7 +673,7 @@ poly rec parseModulesAcc =
         )
 
 poly initialBuildState =
-  MkBuildState (nil [ModuleInfo]) (nil [ImportInfo]) (nil [ExportInfo]) (nil [DefinitionInfo]) (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0)) (cons [DataTypeInfo] (MkDataTypeInfo "Prelude.List" "List" #u8(1)) (nil [DataTypeInfo]))) (nil [OpaqueInfo]) (nil [NativeInfo]) #u8(2)
+  MkBuildState ({ModuleInfo |}) ({ImportInfo |}) ({ExportInfo |}) ({DefinitionInfo |}) ({DataTypeInfo | (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0)) (MkDataTypeInfo "Prelude.List" "List" #u8(1))}) ({OpaqueInfo |}) ({NativeInfo |}) #u8(2)
 
 poly rec findDataTypeId =
   \qName : List U8 =>
@@ -705,34 +695,34 @@ poly rec findDataTypeId =
         )
 
 poly rec countCtors =
-  \ctors : List (Pair (List U8) U8) =>
+  \ctors : List (((List U8), U8)) =>
     \acc : U8 =>
       matchList
-        [Pair (List U8) U8]
+        [((List U8), U8)]
         [U8]
         ctors
         acc
         (
-          \h : Pair (List U8) U8 => \t : List (Pair (List U8) U8) => countCtors t (inc acc)
+          \h : ((List U8), U8) => \t : List (((List U8), U8)) => countCtors t (inc acc)
         )
 
 poly rec addCtorMetas =
   \moduleName : List U8 =>
     \typeName : List U8 =>
       \dataId : U8 =>
-        \ctors : List (Pair (List U8) U8) =>
+        \ctors : List (((List U8), U8)) =>
           \total : U8 =>
             \tag : U8 =>
               \symbolId : U8 =>
                 \acc : List ConstructorMeta =>
                   matchList
-                    [Pair (List U8) U8]
-                    [Pair (List ConstructorMeta) U8]
+                    [((List U8), U8)]
+                    [((List ConstructorMeta), U8)]
                     ctors
-                    (MkPair [List ConstructorMeta] [U8] acc symbolId)
+                    ({List ConstructorMeta, U8 | acc, symbolId})
                     (
-                      \h : Pair (List U8) U8 =>
-                        \t : List (Pair (List U8) U8) =>
+                      \h : ((List U8), U8) =>
+                        \t : List (((List U8), U8)) =>
                           let ctorName = fst [List U8] [U8] h in
                           let arity = snd [List U8] [U8] h in
                           let qName = qualifyCtor moduleName typeName ctorName in
@@ -750,12 +740,7 @@ poly rec addCtorMetas =
                               append
                                 [ConstructorMeta]
                                 acc
-                                (
-                                  cons
-                                    [ConstructorMeta]
-                                    meta
-                                    (nil [ConstructorMeta])
-                                )
+                                ({ConstructorMeta | meta})
                             )
                     )
 
@@ -767,16 +752,16 @@ poly rec collectConstructorsFromDecls =
           \acc : List ConstructorMeta =>
             matchList
               [Decl]
-              [Pair (List ConstructorMeta) U8]
+              [((List ConstructorMeta), U8)]
               decls
-              (MkPair [List ConstructorMeta] [U8] acc symbolId)
+              ({List ConstructorMeta, U8 | acc, symbolId})
               (
                 \h : Decl =>
                   \t : List Decl =>
-                    match h [Pair (List ConstructorMeta) U8] {
+                    match h [((List ConstructorMeta), U8)] {
                       | D_Data typeName ctors =>
                         let dataQName = qualify moduleName typeName in
-                        match (findDataTypeId dataQName dataTypes) [Pair (List ConstructorMeta) U8] {
+                        match (findDataTypeId dataQName dataTypes) [((List ConstructorMeta), U8)] {
                           | None =>
                             collectConstructorsFromDecls
                               moduleName
@@ -786,7 +771,7 @@ poly rec collectConstructorsFromDecls =
                               acc
                           | Some dataId =>
                             let total = countCtors ctors #u8(0) in
-                            match (addCtorMetas moduleName typeName dataId ctors total #u8(0) symbolId acc) [Pair (List ConstructorMeta) U8] {
+                            match (addCtorMetas moduleName typeName dataId ctors total #u8(0) symbolId acc) [((List ConstructorMeta), U8)] {
                               | MkPair nextAcc nextSymbolId =>
                                 collectConstructorsFromDecls
                                   moduleName
@@ -855,15 +840,15 @@ poly rec collectConstructors =
         \acc : List ConstructorMeta =>
           matchList
             [ModuleInfo]
-            [Pair (List ConstructorMeta) U8]
+            [((List ConstructorMeta), U8)]
             mods
-            (MkPair [List ConstructorMeta] [U8] acc symbolId)
+            ({List ConstructorMeta, U8 | acc, symbolId})
             (
               \h : ModuleInfo =>
                 \t : List ModuleInfo =>
-                  match h [Pair (List ConstructorMeta) U8] {
+                  match h [((List ConstructorMeta), U8)] {
                     | MkModuleInfo moduleName decls =>
-                      match (collectConstructorsFromDecls moduleName decls dataTypes symbolId acc) [Pair (List ConstructorMeta) U8] {
+                      match (collectConstructorsFromDecls moduleName decls dataTypes symbolId acc) [((List ConstructorMeta), U8)] {
                         | MkPair nextAcc nextSymbolId =>
                           collectConstructors t dataTypes nextSymbolId nextAcc
                       }
@@ -871,33 +856,20 @@ poly rec collectConstructors =
             )
 
 poly pseudoConstructors =
-  cons
-    [ConstructorMeta]
+  {ConstructorMeta |
     (
       MkConstructorMeta "Prelude.false" "false" "Prelude.false" "Bool" #u8(0) #u8(0) #u8(0) #u8(2) #u8(0)
     )
     (
-      cons
-        [ConstructorMeta]
-        (
-          MkConstructorMeta "Prelude.true" "true" "Prelude.true" "Bool" #u8(0) #u8(1) #u8(1) #u8(2) #u8(0)
-        )
-        (
-          cons
-            [ConstructorMeta]
-            (
-              MkConstructorMeta "Prelude.nil" "nil" "Prelude.nil" "List" #u8(1) #u8(2) #u8(0) #u8(2) #u8(0)
-            )
-            (
-              cons
-                [ConstructorMeta]
-                (
-                  MkConstructorMeta "Prelude.cons" "cons" "Prelude.cons" "List" #u8(1) #u8(3) #u8(1) #u8(2) #u8(2)
-                )
-                (nil [ConstructorMeta])
-            )
-        )
+      MkConstructorMeta "Prelude.true" "true" "Prelude.true" "Bool" #u8(0) #u8(1) #u8(1) #u8(2) #u8(0)
     )
+    (
+      MkConstructorMeta "Prelude.nil" "nil" "Prelude.nil" "List" #u8(1) #u8(2) #u8(0) #u8(2) #u8(0)
+    )
+    (
+      MkConstructorMeta "Prelude.cons" "cons" "Prelude.cons" "List" #u8(1) #u8(3) #u8(1) #u8(2) #u8(2)
+    )
+  }
 
 poly rec addAlias =
   \alias : List U8 =>
@@ -908,10 +880,9 @@ poly rec addAlias =
           [List ConstructorAliasInfo]
           aliases
           (
-            cons
-              [ConstructorAliasInfo]
+            {ConstructorAliasInfo |
               (MkConstructorAliasInfo alias (Some [List U8] qName))
-              (nil [ConstructorAliasInfo])
+            }
           )
           (
             \h : ConstructorAliasInfo =>
@@ -963,83 +934,20 @@ poly rec buildAliases =
 
 poly primitivesStartingAt =
   \firstSymbolId : U8 =>
-    cons
-      [PrimitiveInfo]
+    {PrimitiveInfo |
       (MkPrimitiveInfo "Nat.succ" firstSymbolId #u8(1))
-      (
-        cons
-          [PrimitiveInfo]
-          (MkPrimitiveInfo "Nat.add" (addU8 firstSymbolId #u8(1)) #u8(2))
-          (
-            cons
-              [PrimitiveInfo]
-              (MkPrimitiveInfo "Nat.mul" (addU8 firstSymbolId #u8(2)) #u8(2))
-              (
-                cons
-                  [PrimitiveInfo]
-                  (
-                    MkPrimitiveInfo "Nat.lte" (addU8 firstSymbolId #u8(3)) #u8(2)
-                  )
-                  (
-                    cons
-                      [PrimitiveInfo]
-                      (
-                        MkPrimitiveInfo "Prelude.not" (addU8 firstSymbolId #u8(4)) #u8(1)
-                      )
-                      (
-                        cons
-                          [PrimitiveInfo]
-                          (
-                            MkPrimitiveInfo "Prelude.eqU8" (addU8 firstSymbolId #u8(5)) #u8(2)
-                          )
-                          (
-                            cons
-                              [PrimitiveInfo]
-                              (
-                                MkPrimitiveInfo "Prelude.ltU8" (addU8 firstSymbolId #u8(6)) #u8(2)
-                              )
-                              (
-                                cons
-                                  [PrimitiveInfo]
-                                  (
-                                    MkPrimitiveInfo "Prelude.addU8" (addU8 firstSymbolId #u8(7)) #u8(2)
-                                  )
-                                  (
-                                    cons
-                                      [PrimitiveInfo]
-                                      (
-                                        MkPrimitiveInfo "Prelude.subU8" (addU8 firstSymbolId #u8(8)) #u8(2)
-                                      )
-                                      (
-                                        cons
-                                          [PrimitiveInfo]
-                                          (
-                                            MkPrimitiveInfo "Prelude.divU8" (addU8 firstSymbolId #u8(9)) #u8(2)
-                                          )
-                                          (
-                                            cons
-                                              [PrimitiveInfo]
-                                              (
-                                                MkPrimitiveInfo "Prelude.modU8" (addU8 firstSymbolId #u8(10)) #u8(2)
-                                              )
-                                              (
-                                                cons
-                                                  [PrimitiveInfo]
-                                                  (
-                                                    MkPrimitiveInfo "Prelude.error" (addU8 firstSymbolId #u8(11)) #u8(0)
-                                                  )
-                                                  (nil [PrimitiveInfo])
-                                              )
-                                          )
-                                      )
-                                  )
-                              )
-                          )
-                      )
-                  )
-              )
-          )
-      )
+      (MkPrimitiveInfo "Nat.add" (addU8 firstSymbolId #u8(1)) #u8(2))
+      (MkPrimitiveInfo "Nat.mul" (addU8 firstSymbolId #u8(2)) #u8(2))
+      (MkPrimitiveInfo "Nat.lte" (addU8 firstSymbolId #u8(3)) #u8(2))
+      (MkPrimitiveInfo "Prelude.not" (addU8 firstSymbolId #u8(4)) #u8(1))
+      (MkPrimitiveInfo "Prelude.eqU8" (addU8 firstSymbolId #u8(5)) #u8(2))
+      (MkPrimitiveInfo "Prelude.ltU8" (addU8 firstSymbolId #u8(6)) #u8(2))
+      (MkPrimitiveInfo "Prelude.addU8" (addU8 firstSymbolId #u8(7)) #u8(2))
+      (MkPrimitiveInfo "Prelude.subU8" (addU8 firstSymbolId #u8(8)) #u8(2))
+      (MkPrimitiveInfo "Prelude.divU8" (addU8 firstSymbolId #u8(9)) #u8(2))
+      (MkPrimitiveInfo "Prelude.modU8" (addU8 firstSymbolId #u8(10)) #u8(2))
+      (MkPrimitiveInfo "Prelude.error" (addU8 firstSymbolId #u8(11)) #u8(0))
+    }
 
 poly buildModuleEnv =
   \records : List ModuleRecord =>
@@ -1050,7 +958,7 @@ poly buildModuleEnv =
           | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
             match (collectConstructors mods dataTypes #u8(4) pseudoConstructors) [Result (List U8) ModuleEnv] {
               | MkPair ctors nextSymbolId =>
-                let aliases = buildAliases ctors (nil [ConstructorAliasInfo]) in
+                let aliases = buildAliases ctors ({ConstructorAliasInfo |}) in
                 let primitives = primitivesStartingAt nextSymbolId in
                 Ok
                   [List U8]
@@ -1337,14 +1245,16 @@ poly exportStatus =
         \defs : List DefinitionInfo =>
           \ctors : List ConstructorMeta =>
             let origins = countExportOrigins symbolName exports #u8(0) in
-            if [List U8] (ltU8 #u8(1) origins)
-              (\u : U8 => "AMBIGUOUS")
-              (
-                \u : U8 =>
-                  if [List U8] (or (isDefined moduleName symbolName defs) (isConstructorDefined moduleName symbolName ctors))
-                    (\u : U8 => "OK")
-                    (\u : U8 => "EXPORT_UNDEFINED")
-              )
+            cond
+              [List U8]
+              {|
+                (ltU8 #u8(1) origins) =>
+                "AMBIGUOUS" |
+                (or (isDefined moduleName symbolName defs) (isConstructorDefined moduleName symbolName ctors)) =>
+                "OK" |
+                otherwise =>
+                "EXPORT_UNDEFINED"
+              }
 
 poly rec emitModuleImportsAcc =
   \moduleName : List U8 =>
@@ -1405,7 +1315,7 @@ poly emitModuleImports =
             (reverse [ImportInfo] imports)
             mods
             exports
-            (nil [U8])
+            ("")
 
 poly rec emitModuleExportsAcc =
   \moduleName : List U8 =>
@@ -1466,7 +1376,7 @@ poly emitModuleExports =
             (reverse [ExportInfo] exports)
             defs
             ctors
-            (nil [U8])
+            ("")
 
 poly rec emitModuleDefsAcc =
   \moduleName : List U8 =>
@@ -1502,7 +1412,7 @@ poly rec emitModuleDefsAcc =
 poly emitModuleDefs =
   \moduleName : List U8 =>
     \defs : List DefinitionInfo =>
-      emitModuleDefsAcc moduleName (reverse [DefinitionInfo] defs) (nil [U8])
+      emitModuleDefsAcc moduleName (reverse [DefinitionInfo] defs) ("")
 
 poly rec emitModuleOpaquesAcc =
   \moduleName : List U8 =>
@@ -1533,7 +1443,7 @@ poly rec emitModuleOpaquesAcc =
 poly emitModuleOpaques =
   \moduleName : List U8 =>
     \opaques : List OpaqueInfo =>
-      emitModuleOpaquesAcc moduleName (reverse [OpaqueInfo] opaques) (nil [U8])
+      emitModuleOpaquesAcc moduleName (reverse [OpaqueInfo] opaques) ("")
 
 poly rec emitModuleNativesAcc =
   \moduleName : List U8 =>
@@ -1564,7 +1474,7 @@ poly rec emitModuleNativesAcc =
 poly emitModuleNatives =
   \moduleName : List U8 =>
     \natives : List NativeInfo =>
-      emitModuleNativesAcc moduleName (reverse [NativeInfo] natives) (nil [U8])
+      emitModuleNativesAcc moduleName (reverse [NativeInfo] natives) ("")
 
 poly rec emitModulesAcc =
   \mods : List ModuleInfo =>
@@ -1623,7 +1533,7 @@ poly emitModules =
                   ctors
                   opaques
                   natives
-                  (nil [U8])
+                  ("")
 
 poly rec moduleImportsAcc =
   \moduleName : List U8 =>
@@ -1652,7 +1562,7 @@ poly moduleImports =
     \imports : List ImportInfo =>
       reverse
         [ImportInfo]
-        (moduleImportsAcc moduleName imports (nil [ImportInfo]))
+        (moduleImportsAcc moduleName imports ({ImportInfo |}))
 
 poly rec moduleExportsAcc =
   \moduleName : List U8 =>
@@ -1681,7 +1591,7 @@ poly moduleExports =
     \exports : List ExportInfo =>
       reverse
         [ExportInfo]
-        (moduleExportsAcc moduleName exports (nil [ExportInfo]))
+        (moduleExportsAcc moduleName exports ({ExportInfo |}))
 
 poly rec moduleDefsAcc =
   \moduleName : List U8 =>
@@ -1710,7 +1620,7 @@ poly moduleDefs =
     \defs : List DefinitionInfo =>
       reverse
         [DefinitionInfo]
-        (moduleDefsAcc moduleName defs (nil [DefinitionInfo]))
+        (moduleDefsAcc moduleName defs ({DefinitionInfo |}))
 
 poly rec moduleOpaquesAcc =
   \moduleName : List U8 =>
@@ -1739,7 +1649,7 @@ poly moduleOpaques =
     \opaques : List OpaqueInfo =>
       reverse
         [OpaqueInfo]
-        (moduleOpaquesAcc moduleName opaques (nil [OpaqueInfo]))
+        (moduleOpaquesAcc moduleName opaques ({OpaqueInfo |}))
 
 poly rec moduleNativesAcc =
   \moduleName : List U8 =>
@@ -1768,7 +1678,7 @@ poly moduleNatives =
     \natives : List NativeInfo =>
       reverse
         [NativeInfo]
-        (moduleNativesAcc moduleName natives (nil [NativeInfo]))
+        (moduleNativesAcc moduleName natives ({NativeInfo |}))
 
 poly emitDataType =
   \info : DataTypeInfo =>
@@ -1809,8 +1719,7 @@ poly rec emitDataTypesAcc =
         )
 
 poly emitDataTypes =
-  \dataTypes : List DataTypeInfo =>
-    emitDataTypesAcc (reverse [DataTypeInfo] dataTypes) (nil [U8])
+  \dataTypes : List DataTypeInfo => emitDataTypesAcc (reverse [DataTypeInfo] dataTypes) ("")
 
 poly emitConstructor =
   \info : ConstructorMeta =>
@@ -1843,8 +1752,7 @@ poly rec emitConstructorsAcc =
         )
 
 poly emitConstructors =
-  \ctors : List ConstructorMeta =>
-    emitConstructorsAcc (reverse [ConstructorMeta] ctors) (nil [U8])
+  \ctors : List ConstructorMeta => emitConstructorsAcc (reverse [ConstructorMeta] ctors) ("")
 
 poly emitAlias =
   \info : ConstructorAliasInfo =>
@@ -1870,8 +1778,7 @@ poly rec emitAliasesAcc =
         )
 
 poly emitAliases =
-  \aliases : List ConstructorAliasInfo =>
-    emitAliasesAcc (reverse [ConstructorAliasInfo] aliases) (nil [U8])
+  \aliases : List ConstructorAliasInfo => emitAliasesAcc (reverse [ConstructorAliasInfo] aliases) ("")
 
 poly emitPrimitive =
   \info : PrimitiveInfo =>
@@ -1917,7 +1824,7 @@ poly rec emitPrimitivesAcc =
         )
 
 poly emitPrimitives =
-  \prims : List PrimitiveInfo => emitPrimitivesAcc (reverse [PrimitiveInfo] prims) (nil [U8])
+  \prims : List PrimitiveInfo => emitPrimitivesAcc (reverse [PrimitiveInfo] prims) ("")
 
 poly rec insertDataEnvCtors =
   \ctors : List ConstructorMeta =>
@@ -1961,7 +1868,7 @@ poly rec ctorNamesForData =
         [ConstructorMeta]
         [List (List U8)]
         ctors
-        (nil [List U8])
+        ({List U8 |})
         (
           \h : ConstructorMeta =>
             \t : List ConstructorMeta =>

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -369,10 +369,10 @@ poly checkedIncrementU8 =
       (\u : U8 => Err [ParseError] [U8] parseError)
 
 poly identTag =
-  tokenTag (T_Ident (nil [U8]))
+  tokenTag (T_Ident (""))
 
 poly natTag =
-  tokenTag (T_Nat (nil [U8]))
+  tokenTag (T_Nat (""))
 
 poly lParenTag =
   tokenTag T_LParen
@@ -462,60 +462,62 @@ poly kwDataTag =
   tokenTag T_KwData
 
 poly fstTypeToken =
-  \p : Pair Type (List Token) => fst [Type] [List Token] p
+  \p : (Type, (List Token)) => fst [Type] [List Token] p
 
 poly sndTypeToken =
-  \p : Pair Type (List Token) => snd [Type] [List Token] p
+  \p : (Type, (List Token)) => snd [Type] [List Token] p
 
 poly fstNameToken =
-  \p : Pair (List U8) (List Token) => fst [List U8] [List Token] p
+  \p : ((List U8), (List Token)) => fst [List U8] [List Token] p
 
 poly sndNameToken =
-  \p : Pair (List U8) (List Token) => snd [List U8] [List Token] p
+  \p : ((List U8), (List Token)) => snd [List U8] [List Token] p
 
 poly fstExprToken =
-  \p : Pair Expr (List Token) => fst [Expr] [List Token] p
+  \p : (Expr, (List Token)) => fst [Expr] [List Token] p
 
 poly sndExprToken =
-  \p : Pair Expr (List Token) => snd [Expr] [List Token] p
+  \p : (Expr, (List Token)) => snd [Expr] [List Token] p
 
 poly fstArgsToken =
-  \p : Pair (List (List U8)) (List Token) => fst [List (List U8)] [List Token] p
+  \p : ((List (List U8)), (List Token)) => fst [List (List U8)] [List Token] p
 
 poly sndArgsToken =
-  \p : Pair (List (List U8)) (List Token) => snd [List (List U8)] [List Token] p
+  \p : ((List (List U8)), (List Token)) => snd [List (List U8)] [List Token] p
 
 poly fstPatternExprToken =
-  \p : Pair (Pair Pattern Expr) (List Token) => fst [Pair Pattern Expr] [List Token] p
+  \p : ((Pair Pattern Expr), (List Token)) => fst [(Pattern, Expr)] [List Token] p
 
 poly sndPatternExprToken =
-  \p : Pair (Pair Pattern Expr) (List Token) => snd [Pair Pattern Expr] [List Token] p
+  \p : ((Pair Pattern Expr), (List Token)) => snd [(Pattern, Expr)] [List Token] p
 
 poly fstArmsToken =
-  \p : Pair (List (Pair Pattern Expr)) (List Token) => fst [List (Pair Pattern Expr)] [List Token] p
+  \p : ((List (Pair Pattern Expr)), (List Token)) => fst [List ((Pattern, Expr))] [List Token] p
 
 poly sndArmsToken =
-  \p : Pair (List (Pair Pattern Expr)) (List Token) => snd [List (Pair Pattern Expr)] [List Token] p
+  \p : ((List (Pair Pattern Expr)), (List Token)) => snd [List ((Pattern, Expr))] [List Token] p
 
 poly fstDeclToken =
-  \p : Pair Decl (List Token) => fst [Decl] [List Token] p
+  \p : (Decl, (List Token)) => fst [Decl] [List Token] p
 
 poly sndDeclToken =
-  \p : Pair Decl (List Token) => snd [Decl] [List Token] p
+  \p : (Decl, (List Token)) => snd [Decl] [List Token] p
 
 poly isTopLevelStartTag =
   \tag : U8 =>
     or
       (eqU8 tag kwPolyTag)
       (
-        if [Bool] (ltU8 tag #u8(21))
-          (\u : U8 => false)
-          (
-            \u : U8 =>
-              if [Bool] (ltU8 tag #u8(29))
-                (\u : U8 => true)
-                (\u : U8 => false)
-          )
+        cond
+          [Bool]
+          {|
+            (ltU8 tag #u8(21)) =>
+            false |
+            (ltU8 tag #u8(29)) =>
+            true |
+            otherwise =>
+            false
+          }
       )
 
 poly isTopLevelStartToken =
@@ -541,22 +543,22 @@ poly expectIdent =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (Pair (List U8) (List Token))]
+      [Result ParseError (((List U8), (List Token)))]
       toks
-      (Err [ParseError] [Pair (List U8) (List Token)] parseError)
+      (Err [ParseError] [((List U8), (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
-            if [Result ParseError (Pair (List U8) (List Token))] (eqU8 (tokenTag h) identTag)
+            if [Result ParseError (((List U8), (List Token)))] (eqU8 (tokenTag h) identTag)
               (
                 \u : U8 =>
                   Ok
                     [ParseError]
-                    [Pair (List U8) (List Token)]
-                    (MkPair [List U8] [List Token] (tokenText h) t)
+                    [((List U8), (List Token))]
+                    ({List U8, List Token | (tokenText h), t})
               )
               (
-                \u : U8 => Err [ParseError] [Pair (List U8) (List Token)] parseError
+                \u : U8 => Err [ParseError] [((List U8), (List Token))] parseError
               )
       )
 
@@ -598,19 +600,28 @@ poly rec skipToTopLevelDecl =
       [Token]
       [Result ParseError (List Token)]
       toks
-      (Ok [ParseError] [List Token] (nil [Token]))
+      (Ok [ParseError] [List Token] ({Token |}))
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            if [Result ParseError (List Token)] (eqU8 tag eofTag)
-              (\u : U8 => Ok [ParseError] [List Token] toks)
-              (
-                \u : U8 =>
-                  if [Result ParseError (List Token)] (isTopLevelStartTag tag)
-                    (\u : U8 => Ok [ParseError] [List Token] toks)
-                    (\u : U8 => skipToTopLevelDecl t)
-              )
+            cond
+              [Result ParseError (List Token)]
+              {|
+                (eqU8 tag eofTag) =>
+                Ok
+                [ParseError]
+                [List Token]
+                toks |
+                (isTopLevelStartTag tag) =>
+                Ok
+                [ParseError]
+                [List Token]
+                toks |
+                otherwise =>
+                skipToTopLevelDecl
+                t
+              }
       )
 
 poly rec parsePatternArgs =
@@ -618,90 +629,73 @@ poly rec parsePatternArgs =
     \acc : List (List U8) =>
       matchList
         [Token]
-        [Result ParseError (Pair (List (List U8)) (List Token))]
+        [Result ParseError (((List (List U8)), (List Token)))]
         toks
-        (Err [ParseError] [Pair (List (List U8)) (List Token)] parseError)
+        (Err [ParseError] [((List (List U8)), (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair (List (List U8)) (List Token))] (eqU8 tag fatArrowTag)
-                (
-                  \u : U8 =>
-                    Ok
-                      [ParseError]
-                      [Pair (List (List U8)) (List Token)]
-                      (
-                        MkPair
-                          [List (List U8)]
-                          [List Token]
-                          (reverse [List U8] acc)
-                          toks
-                      )
-                )
-                (
-                  \u : U8 =>
-                    if [Result ParseError (Pair (List (List U8)) (List Token))] (eqU8 tag identTag)
-                      (
-                        \u : U8 => parsePatternArgs t (cons [List U8] (tokenText h) acc)
-                      )
-                      (
-                        \u : U8 =>
-                          Err
-                            [ParseError]
-                            [Pair (List (List U8)) (List Token)]
-                            parseError
-                      )
-                )
+              cond
+                [Result ParseError (Pair (List (List U8)) (List Token))]
+                {|
+                  (eqU8 tag fatArrowTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair (List (List U8)) (List Token)]
+                  (MkPair [List (List U8)] [List Token] (reverse [List U8] acc) toks) |
+                  (eqU8 tag identTag) =>
+                  parsePatternArgs
+                  t
+                  (cons [List U8] (tokenText h) acc) |
+                  otherwise =>
+                  Err
+                  [ParseError]
+                  [Pair (List (List U8)) (List Token)]
+                  parseError
+                }
         )
 
 poly parseMatchArmWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
-      match (expect toks pipeTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+      match (expect toks pipeTag) [Result ParseError (((Pair Pattern Expr), (List Token)))] {
         | Err e =>
-          Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+          Err [ParseError] [((Pair Pattern Expr), (List Token))] e
         | Ok afterPipe =>
-          match (expectIdent afterPipe) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+          match (expectIdent afterPipe) [Result ParseError (((Pair Pattern Expr), (List Token)))] {
             | Err e =>
-              Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+              Err [ParseError] [((Pair Pattern Expr), (List Token))] e
             | Ok ctorRes =>
               let ctorName = fstNameToken ctorRes in
               let afterCtor = sndNameToken ctorRes in
-              match (parsePatternArgs afterCtor (nil [List U8])) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+              match (parsePatternArgs afterCtor ({List U8 |})) [Result ParseError (((Pair Pattern Expr), (List Token)))] {
                 | Err e =>
-                  Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+                  Err [ParseError] [((Pair Pattern Expr), (List Token))] e
                 | Ok argRes =>
                   let args = fstArgsToken argRes in
                   let atArrow = sndArgsToken argRes in
-                  match (expect atArrow fatArrowTag) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+                  match (expect atArrow fatArrowTag) [Result ParseError (((Pair Pattern Expr), (List Token)))] {
                     | Err e =>
-                      Err [ParseError] [Pair (Pair Pattern Expr) (List Token)] e
+                      Err [ParseError] [((Pair Pattern Expr), (List Token))] e
                     | Ok bodyToks =>
-                      match (recurse bodyToks) [Result ParseError (Pair (Pair Pattern Expr) (List Token))] {
+                      match (recurse bodyToks) [Result ParseError (((Pair Pattern Expr), (List Token)))] {
                         | Err e =>
                           Err
                             [ParseError]
-                            [Pair (Pair Pattern Expr) (List Token)]
+                            [((Pair Pattern Expr), (List Token))]
                             e
                         | Ok bodyRes =>
                           let body = fstExprToken bodyRes in
                           let rest = sndExprToken bodyRes in
                           Ok
                             [ParseError]
-                            [Pair (Pair Pattern Expr) (List Token)]
+                            [((Pair Pattern Expr), (List Token))]
                             (
-                              MkPair
-                                [Pair Pattern Expr]
-                                [List Token]
-                                (
-                                  MkPair
-                                    [Pattern]
-                                    [Expr]
-                                    (P_Ctor ctorName args)
-                                    body
-                                )
+                              {Pair Pattern Expr, List Token |
+                                (MkPair [Pattern] [Expr] (P_Ctor ctorName args) body),
                                 rest
+                              }
                             )
                       }
                   }
@@ -710,97 +704,66 @@ poly parseMatchArmWith =
       }
 
 poly rec parseMatchArmsWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
-      \acc : List (Pair Pattern Expr) =>
+      \acc : List ((Pattern, Expr)) =>
         matchList
           [Token]
-          [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
+          [Result ParseError (((List (Pair Pattern Expr)), (List Token)))]
           toks
           (
             Err
               [ParseError]
-              [Pair (List (Pair Pattern Expr)) (List Token)]
+              [((List (Pair Pattern Expr)), (List Token))]
               parseError
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] (eqU8 tag rBraceTag)
-                  (
-                    \u : U8 =>
-                      Ok
-                        [ParseError]
-                        [Pair (List (Pair Pattern Expr)) (List Token)]
-                        (
-                          MkPair
-                            [List (Pair Pattern Expr)]
-                            [List Token]
-                            (reverse [Pair Pattern Expr] acc)
-                            t
-                        )
-                  )
-                  (
-                    \u : U8 =>
-                      if [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] (eqU8 tag pipeTag)
-                        (
-                          \u : U8 =>
-                            match (parseMatchArmWith recurse toks) [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] {
-                              | Err e =>
-                                Err
-                                  [ParseError]
-                                  [Pair (List (Pair Pattern Expr)) (List Token)]
-                                  e
-                              | Ok armRes =>
-                                let arm = fstPatternExprToken armRes in
-                                let rest = sndPatternExprToken armRes in
-                                parseMatchArmsWith
-                                  recurse
-                                  rest
-                                  (cons [Pair Pattern Expr] arm acc)
-                            }
-                        )
-                        (
-                          \u : U8 =>
-                            Err
-                              [ParseError]
-                              [Pair (List (Pair Pattern Expr)) (List Token)]
-                              parseError
-                        )
-                  )
+                cond
+                  [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
+                  {|
+                    (eqU8 tag rBraceTag) =>
+                    Ok
+                    [ParseError]
+                    [Pair (List (Pair Pattern Expr)) (List Token)]
+                    (MkPair [List (Pair Pattern Expr)] [List Token] (reverse [Pair Pattern Expr] acc) t) |
+                    (eqU8 tag pipeTag) =>
+                    match
+                    (parseMatchArmWith recurse toks)
+                    [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))]
+                    {| Err e => Err [ParseError] [Pair (List (Pair Pattern Expr)) (List Token)] e | Ok armRes => let arm = fstPatternExprToken armRes in let rest = sndPatternExprToken armRes in parseMatchArmsWith recurse rest (cons [Pair Pattern Expr] arm acc)} |
+                    otherwise =>
+                    Err
+                    [ParseError]
+                    [Pair (List (Pair Pattern Expr)) (List Token)]
+                    parseError
+                  }
           )
 
 poly isAtomStartTag =
   \tag : U8 =>
-    if [Bool] (eqU8 tag identTag)
-      (\u : U8 => true)
-      (
-        \u : U8 =>
-          if [Bool] (eqU8 tag natTag)
-            (\u : U8 => true)
-            (
-              \u : U8 =>
-                if [Bool] (eqU8 tag lParenTag)
-                  (\u : U8 => true)
-                  (
-                    \u : U8 =>
-                      if [Bool] (eqU8 tag commaTag)
-                        (\u : U8 => true)
-                        (
-                          \u : U8 =>
-                            if [Bool] (eqU8 tag dotTag)
-                              (\u : U8 => true)
-                              (
-                                \u : U8 =>
-                                  if [Bool] (eqU8 tag hashTag)
-                                    (\u : U8 => true)
-                                    (\u : U8 => eqU8 tag lBraceTag)
-                              )
-                        )
-                  )
-            )
-      )
+    cond
+      [Bool]
+      {|
+        (eqU8 tag identTag) =>
+        true |
+        (eqU8 tag natTag) =>
+        true |
+        (eqU8 tag lParenTag) =>
+        true |
+        (eqU8 tag commaTag) =>
+        true |
+        (eqU8 tag dotTag) =>
+        true |
+        (eqU8 tag hashTag) =>
+        true |
+        otherwise =>
+        eqU8
+        tag
+        lBraceTag
+      }
 
 poly isAtomStart =
   \tok : Token => isAtomStartTag (tokenTag tok)
@@ -818,199 +781,83 @@ poly rec buildListExpr =
       )
 
 poly parseLiteralAtomWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError (Pair Expr (List Token))]
+        [Result ParseError ((Expr, (List Token)))]
         toks
-        (Err [ParseError] [Pair Expr (List Token)] parseError)
+        (Err [ParseError] [(Expr, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag identTag)
-                (
-                  \u : U8 =>
-                    Ok
-                      [ParseError]
-                      [Pair Expr (List Token)]
-                      (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)
-                )
-                (
-                  \u : U8 =>
-                    if [Result ParseError (Pair Expr (List Token))] (eqU8 tag natTag)
-                      (
-                        \u : U8 =>
-                          Ok
-                            [ParseError]
-                            [Pair Expr (List Token)]
-                            (
-                              MkPair
-                                [Expr]
-                                [List Token]
-                                (E_Nat (tokenNatValue h))
-                                t
-                            )
-                      )
-                      (
-                        \u : U8 =>
-                          if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lParenTag)
-                            (
-                              \u : U8 =>
-                                match (recurse t) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                  | Ok res =>
-                                    let inner = fstExprToken res in
-                                    let rest = sndExprToken res in
-                                    match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                      | Ok final =>
-                                        Ok
-                                          [ParseError]
-                                          [Pair Expr (List Token)]
-                                          (
-                                            MkPair
-                                              [Expr]
-                                              [List Token]
-                                              inner
-                                              final
-                                          )
-                                    }
-                                }
-                            )
-                            (
-                              \u : U8 =>
-                                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag commaTag)
-                                  (
-                                    \u : U8 =>
-                                      Ok
-                                        [ParseError]
-                                        [Pair Expr (List Token)]
-                                        (
-                                          MkPair
-                                            [Expr]
-                                            [List Token]
-                                            (E_Var ",")
-                                            t
-                                        )
-                                  )
-                                  (
-                                    \u : U8 =>
-                                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag dotTag)
-                                        (
-                                          \u : U8 =>
-                                            Ok
-                                              [ParseError]
-                                              [Pair Expr (List Token)]
-                                              (
-                                                MkPair
-                                                  [Expr]
-                                                  [List Token]
-                                                  (E_Var ".")
-                                                  t
-                                              )
-                                        )
-                                        (
-                                          \u : U8 =>
-                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
-                                              (
-                                                \u : U8 =>
-                                                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                    | Ok tvRes =>
-                                                      match tvRes [Result ParseError (Pair Expr (List Token))] {
-                                                        | MkPair tyVar afterTyVar =>
-                                                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                                                            (
-                                                              \u : U8 =>
-                                                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                                  | Ok afterOpen =>
-                                                                    matchList
-                                                                      [Token]
-                                                                      [Result ParseError (Pair Expr (List Token))]
-                                                                      afterOpen
-                                                                      (
-                                                                        Err
-                                                                          [ParseError]
-                                                                          [Pair Expr (List Token)]
-                                                                          parseError
-                                                                      )
-                                                                      (
-                                                                        \natTok : Token =>
-                                                                          \afterNat : List Token =>
-                                                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                                                              (
-                                                                                \u : U8 =>
-                                                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                                                    | Ok rest =>
-                                                                                      Ok
-                                                                                        [ParseError]
-                                                                                        [Pair Expr (List Token)]
-                                                                                        (
-                                                                                          MkPair
-                                                                                            [Expr]
-                                                                                            [List Token]
-                                                                                            (
-                                                                                              E_Nat
-                                                                                                (
-                                                                                                  tokenNatValue
-                                                                                                    natTok
-                                                                                                )
-                                                                                            )
-                                                                                            rest
-                                                                                        )
-                                                                                  }
-                                                                              )
-                                                                              (
-                                                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                                                              )
-                                                                      )
-                                                                }
-                                                            )
-                                                            (
-                                                              \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                                            )
-                                                      }
-                                                  }
-                                              )
-                                              (
-                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                              )
-                                        )
-                                  )
-                            )
-                      )
-                )
+              cond
+                [Result ParseError (Pair Expr (List Token))]
+                {|
+                  (eqU8 tag identTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var (tokenText h)) t) |
+                  (eqU8 tag natTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Nat (tokenNatValue h)) t) |
+                  (eqU8 tag lParenTag) =>
+                  match
+                  (recurse t)
+                  [Result ParseError (Pair Expr (List Token))]
+                  {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok res => let inner = fstExprToken res in let rest = sndExprToken res in match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok final => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] inner final)}} |
+                  (eqU8 tag commaTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var ",") t) |
+                  (eqU8 tag dotTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var ".") t) |
+                  (eqU8 tag hashTag) =>
+                  match
+                  (expectIdent t)
+                  [Result ParseError (Pair Expr (List Token))]
+                  {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok tvRes => match tvRes [Result ParseError (Pair Expr (List Token))] {| MkPair tyVar afterTyVar => if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8") (\u : U8 => match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok afterOpen => matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen (Err [ParseError] [Pair Expr (List Token)] parseError) (\natTok : Token => \afterNat : List Token => if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag) (\u : U8 => match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok rest => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)}) (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))}) (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)}} |
+                  otherwise =>
+                  Err
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  parseError
+                }
         )
 
 poly rec parseListElements =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
       \acc : List Expr =>
         matchList
           [Token]
-          [Result ParseError (Pair (List Expr) (List Token))]
+          [Result ParseError (((List Expr), (List Token)))]
           toks
-          (Err [ParseError] [Pair (List Expr) (List Token)] parseError)
+          (Err [ParseError] [((List Expr), (List Token))] parseError)
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (Pair (List Expr) (List Token))] (eqU8 tag rBraceTag)
+                if [Result ParseError (((List Expr), (List Token)))] (eqU8 tag rBraceTag)
                   (
                     \u : U8 =>
                       Ok
                         [ParseError]
-                        [Pair (List Expr) (List Token)]
-                        (MkPair [List Expr] [List Token] (reverse [Expr] acc) t)
+                        [((List Expr), (List Token))]
+                        ({List Expr, List Token | (reverse [Expr] acc), t})
                   )
                   (
                     \u : U8 =>
-                      match (parseLiteralAtomWith recurse toks) [Result ParseError (Pair (List Expr) (List Token))] {
-                        | Err e => Err [ParseError] [Pair (List Expr) (List Token)] e
+                      match (parseLiteralAtomWith recurse toks) [Result ParseError (((List Expr), (List Token)))] {
+                        | Err e => Err [ParseError] [((List Expr), (List Token))] e
                         | Ok elemRes =>
                           let elem = fstExprToken elemRes in
                           let rest = sndExprToken elemRes in
@@ -1020,63 +867,54 @@ poly rec parseListElements =
           )
 
 poly parseBraceBodyWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \afterBrace : List Token =>
-      match (parseType afterBrace) [Result ParseError (Pair Expr (List Token))] {
-        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+      match (parseType afterBrace) [Result ParseError ((Expr, (List Token)))] {
+        | Err e => Err [ParseError] [(Expr, (List Token))] e
         | Ok type1Res =>
           let afterType1 = sndTypeToken type1Res in
           matchList
             [Token]
-            [Result ParseError (Pair Expr (List Token))]
+            [Result ParseError ((Expr, (List Token)))]
             afterType1
-            (Err [ParseError] [Pair Expr (List Token)] parseError)
+            (Err [ParseError] [(Expr, (List Token))] parseError)
             (
               \h : Token =>
                 \t : List Token =>
-                  if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag h) commaTag)
+                  if [Result ParseError ((Expr, (List Token)))] (eqU8 (tokenTag h) commaTag)
                     (
                       \u : U8 =>
-                        match (parseType t) [Result ParseError (Pair Expr (List Token))] {
-                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        match (parseType t) [Result ParseError ((Expr, (List Token)))] {
+                          | Err e => Err [ParseError] [(Expr, (List Token))] e
                           | Ok type2Res =>
                             let afterType2 = sndTypeToken type2Res in
-                            match (expect afterType2 pipeTag) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                            match (expect afterType2 pipeTag) [Result ParseError ((Expr, (List Token)))] {
+                              | Err e => Err [ParseError] [(Expr, (List Token))] e
                               | Ok afterPipe =>
-                                match (parseLiteralAtomWith recurse afterPipe) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                match (parseLiteralAtomWith recurse afterPipe) [Result ParseError ((Expr, (List Token)))] {
+                                  | Err e => Err [ParseError] [(Expr, (List Token))] e
                                   | Ok firstRes =>
                                     let first = fstExprToken firstRes in
                                     let afterFirst = sndExprToken firstRes in
-                                    match (expect afterFirst commaTag) [Result ParseError (Pair Expr (List Token))] {
-                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                    match (expect afterFirst commaTag) [Result ParseError ((Expr, (List Token)))] {
+                                      | Err e => Err [ParseError] [(Expr, (List Token))] e
                                       | Ok afterComma =>
-                                        match (parseLiteralAtomWith recurse afterComma) [Result ParseError (Pair Expr (List Token))] {
-                                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                        match (parseLiteralAtomWith recurse afterComma) [Result ParseError ((Expr, (List Token)))] {
+                                          | Err e => Err [ParseError] [(Expr, (List Token))] e
                                           | Ok secondRes =>
                                             let second = fstExprToken secondRes in
                                             let afterSecond = sndExprToken secondRes in
-                                            match (expect afterSecond rBraceTag) [Result ParseError (Pair Expr (List Token))] {
-                                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                            match (expect afterSecond rBraceTag) [Result ParseError ((Expr, (List Token)))] {
+                                              | Err e => Err [ParseError] [(Expr, (List Token))] e
                                               | Ok rest =>
                                                 Ok
                                                   [ParseError]
-                                                  [Pair Expr (List Token)]
+                                                  [(Expr, (List Token))]
                                                   (
-                                                    MkPair
-                                                      [Expr]
-                                                      [List Token]
-                                                      (
-                                                        E_App
-                                                          (
-                                                            E_App
-                                                              (E_Var "MkPair")
-                                                              first
-                                                          )
-                                                          second
-                                                      )
+                                                    {Expr, List Token |
+                                                      (E_App (E_App (E_Var "MkPair") first) second),
                                                       rest
+                                                    }
                                                   )
                                             }
                                         }
@@ -1087,23 +925,22 @@ poly parseBraceBodyWith =
                     )
                     (
                       \u : U8 =>
-                        match (expect afterType1 pipeTag) [Result ParseError (Pair Expr (List Token))] {
-                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                        match (expect afterType1 pipeTag) [Result ParseError ((Expr, (List Token)))] {
+                          | Err e => Err [ParseError] [(Expr, (List Token))] e
                           | Ok afterPipe =>
-                            match (parseListElements recurse afterPipe (nil [Expr])) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                            match (parseListElements recurse afterPipe ({Expr |})) [Result ParseError ((Expr, (List Token)))] {
+                              | Err e => Err [ParseError] [(Expr, (List Token))] e
                               | Ok listRes =>
                                 let elements = fst [List Expr] [List Token] listRes in
                                 let rest = snd [List Expr] [List Token] listRes in
                                 Ok
                                   [ParseError]
-                                  [Pair Expr (List Token)]
+                                  [(Expr, (List Token))]
                                   (
-                                    MkPair
-                                      [Expr]
-                                      [List Token]
-                                      (buildListExpr elements)
+                                    {Expr, List Token |
+                                      (buildListExpr elements),
                                       rest
+                                    }
                                   )
                             }
                         }
@@ -1112,179 +949,60 @@ poly parseBraceBodyWith =
       }
 
 poly parseAtomWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError (Pair Expr (List Token))]
+        [Result ParseError ((Expr, (List Token)))]
         toks
-        (Err [ParseError] [Pair Expr (List Token)] parseError)
+        (Err [ParseError] [(Expr, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag identTag)
-                (
-                  \u : U8 =>
-                    Ok
-                      [ParseError]
-                      [Pair Expr (List Token)]
-                      (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)
-                )
-                (
-                  \u : U8 =>
-                    if [Result ParseError (Pair Expr (List Token))] (eqU8 tag natTag)
-                      (
-                        \u : U8 =>
-                          Ok
-                            [ParseError]
-                            [Pair Expr (List Token)]
-                            (
-                              MkPair
-                                [Expr]
-                                [List Token]
-                                (E_Nat (tokenNatValue h))
-                                t
-                            )
-                      )
-                      (
-                        \u : U8 =>
-                          if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lParenTag)
-                            (
-                              \u : U8 =>
-                                match (recurse t) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                  | Ok res =>
-                                    let inner = fstExprToken res in
-                                    let rest = sndExprToken res in
-                                    match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                      | Ok final =>
-                                        Ok
-                                          [ParseError]
-                                          [Pair Expr (List Token)]
-                                          (
-                                            MkPair
-                                              [Expr]
-                                              [List Token]
-                                              inner
-                                              final
-                                          )
-                                    }
-                                }
-                            )
-                            (
-                              \u : U8 =>
-                                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag commaTag)
-                                  (
-                                    \u : U8 =>
-                                      Ok
-                                        [ParseError]
-                                        [Pair Expr (List Token)]
-                                        (
-                                          MkPair
-                                            [Expr]
-                                            [List Token]
-                                            (E_Var ",")
-                                            t
-                                        )
-                                  )
-                                  (
-                                    \u : U8 =>
-                                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag dotTag)
-                                        (
-                                          \u : U8 =>
-                                            Ok
-                                              [ParseError]
-                                              [Pair Expr (List Token)]
-                                              (
-                                                MkPair
-                                                  [Expr]
-                                                  [List Token]
-                                                  (E_Var ".")
-                                                  t
-                                              )
-                                        )
-                                        (
-                                          \u : U8 =>
-                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
-                                              (
-                                                \u : U8 =>
-                                                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                    | Ok tvRes =>
-                                                      match tvRes [Result ParseError (Pair Expr (List Token))] {
-                                                        | MkPair tyVar afterTyVar =>
-                                                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                                                            (
-                                                              \u : U8 =>
-                                                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                                  | Ok afterOpen =>
-                                                                    matchList
-                                                                      [Token]
-                                                                      [Result ParseError (Pair Expr (List Token))]
-                                                                      afterOpen
-                                                                      (
-                                                                        Err
-                                                                          [ParseError]
-                                                                          [Pair Expr (List Token)]
-                                                                          parseError
-                                                                      )
-                                                                      (
-                                                                        \natTok : Token =>
-                                                                          \afterNat : List Token =>
-                                                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                                                              (
-                                                                                \u : U8 =>
-                                                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                                                    | Ok rest =>
-                                                                                      Ok
-                                                                                        [ParseError]
-                                                                                        [Pair Expr (List Token)]
-                                                                                        (
-                                                                                          MkPair
-                                                                                            [Expr]
-                                                                                            [List Token]
-                                                                                            (
-                                                                                              E_Nat
-                                                                                                (
-                                                                                                  tokenNatValue
-                                                                                                    natTok
-                                                                                                )
-                                                                                            )
-                                                                                            rest
-                                                                                        )
-                                                                                  }
-                                                                              )
-                                                                              (
-                                                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                                                              )
-                                                                      )
-                                                                }
-                                                            )
-                                                            (
-                                                              \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                                            )
-                                                      }
-                                                  }
-                                              )
-                                              (
-                                                \u : U8 =>
-                                                  if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
-                                                    (
-                                                      \u : U8 => parseBraceBodyWith recurse t
-                                                    )
-                                                    (
-                                                      \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                                    )
-                                              )
-                                        )
-                                  )
-                            )
-                      )
-                )
+              cond
+                [Result ParseError (Pair Expr (List Token))]
+                {|
+                  (eqU8 tag identTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var (tokenText h)) t) |
+                  (eqU8 tag natTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Nat (tokenNatValue h)) t) |
+                  (eqU8 tag lParenTag) =>
+                  match
+                  (recurse t)
+                  [Result ParseError (Pair Expr (List Token))]
+                  {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok res => let inner = fstExprToken res in let rest = sndExprToken res in match (expect rest rParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok final => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] inner final)}} |
+                  (eqU8 tag commaTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var ",") t) |
+                  (eqU8 tag dotTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  (MkPair [Expr] [List Token] (E_Var ".") t) |
+                  (eqU8 tag hashTag) =>
+                  match
+                  (expectIdent t)
+                  [Result ParseError (Pair Expr (List Token))]
+                  {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok tvRes => match tvRes [Result ParseError (Pair Expr (List Token))] {| MkPair tyVar afterTyVar => if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8") (\u : U8 => match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok afterOpen => matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen (Err [ParseError] [Pair Expr (List Token)] parseError) (\natTok : Token => \afterNat : List Token => if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag) (\u : U8 => match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok rest => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)}) (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))}) (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError)}} |
+                  (eqU8 tag lBraceTag) =>
+                  parseBraceBodyWith
+                  recurse
+                  t |
+                  otherwise =>
+                  Err
+                  [ParseError]
+                  [Pair Expr (List Token)]
+                  parseError
+                }
         )
 
 poly skipTypeArg =
@@ -1295,105 +1013,36 @@ poly skipTypeArg =
     }
 
 poly parseSimpleTypeWith =
-  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError (Pair Type (List Token))]
+        [Result ParseError ((Type, (List Token)))]
         toks
-        (Err [ParseError] [Pair Type (List Token)] parseError)
+        (Err [ParseError] [(Type, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair Type (List Token))] (eqU8 tag lParenTag)
-                (
-                  \u : U8 =>
-                    match (recurse t) [Result ParseError (Pair Type (List Token))] {
-                      | Err e => Err [ParseError] [Pair Type (List Token)] e
-                      | Ok res =>
-                        let inner = fstTypeToken res in
-                        let afterInner = sndTypeToken res in
-                        matchList
-                          [Token]
-                          [Result ParseError (Pair Type (List Token))]
-                          afterInner
-                          (Err [ParseError] [Pair Type (List Token)] parseError)
-                          (
-                            \h2 : Token =>
-                              \t2 : List Token =>
-                                if [Result ParseError (Pair Type (List Token))] (eqU8 (tokenTag h2) commaTag)
-                                  (
-                                    \u : U8 =>
-                                      match (recurse t2) [Result ParseError (Pair Type (List Token))] {
-                                        | Err e => Err [ParseError] [Pair Type (List Token)] e
-                                        | Ok res2 =>
-                                          let second = fstTypeToken res2 in
-                                          let afterSecond = sndTypeToken res2 in
-                                          match (expect afterSecond rParenTag) [Result ParseError (Pair Type (List Token))] {
-                                            | Err e => Err [ParseError] [Pair Type (List Token)] e
-                                            | Ok final =>
-                                              Ok
-                                                [ParseError]
-                                                [Pair Type (List Token)]
-                                                (
-                                                  MkPair
-                                                    [Type]
-                                                    [List Token]
-                                                    (
-                                                      Ty_App
-                                                        (
-                                                          Ty_App
-                                                            (Ty_Var "Pair")
-                                                            inner
-                                                        )
-                                                        second
-                                                    )
-                                                    final
-                                                )
-                                          }
-                                      }
-                                  )
-                                  (
-                                    \u : U8 =>
-                                      match (expect afterInner rParenTag) [Result ParseError (Pair Type (List Token))] {
-                                        | Err e => Err [ParseError] [Pair Type (List Token)] e
-                                        | Ok final =>
-                                          Ok
-                                            [ParseError]
-                                            [Pair Type (List Token)]
-                                            (
-                                              MkPair
-                                                [Type]
-                                                [List Token]
-                                                inner
-                                                final
-                                            )
-                                      }
-                                  )
-                          )
-                    }
-                )
-                (
-                  \u : U8 =>
-                    if [Result ParseError (Pair Type (List Token))] (eqU8 tag identTag)
-                      (
-                        \u : U8 =>
-                          Ok
-                            [ParseError]
-                            [Pair Type (List Token)]
-                            (
-                              MkPair
-                                [Type]
-                                [List Token]
-                                (Ty_Var (tokenText h))
-                                t
-                            )
-                      )
-                      (
-                        \u : U8 => Err [ParseError] [Pair Type (List Token)] parseError
-                      )
-                )
+              cond
+                [Result ParseError (Pair Type (List Token))]
+                {|
+                  (eqU8 tag lParenTag) =>
+                  match
+                  (recurse t)
+                  [Result ParseError (Pair Type (List Token))]
+                  {| Err e => Err [ParseError] [Pair Type (List Token)] e | Ok res => let inner = fstTypeToken res in let afterInner = sndTypeToken res in matchList [Token] [Result ParseError (Pair Type (List Token))] afterInner (Err [ParseError] [Pair Type (List Token)] parseError) (\h2 : Token => \t2 : List Token => if [Result ParseError (Pair Type (List Token))] (eqU8 (tokenTag h2) commaTag) (\u : U8 => match (recurse t2) [Result ParseError (Pair Type (List Token))] {| Err e => Err [ParseError] [Pair Type (List Token)] e | Ok res2 => let second = fstTypeToken res2 in let afterSecond = sndTypeToken res2 in match (expect afterSecond rParenTag) [Result ParseError (Pair Type (List Token))] {| Err e => Err [ParseError] [Pair Type (List Token)] e | Ok final => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] (Ty_App (Ty_App (Ty_Var "Pair") inner) second) final)}}) (\u : U8 => match (expect afterInner rParenTag) [Result ParseError (Pair Type (List Token))] {| Err e => Err [ParseError] [Pair Type (List Token)] e | Ok final => Ok [ParseError] [Pair Type (List Token)] (MkPair [Type] [List Token] inner final)}))} |
+                  (eqU8 tag identTag) =>
+                  Ok
+                  [ParseError]
+                  [Pair Type (List Token)]
+                  (MkPair [Type] [List Token] (Ty_Var (tokenText h)) t) |
+                  otherwise =>
+                  Err
+                  [ParseError]
+                  [Pair Type (List Token)]
+                  parseError
+                }
         )
 
 poly isTypeAtomStartTag =
@@ -1403,28 +1052,28 @@ poly isTypeAtomStartTag =
       (\u : U8 => eqU8 tag lParenTag)
 
 poly rec parseTypeAppLoopWith =
-  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
     \lhs : Type =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError (Pair Type (List Token))]
+          [Result ParseError ((Type, (List Token)))]
           toks
           (
             Ok
               [ParseError]
-              [Pair Type (List Token)]
-              (MkPair [Type] [List Token] lhs toks)
+              [(Type, (List Token))]
+              ({Type, List Token | lhs, toks})
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (Pair Type (List Token))] (isTypeAtomStartTag tag)
+                if [Result ParseError ((Type, (List Token)))] (isTypeAtomStartTag tag)
                   (
                     \u : U8 =>
-                      match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
-                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                      match (parseSimpleTypeWith recurse toks) [Result ParseError ((Type, (List Token)))] {
+                        | Err e => Err [ParseError] [(Type, (List Token))] e
                         | Ok rhsRes =>
                           let rhs = fstTypeToken rhsRes in
                           let rest = sndTypeToken rhsRes in
@@ -1435,16 +1084,16 @@ poly rec parseTypeAppLoopWith =
                     \u : U8 =>
                       Ok
                         [ParseError]
-                        [Pair Type (List Token)]
-                        (MkPair [Type] [List Token] lhs toks)
+                        [(Type, (List Token))]
+                        ({Type, List Token | lhs, toks})
                   )
           )
 
 poly parseTypeApplicationWith =
-  \recurse : (List Token -> Result ParseError (Pair Type (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
     \toks : List Token =>
-      match (parseSimpleTypeWith recurse toks) [Result ParseError (Pair Type (List Token))] {
-        | Err e => Err [ParseError] [Pair Type (List Token)] e
+      match (parseSimpleTypeWith recurse toks) [Result ParseError ((Type, (List Token)))] {
+        | Err e => Err [ParseError] [(Type, (List Token))] e
         | Ok headRes =>
           let head = fstTypeToken headRes in
           let rest = sndTypeToken headRes in
@@ -1455,38 +1104,37 @@ poly rec parseType =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (Pair Type (List Token))]
+      [Result ParseError ((Type, (List Token)))]
       toks
-      (Err [ParseError] [Pair Type (List Token)] parseError)
+      (Err [ParseError] [(Type, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            if [Result ParseError (Pair Type (List Token))] (eqU8 tag hashTag)
+            if [Result ParseError ((Type, (List Token)))] (eqU8 tag hashTag)
               (
                 \u : U8 =>
-                  match (expectIdent t) [Result ParseError (Pair Type (List Token))] {
-                    | Err e => Err [ParseError] [Pair Type (List Token)] e
+                  match (expectIdent t) [Result ParseError ((Type, (List Token)))] {
+                    | Err e => Err [ParseError] [(Type, (List Token))] e
                     | Ok idRes =>
                       let tyVar = fstNameToken idRes in
                       let afterVar = sndNameToken idRes in
-                      match (expect afterVar arrowTag) [Result ParseError (Pair Type (List Token))] {
-                        | Err e => Err [ParseError] [Pair Type (List Token)] e
+                      match (expect afterVar arrowTag) [Result ParseError ((Type, (List Token)))] {
+                        | Err e => Err [ParseError] [(Type, (List Token))] e
                         | Ok afterArrow =>
-                          match (parseType afterArrow) [Result ParseError (Pair Type (List Token))] {
-                            | Err e => Err [ParseError] [Pair Type (List Token)] e
+                          match (parseType afterArrow) [Result ParseError ((Type, (List Token)))] {
+                            | Err e => Err [ParseError] [(Type, (List Token))] e
                             | Ok bodyRes =>
                               let bodyTy = fstTypeToken bodyRes in
                               let rest = sndTypeToken bodyRes in
                               Ok
                                 [ParseError]
-                                [Pair Type (List Token)]
+                                [(Type, (List Token))]
                                 (
-                                  MkPair
-                                    [Type]
-                                    [List Token]
-                                    (Ty_Forall tyVar bodyTy)
+                                  {Type, List Token |
+                                    (Ty_Forall tyVar bodyTy),
                                     rest
+                                  }
                                 )
                           }
                       }
@@ -1494,41 +1142,40 @@ poly rec parseType =
               )
               (
                 \u : U8 =>
-                  match (parseTypeApplicationWith parseType toks) [Result ParseError (Pair Type (List Token))] {
-                    | Err e => Err [ParseError] [Pair Type (List Token)] e
+                  match (parseTypeApplicationWith parseType toks) [Result ParseError ((Type, (List Token)))] {
+                    | Err e => Err [ParseError] [(Type, (List Token))] e
                     | Ok appRes =>
                       let lhs = fstTypeToken appRes in
                       let rest = sndTypeToken appRes in
                       matchList
                         [Token]
-                        [Result ParseError (Pair Type (List Token))]
+                        [Result ParseError ((Type, (List Token)))]
                         rest
-                        (Ok [ParseError] [Pair Type (List Token)] appRes)
+                        (Ok [ParseError] [(Type, (List Token))] appRes)
                         (
                           \h2 : Token =>
                             \t2 : List Token =>
-                              if [Result ParseError (Pair Type (List Token))] (eqU8 (tokenTag h2) arrowTag)
+                              if [Result ParseError ((Type, (List Token)))] (eqU8 (tokenTag h2) arrowTag)
                                 (
                                   \u : U8 =>
-                                    match (parseType t2) [Result ParseError (Pair Type (List Token))] {
-                                      | Err e => Err [ParseError] [Pair Type (List Token)] e
+                                    match (parseType t2) [Result ParseError ((Type, (List Token)))] {
+                                      | Err e => Err [ParseError] [(Type, (List Token))] e
                                       | Ok rhsRes =>
                                         let rhs = fstTypeToken rhsRes in
                                         let finalRest = sndTypeToken rhsRes in
                                         Ok
                                           [ParseError]
-                                          [Pair Type (List Token)]
+                                          [(Type, (List Token))]
                                           (
-                                            MkPair
-                                              [Type]
-                                              [List Token]
-                                              (Ty_Arrow lhs rhs)
+                                            {Type, List Token |
+                                              (Ty_Arrow lhs rhs),
                                               finalRest
+                                            }
                                           )
                                     }
                                 )
                                 (
-                                  \u : U8 => Ok [ParseError] [Pair Type (List Token)] appRes
+                                  \u : U8 => Ok [ParseError] [(Type, (List Token))] appRes
                                 )
                         )
                   }
@@ -1542,122 +1189,93 @@ poly parseTypeApplication =
   \toks : List Token => parseTypeApplicationWith parseType toks
 
 poly rec parseAppLoopWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \lhs : Expr =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError (Pair Expr (List Token))]
+          [Result ParseError ((Expr, (List Token)))]
           toks
           (
             Ok
               [ParseError]
-              [Pair Expr (List Token)]
-              (MkPair [Expr] [List Token] lhs toks)
+              [(Expr, (List Token))]
+              ({Expr, List Token | lhs, toks})
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBracketTag)
-                  (
-                    \u : U8 =>
-                      match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
-                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                        | Ok afterType => parseAppLoopWith recurse lhs afterType
-                      }
-                  )
-                  (
-                    \u : U8 =>
-                      if [Result ParseError (Pair Expr (List Token))] (isAtomStartTag tag)
-                        (
-                          \u : U8 =>
-                            match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                              | Ok rhsRes =>
-                                let rhs = fstExprToken rhsRes in
-                                let rest = sndExprToken rhsRes in
-                                parseAppLoopWith recurse (E_App lhs rhs) rest
-                            }
-                        )
-                        (
-                          \u : U8 =>
-                            Ok
-                              [ParseError]
-                              [Pair Expr (List Token)]
-                              (MkPair [Expr] [List Token] lhs toks)
-                        )
-                  )
+                cond
+                  [Result ParseError (Pair Expr (List Token))]
+                  {|
+                    (eqU8 tag lBracketTag) =>
+                    match
+                    (skipTypeArg toks)
+                    [Result ParseError (Pair Expr (List Token))]
+                    {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok afterType => parseAppLoopWith recurse lhs afterType} |
+                    (isAtomStartTag tag) =>
+                    match
+                    (parseAtomWith recurse toks)
+                    [Result ParseError (Pair Expr (List Token))]
+                    {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok rhsRes => let rhs = fstExprToken rhsRes in let rest = sndExprToken rhsRes in parseAppLoopWith recurse (E_App lhs rhs) rest} |
+                    otherwise =>
+                    Ok
+                    [ParseError]
+                    [Pair Expr (List Token)]
+                    (MkPair [Expr] [List Token] lhs toks)
+                  }
           )
 
 poly rec parseAppLoopNoBraceWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \lhs : Expr =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError (Pair Expr (List Token))]
+          [Result ParseError ((Expr, (List Token)))]
           toks
           (
             Ok
               [ParseError]
-              [Pair Expr (List Token)]
-              (MkPair [Expr] [List Token] lhs toks)
+              [(Expr, (List Token))]
+              ({Expr, List Token | lhs, toks})
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBraceTag)
-                  (
-                    \u : U8 =>
-                      Ok
-                        [ParseError]
-                        [Pair Expr (List Token)]
-                        (MkPair [Expr] [List Token] lhs toks)
-                  )
-                  (
-                    \u : U8 =>
-                      if [Result ParseError (Pair Expr (List Token))] (eqU8 tag lBracketTag)
-                        (
-                          \u : U8 =>
-                            match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                              | Ok afterType => parseAppLoopNoBraceWith recurse lhs afterType
-                            }
-                        )
-                        (
-                          \u : U8 =>
-                            if [Result ParseError (Pair Expr (List Token))] (isAtomStartTag tag)
-                              (
-                                \u : U8 =>
-                                  match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                    | Ok rhsRes =>
-                                      let rhs = fstExprToken rhsRes in
-                                      let rest = sndExprToken rhsRes in
-                                      parseAppLoopNoBraceWith
-                                        recurse
-                                        (E_App lhs rhs)
-                                        rest
-                                  }
-                              )
-                              (
-                                \u : U8 =>
-                                  Ok
-                                    [ParseError]
-                                    [Pair Expr (List Token)]
-                                    (MkPair [Expr] [List Token] lhs toks)
-                              )
-                        )
-                  )
+                cond
+                  [Result ParseError (Pair Expr (List Token))]
+                  {|
+                    (eqU8 tag lBraceTag) =>
+                    Ok
+                    [ParseError]
+                    [Pair Expr (List Token)]
+                    (MkPair [Expr] [List Token] lhs toks) |
+                    (eqU8 tag lBracketTag) =>
+                    match
+                    (skipTypeArg toks)
+                    [Result ParseError (Pair Expr (List Token))]
+                    {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok afterType => parseAppLoopNoBraceWith recurse lhs afterType} |
+                    (isAtomStartTag tag) =>
+                    match
+                    (parseAtomWith recurse toks)
+                    [Result ParseError (Pair Expr (List Token))]
+                    {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok rhsRes => let rhs = fstExprToken rhsRes in let rest = sndExprToken rhsRes in parseAppLoopNoBraceWith recurse (E_App lhs rhs) rest} |
+                    otherwise =>
+                    Ok
+                    [ParseError]
+                    [Pair Expr (List Token)]
+                    (MkPair [Expr] [List Token] lhs toks)
+                  }
           )
 
 poly parseAppNoBraceWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
-      match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+      match (parseAtomWith recurse toks) [Result ParseError ((Expr, (List Token)))] {
+        | Err e => Err [ParseError] [(Expr, (List Token))] e
         | Ok headRes =>
           let head = fstExprToken headRes in
           let rest = sndExprToken headRes in
@@ -1665,10 +1283,10 @@ poly parseAppNoBraceWith =
       }
 
 poly parseAppWith =
-  \recurse : (List Token -> Result ParseError (Pair Expr (List Token))) =>
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
-      match (parseAtomWith recurse toks) [Result ParseError (Pair Expr (List Token))] {
-        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+      match (parseAtomWith recurse toks) [Result ParseError ((Expr, (List Token)))] {
+        | Err e => Err [ParseError] [(Expr, (List Token))] e
         | Ok headRes =>
           let head = fstExprToken headRes in
           let rest = sndExprToken headRes in
@@ -1685,229 +1303,74 @@ poly parseMatchArm =
   \toks : List Token => parseMatchArmWith parseExpr toks
 
 poly parseMatchArms =
-  \toks : List Token => parseMatchArmsWith parseExpr toks (nil [Pair Pattern Expr])
+  \toks : List Token => parseMatchArmsWith parseExpr toks ({Pair Pattern Expr |})
 
 poly rec parseExpr =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (Pair Expr (List Token))]
+      [Result ParseError ((Expr, (List Token)))]
       toks
-      (Err [ParseError] [Pair Expr (List Token)] parseError)
+      (Err [ParseError] [(Expr, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            if [Result ParseError (Pair Expr (List Token))] (eqU8 tag hashTag)
-              (
-                \u : U8 =>
-                  match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                    | Ok tvRes =>
-                      match tvRes [Result ParseError (Pair Expr (List Token))] {
-                        | MkPair tyVar afterTyVar =>
-                          if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8")
-                            (
-                              \u : U8 =>
-                                match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                  | Ok afterOpen =>
-                                    matchList
-                                      [Token]
-                                      [Result ParseError (Pair Expr (List Token))]
-                                      afterOpen
-                                      (
-                                        Err
-                                          [ParseError]
-                                          [Pair Expr (List Token)]
-                                          parseError
-                                      )
-                                      (
-                                        \natTok : Token =>
-                                          \afterNat : List Token =>
-                                            if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag)
-                                              (
-                                                \u : U8 =>
-                                                  match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {
-                                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                    | Ok rest =>
-                                                      Ok
-                                                        [ParseError]
-                                                        [Pair Expr (List Token)]
-                                                        (
-                                                          MkPair
-                                                            [Expr]
-                                                            [List Token]
-                                                            (
-                                                              E_Nat
-                                                                (
-                                                                  tokenNatValue
-                                                                    natTok
-                                                                )
-                                                            )
-                                                            rest
-                                                        )
-                                                  }
-                                              )
-                                              (
-                                                \u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError
-                                              )
-                                      )
-                                }
-                            )
-                            (
-                              \u : U8 =>
-                                match (expect afterTyVar fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                  | Ok bodyToks => parseExpr bodyToks
-                                }
-                            )
-                      }
-                  }
-              )
-              (
-                \u : U8 =>
-                  if [Result ParseError (Pair Expr (List Token))] (eqU8 tag backslashTag)
-                    (
-                      \u : U8 =>
-                        match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                          | Ok idRes =>
-                            let name = fstNameToken idRes in
-                            let afterName = sndNameToken idRes in
-                            match (skipAfter afterName fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
-                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                              | Ok bodyToks =>
-                                match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {
-                                  | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                  | Ok bodyRes =>
-                                    let body = fstExprToken bodyRes in
-                                    let rest = sndExprToken bodyRes in
-                                    Ok
-                                      [ParseError]
-                                      [Pair Expr (List Token)]
-                                      (
-                                        MkPair
-                                          [Expr]
-                                          [List Token]
-                                          (E_Lam name body)
-                                          rest
-                                      )
-                                }
-                            }
-                        }
-                    )
-                    (
-                      \u : U8 =>
-                        if [Result ParseError (Pair Expr (List Token))] (eqU8 tag kwLetTag)
-                          (
-                            \u : U8 =>
-                              match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
-                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                | Ok idRes =>
-                                  let name = fstNameToken idRes in
-                                  let afterName = sndNameToken idRes in
-                                  match (skipAfter afterName eqTag) [Result ParseError (Pair Expr (List Token))] {
-                                    | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                    | Ok valToks =>
-                                      match (parseExpr valToks) [Result ParseError (Pair Expr (List Token))] {
-                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                        | Ok valRes =>
-                                          let valExpr = fstExprToken valRes in
-                                          let afterVal = sndExprToken valRes in
-                                          match (expect afterVal kwInTag) [Result ParseError (Pair Expr (List Token))] {
-                                            | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                            | Ok bodyToks =>
-                                              match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {
-                                                | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                                | Ok bodyRes =>
-                                                  let bodyExpr = fstExprToken bodyRes in
-                                                  let rest = sndExprToken bodyRes in
-                                                  Ok
-                                                    [ParseError]
-                                                    [Pair Expr (List Token)]
-                                                    (
-                                                      MkPair
-                                                        [Expr]
-                                                        [List Token]
-                                                        (
-                                                          E_Let
-                                                            name
-                                                            valExpr
-                                                            bodyExpr
-                                                        )
-                                                        rest
-                                                    )
-                                              }
-                                          }
-                                      }
-                                  }
-                              }
-                          )
-                          (
-                            \u : U8 =>
-                              if [Result ParseError (Pair Expr (List Token))] (eqU8 tag kwMatchTag)
-                                (
-                                  \u : U8 =>
-                                    match (parseAppNoBraceWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
-                                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                      | Ok scrutRes =>
-                                        let scrutinee = fstExprToken scrutRes in
-                                        let afterScrut = sndExprToken scrutRes in
-                                        match (skipAfter afterScrut lBraceTag) [Result ParseError (Pair Expr (List Token))] {
-                                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                          | Ok inside =>
-                                            match (parseMatchArmsWith parseExpr inside (nil [Pair Pattern Expr])) [Result ParseError (Pair Expr (List Token))] {
-                                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
-                                              | Ok armsRes =>
-                                                let arms = fstArmsToken armsRes in
-                                                let rest = sndArmsToken armsRes in
-                                                Ok
-                                                  [ParseError]
-                                                  [Pair Expr (List Token)]
-                                                  (
-                                                    MkPair
-                                                      [Expr]
-                                                      [List Token]
-                                                      (E_Match scrutinee arms)
-                                                      rest
-                                                  )
-                                            }
-                                        }
-                                    }
-                                )
-                                (\u : U8 => parseAppWith parseExpr toks)
-                          )
-                    )
-              )
+            cond
+              [Result ParseError (Pair Expr (List Token))]
+              {|
+                (eqU8 tag hashTag) =>
+                match
+                (expectIdent t)
+                [Result ParseError (Pair Expr (List Token))]
+                {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok tvRes => match tvRes [Result ParseError (Pair Expr (List Token))] {| MkPair tyVar afterTyVar => if [Result ParseError (Pair Expr (List Token))] (eqListU8 tyVar "u8") (\u : U8 => match (expect afterTyVar lParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok afterOpen => matchList [Token] [Result ParseError (Pair Expr (List Token))] afterOpen (Err [ParseError] [Pair Expr (List Token)] parseError) (\natTok : Token => \afterNat : List Token => if [Result ParseError (Pair Expr (List Token))] (eqU8 (tokenTag natTok) natTag) (\u : U8 => match (expect afterNat rParenTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok rest => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Nat (tokenNatValue natTok)) rest)}) (\u : U8 => Err [ParseError] [Pair Expr (List Token)] parseError))}) (\u : U8 => match (expect afterTyVar fatArrowTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok bodyToks => parseExpr bodyToks})}} |
+                (eqU8 tag backslashTag) =>
+                match
+                (expectIdent t)
+                [Result ParseError (Pair Expr (List Token))]
+                {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok idRes => let name = fstNameToken idRes in let afterName = sndNameToken idRes in match (skipAfter afterName fatArrowTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok bodyToks => match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok bodyRes => let body = fstExprToken bodyRes in let rest = sndExprToken bodyRes in Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Lam name body) rest)}}} |
+                (eqU8 tag kwLetTag) =>
+                match
+                (expectIdent t)
+                [Result ParseError (Pair Expr (List Token))]
+                {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok idRes => let name = fstNameToken idRes in let afterName = sndNameToken idRes in match (skipAfter afterName eqTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok valToks => match (parseExpr valToks) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok valRes => let valExpr = fstExprToken valRes in let afterVal = sndExprToken valRes in match (expect afterVal kwInTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok bodyToks => match (parseExpr bodyToks) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok bodyRes => let bodyExpr = fstExprToken bodyRes in let rest = sndExprToken bodyRes in Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Let name valExpr bodyExpr) rest)}}}}} |
+                (eqU8 tag kwMatchTag) =>
+                match
+                (parseAppNoBraceWith parseExpr t)
+                [Result ParseError (Pair Expr (List Token))]
+                {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok scrutRes => let scrutinee = fstExprToken scrutRes in let afterScrut = sndExprToken scrutRes in match (skipAfter afterScrut lBraceTag) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok inside => match (parseMatchArmsWith parseExpr inside (nil [Pair Pattern Expr])) [Result ParseError (Pair Expr (List Token))] {| Err e => Err [ParseError] [Pair Expr (List Token)] e | Ok armsRes => let arms = fstArmsToken armsRes in let rest = sndArmsToken armsRes in Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Match scrutinee arms) rest)}}} |
+                otherwise =>
+                parseAppWith
+                parseExpr
+                toks
+              }
       )
 
 poly parseNamedDef =
   \defKind : DefKind =>
     \isRecursive : Bool =>
       \toks : List Token =>
-        match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok nameRes =>
             let name = fstNameToken nameRes in
             let afterName = sndNameToken nameRes in
-            match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
-              | Err e => Err [ParseError] [Pair Decl (List Token)] e
+            match (skipAfter afterName eqTag) [Result ParseError ((Decl, (List Token)))] {
+              | Err e => Err [ParseError] [(Decl, (List Token))] e
               | Ok bodyToks =>
-                match (parseExpr bodyToks) [Result ParseError (Pair Decl (List Token))] {
-                  | Err e => Err [ParseError] [Pair Decl (List Token)] e
+                match (parseExpr bodyToks) [Result ParseError ((Decl, (List Token)))] {
+                  | Err e => Err [ParseError] [(Decl, (List Token))] e
                   | Ok bodyRes =>
                     let body = fstExprToken bodyRes in
                     let rest = sndExprToken bodyRes in
                     Ok
                       [ParseError]
-                      [Pair Decl (List Token)]
+                      [(Decl, (List Token))]
                       (
-                        MkPair
-                          [Decl]
-                          [List Token]
-                          (D_Def defKind isRecursive name body)
+                        {Decl, List Token |
+                          (D_Def defKind isRecursive name body),
                           rest
+                        }
                       )
                 }
             }
@@ -1918,34 +1381,29 @@ poly rec parseCtorArity =
     \acc : U8 =>
       matchList
         [Token]
-        [Result ParseError (Pair U8 (List Token))]
+        [Result ParseError ((U8, (List Token)))]
         toks
-        (
-          Ok
-            [ParseError]
-            [Pair U8 (List Token)]
-            (MkPair [U8] [List Token] acc toks)
-        )
+        (Ok [ParseError] [(U8, (List Token))] ({U8, List Token | acc, toks}))
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair U8 (List Token))] (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
+              if [Result ParseError ((U8, (List Token)))] (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
-                      [Pair U8 (List Token)]
-                      (MkPair [U8] [List Token] acc toks)
+                      [(U8, (List Token))]
+                      ({U8, List Token | acc, toks})
                 )
                 (
                   \u : U8 =>
-                    match (parseSimpleType toks) [Result ParseError (Pair Type (List Token))] {
-                      | Err e => Err [ParseError] [Pair U8 (List Token)] e
+                    match (parseSimpleType toks) [Result ParseError ((Type, (List Token)))] {
+                      | Err e => Err [ParseError] [(U8, (List Token))] e
                       | Ok res =>
                         let rest = sndTypeToken res in
-                        match (checkedIncrementU8 acc) [Result ParseError (Pair U8 (List Token))] {
-                          | Err e => Err [ParseError] [Pair U8 (List Token)] e
+                        match (checkedIncrementU8 acc) [Result ParseError ((U8, (List Token)))] {
+                          | Err e => Err [ParseError] [(U8, (List Token))] e
                           | Ok nextAcc => parseCtorArity rest nextAcc
                         }
                     }
@@ -1954,231 +1412,177 @@ poly rec parseCtorArity =
 
 poly rec parseDataCtors =
   \toks : List Token =>
-    \acc : List (Pair (List U8) U8) =>
+    \acc : List (((List U8), U8)) =>
       matchList
         [Token]
-        [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))]
+        [Result ParseError (((List (Pair (List U8) U8)), (List Token)))]
         toks
         (
           Ok
             [ParseError]
-            [Pair (List (Pair (List U8) U8)) (List Token)]
+            [((List (Pair (List U8) U8)), (List Token))]
             (
-              MkPair
-                [List (Pair (List U8) U8)]
-                [List Token]
-                (reverse [Pair (List U8) U8] acc)
+              {List (Pair (List U8) U8), List Token |
+                (reverse [Pair (List U8) U8] acc),
                 toks
+              }
             )
         )
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (isTopLevelStartTag tag)
-                (
-                  \u : U8 =>
-                    Ok
-                      [ParseError]
-                      [Pair (List (Pair (List U8) U8)) (List Token)]
-                      (
-                        MkPair
-                          [List (Pair (List U8) U8)]
-                          [List Token]
-                          (reverse [Pair (List U8) U8] acc)
-                          toks
-                      )
-                )
-                (
-                  \u : U8 =>
-                    if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag pipeTag)
-                      (
-                        \u : U8 =>
-                          match (expectIdent t) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                            | Err e =>
-                              Err
-                                [ParseError]
-                                [Pair (List (Pair (List U8) U8)) (List Token)]
-                                e
-                            | Ok ctorRes =>
-                              let ctorName = fstNameToken ctorRes in
-                              let afterCtor = sndNameToken ctorRes in
-                              match (parseCtorArity afterCtor #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                                | Err e =>
-                                  Err
-                                    [ParseError]
-                                    [Pair (List (Pair (List U8) U8)) (List Token)]
-                                    e
-                                | Ok arityRes =>
-                                  let arity = fst [U8] [List Token] arityRes in
-                                  let rest = snd [U8] [List Token] arityRes in
-                                  parseDataCtors
-                                    rest
-                                    (
-                                      cons
-                                        [Pair (List U8) U8]
-                                        (MkPair [List U8] [U8] ctorName arity)
-                                        acc
-                                    )
-                              }
-                          }
-                      )
-                      (
-                        \u : U8 =>
-                          if [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] (eqU8 tag identTag)
-                            (
-                              \u : U8 =>
-                                let ctorName = tokenText h in
-                                match (parseCtorArity t #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
-                                  | Err e =>
-                                    Err
-                                      [ParseError]
-                                      [Pair (List (Pair (List U8) U8)) (List Token)]
-                                      e
-                                  | Ok arityRes =>
-                                    let arity = fst [U8] [List Token] arityRes in
-                                    let rest = snd [U8] [List Token] arityRes in
-                                    parseDataCtors
-                                      rest
-                                      (
-                                        cons
-                                          [Pair (List U8) U8]
-                                          (MkPair [List U8] [U8] ctorName arity)
-                                          acc
-                                      )
-                                }
-                            )
-                            (
-                              \u : U8 =>
-                                Err
-                                  [ParseError]
-                                  [Pair (List (Pair (List U8) U8)) (List Token)]
-                                  parseError
-                            )
-                      )
-                )
+              cond
+                [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))]
+                {|
+                  (isTopLevelStartTag tag) =>
+                  Ok
+                  [ParseError]
+                  [Pair (List (Pair (List U8) U8)) (List Token)]
+                  (MkPair [List (Pair (List U8) U8)] [List Token] (reverse [Pair (List U8) U8] acc) toks) |
+                  (eqU8 tag pipeTag) =>
+                  match
+                  (expectIdent t)
+                  [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))]
+                  {| Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e | Ok ctorRes => let ctorName = fstNameToken ctorRes in let afterCtor = sndNameToken ctorRes in match (parseCtorArity afterCtor #u8(0)) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {| Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e | Ok arityRes => let arity = fst [U8] [List Token] arityRes in let rest = snd [U8] [List Token] arityRes in parseDataCtors rest (cons [Pair (List U8) U8] (MkPair [List U8] [U8] ctorName arity) acc)}} |
+                  (eqU8 tag identTag) =>
+                  let
+                  ctorName =
+                  tokenText
+                  h
+                  in
+                  match
+                  (parseCtorArity t #u8(0))
+                  [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))]
+                  {| Err e => Err [ParseError] [Pair (List (Pair (List U8) U8)) (List Token)] e | Ok arityRes => let arity = fst [U8] [List Token] arityRes in let rest = snd [U8] [List Token] arityRes in parseDataCtors rest (cons [Pair (List U8) U8] (MkPair [List U8] [U8] ctorName arity) acc)} |
+                  otherwise =>
+                  Err
+                  [ParseError]
+                  [Pair (List (Pair (List U8) U8)) (List Token)]
+                  parseError
+                }
         )
 
 poly parseModuleDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok modRes =>
         let name = fstNameToken modRes in
         let rest = sndNameToken modRes in
         Ok
           [ParseError]
-          [Pair Decl (List Token)]
-          (MkPair [Decl] [List Token] (D_Module name) rest)
+          [(Decl, (List Token))]
+          ({Decl, List Token | (D_Module name), rest})
     }
 
 poly parseImportDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok modRes =>
         let modName = fstNameToken modRes in
         let afterMod = sndNameToken modRes in
-        match (expectIdent afterMod) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (expectIdent afterMod) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok symRes =>
             let sym = fstNameToken symRes in
             let rest = sndNameToken symRes in
             Ok
               [ParseError]
-              [Pair Decl (List Token)]
-              (MkPair [Decl] [List Token] (D_Import modName sym) rest)
+              [(Decl, (List Token))]
+              ({Decl, List Token | (D_Import modName sym), rest})
         }
     }
 
 poly parseExportDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok expRes =>
         let name = fstNameToken expRes in
         let rest = sndNameToken expRes in
         Ok
           [ParseError]
-          [Pair Decl (List Token)]
-          (MkPair [Decl] [List Token] (D_Export name) rest)
+          [(Decl, (List Token))]
+          ({Decl, List Token | (D_Export name), rest})
     }
 
 poly parseOpaqueDecl =
   \toks : List Token =>
-    match (expect toks kwTypeTag) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expect toks kwTypeTag) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok afterType =>
-        match (expectIdent afterType) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (expectIdent afterType) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok opqRes =>
             let name = fstNameToken opqRes in
             let afterName = sndNameToken opqRes in
             Ok
               [ParseError]
-              [Pair Decl (List Token)]
-              (MkPair [Decl] [List Token] (D_Opaque name) afterName)
+              [(Decl, (List Token))]
+              ({Decl, List Token | (D_Opaque name), afterName})
         }
     }
 
 poly parseNativeDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok natRes =>
         let name = fstNameToken natRes in
         let afterName = sndNameToken natRes in
-        match (expect afterName colonTag) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (expect afterName colonTag) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok afterColon =>
-            match (parseType afterColon) [Result ParseError (Pair Type (List Token))] {
-              | Err e => Err [ParseError] [Pair Decl (List Token)] e
+            match (parseType afterColon) [Result ParseError ((Type, (List Token)))] {
+              | Err e => Err [ParseError] [(Decl, (List Token))] e
               | Ok tyRes =>
                 let rest = sndTypeToken tyRes in
                 Ok
                   [ParseError]
-                  [Pair Decl (List Token)]
-                  (MkPair [Decl] [List Token] (D_Native name) rest)
+                  [(Decl, (List Token))]
+                  ({Decl, List Token | (D_Native name), rest})
             }
         }
     }
 
 poly parseTypeDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok tyRes =>
         let name = fstNameToken tyRes in
         let afterName = sndNameToken tyRes in
-        match (skipToTopLevelDecl afterName) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (skipToTopLevelDecl afterName) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok rest =>
             Ok
               [ParseError]
-              [Pair Decl (List Token)]
-              (MkPair [Decl] [List Token] (D_Type name) rest)
+              [(Decl, (List Token))]
+              ({Decl, List Token | (D_Type name), rest})
         }
     }
 
 poly parseDataDecl =
   \toks : List Token =>
-    match (expectIdent toks) [Result ParseError (Pair Decl (List Token))] {
-      | Err e => Err [ParseError] [Pair Decl (List Token)] e
+    match (expectIdent toks) [Result ParseError ((Decl, (List Token)))] {
+      | Err e => Err [ParseError] [(Decl, (List Token))] e
       | Ok datRes =>
         let name = fstNameToken datRes in
         let afterName = sndNameToken datRes in
-        match (skipAfter afterName eqTag) [Result ParseError (Pair Decl (List Token))] {
-          | Err e => Err [ParseError] [Pair Decl (List Token)] e
+        match (skipAfter afterName eqTag) [Result ParseError ((Decl, (List Token)))] {
+          | Err e => Err [ParseError] [(Decl, (List Token))] e
           | Ok afterEq =>
-            match (parseDataCtors afterEq (nil [Pair (List U8) U8])) [Result ParseError (Pair Decl (List Token))] {
-              | Err e => Err [ParseError] [Pair Decl (List Token)] e
+            match (parseDataCtors afterEq ({Pair (List U8) U8 |})) [Result ParseError ((Decl, (List Token)))] {
+              | Err e => Err [ParseError] [(Decl, (List Token))] e
               | Ok ctorsRes =>
-                let ctors = fst [List (Pair (List U8) U8)] [List Token] ctorsRes in
-                let rest = snd [List (Pair (List U8) U8)] [List Token] ctorsRes in
+                let ctors = fst [List (((List U8), U8))] [List Token] ctorsRes in
+                let rest = snd [List (((List U8), U8))] [List Token] ctorsRes in
                 Ok
                   [ParseError]
-                  [Pair Decl (List Token)]
-                  (MkPair [Decl] [List Token] (D_Data name ctors) rest)
+                  [(Decl, (List Token))]
+                  ({Decl, List Token | (D_Data name ctors), rest})
             }
         }
     }
@@ -2187,13 +1591,13 @@ poly parsePolyDecl =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (Pair Decl (List Token))]
+      [Result ParseError ((Decl, (List Token)))]
       toks
-      (Err [ParseError] [Pair Decl (List Token)] parseError)
+      (Err [ParseError] [(Decl, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
-            if [Result ParseError (Pair Decl (List Token))] (eqU8 (tokenTag h) kwRecTag)
+            if [Result ParseError ((Decl, (List Token)))] (eqU8 (tokenTag h) kwRecTag)
               (\u : U8 => parseNamedDef K_Poly true t)
               (\u : U8 => parseNamedDef K_Poly false toks)
       )
@@ -2202,62 +1606,51 @@ poly parseDecl =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (Pair Decl (List Token))]
+      [Result ParseError ((Decl, (List Token)))]
       toks
-      (Err [ParseError] [Pair Decl (List Token)] parseError)
+      (Err [ParseError] [(Decl, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwModuleTag)
-              (\u : U8 => parseModuleDecl t)
-              (
-                \u : U8 =>
-                  if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwImportTag)
-                    (\u : U8 => parseImportDecl t)
-                    (
-                      \u : U8 =>
-                        if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwExportTag)
-                          (\u : U8 => parseExportDecl t)
-                          (
-                            \u : U8 =>
-                              if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwOpaqueTag)
-                                (\u : U8 => parseOpaqueDecl t)
-                                (
-                                  \u : U8 =>
-                                    if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwNativeTag)
-                                      (\u : U8 => parseNativeDecl t)
-                                      (
-                                        \u : U8 =>
-                                          if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwTypeTag)
-                                            (\u : U8 => parseTypeDecl t)
-                                            (
-                                              \u : U8 =>
-                                                if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwDataTag)
-                                                  (\u : U8 => parseDataDecl t)
-                                                  (
-                                                    \u : U8 =>
-                                                      if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwPolyTag)
-                                                        (
-                                                          \u : U8 => parsePolyDecl t
-                                                        )
-                                                        (
-                                                          \u : U8 =>
-                                                            if [Result ParseError (Pair Decl (List Token))] (eqU8 tag kwCombinatorTag)
-                                                              (
-                                                                \u : U8 => parseNamedDef K_Combinator false t
-                                                              )
-                                                              (
-                                                                \u : U8 => Err [ParseError] [Pair Decl (List Token)] parseError
-                                                              )
-                                                        )
-                                                  )
-                                            )
-                                      )
-                                )
-                          )
-                    )
-              )
+            cond
+              [Result ParseError (Pair Decl (List Token))]
+              {|
+                (eqU8 tag kwModuleTag) =>
+                parseModuleDecl
+                t |
+                (eqU8 tag kwImportTag) =>
+                parseImportDecl
+                t |
+                (eqU8 tag kwExportTag) =>
+                parseExportDecl
+                t |
+                (eqU8 tag kwOpaqueTag) =>
+                parseOpaqueDecl
+                t |
+                (eqU8 tag kwNativeTag) =>
+                parseNativeDecl
+                t |
+                (eqU8 tag kwTypeTag) =>
+                parseTypeDecl
+                t |
+                (eqU8 tag kwDataTag) =>
+                parseDataDecl
+                t |
+                (eqU8 tag kwPolyTag) =>
+                parsePolyDecl
+                t |
+                (eqU8 tag kwCombinatorTag) =>
+                parseNamedDef
+                K_Combinator
+                false
+                t |
+                otherwise =>
+                Err
+                [ParseError]
+                [Pair Decl (List Token)]
+                parseError
+              }
       )
 
 poly rec parseProgramAcc =
@@ -2287,4 +1680,4 @@ poly rec parseProgramAcc =
         )
 
 poly parseProgram =
-  \toks : List Token => parseProgramAcc toks (nil [Decl])
+  \toks : List Token => parseProgramAcc toks ({Decl |})

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -948,6 +948,101 @@ poly parseBraceBodyWith =
             )
       }
 
+poly rec desugarCondLoop =
+  \arms : List ((Expr, Expr)) =>
+    \currentElse : Expr =>
+      matchList
+        [(Expr, Expr)]
+        [Expr]
+        arms
+        currentElse
+        (
+          \h : (Expr, Expr) =>
+            \t : List ((Expr, Expr)) =>
+              let condExpr = fst [Expr] [Expr] h in
+              let bodyExpr = snd [Expr] [Expr] h in
+              let lazyThen = E_Lam ("u") bodyExpr in
+              let lazyElse = E_Lam ("u") currentElse in
+              let ifCall = E_App (E_App (E_App (E_Var "if") condExpr) lazyThen) lazyElse in
+              desugarCondLoop t ifCall
+        )
+
+poly desugarCond =
+  \arms : List ((Expr, Expr)) =>
+    matchList
+      [(Expr, Expr)]
+      [Expr]
+      arms
+      (E_Var "error")
+      (
+        \h : (Expr, Expr) =>
+          \t : List ((Expr, Expr)) => desugarCondLoop t (snd [Expr] [Expr] h)
+      )
+
+poly rec parseCondArms =
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+    \toks : List Token =>
+      \acc : List ((Expr, Expr)) =>
+        matchList
+          [Token]
+          [Result ParseError ((Expr, (List Token)))]
+          toks
+          (Err [ParseError] [(Expr, (List Token))] parseError)
+          (
+            \h : Token =>
+              \t : List Token =>
+                let tag = tokenTag h in
+                cond
+                  [Result ParseError (Pair Expr (List Token))]
+                  {|
+                    (eqU8 tag rBraceTag) =>
+                    Ok
+                    [ParseError]
+                    [Pair Expr (List Token)]
+                    (MkPair [Expr] [List Token] (desugarCond acc) t) |
+                    (eqU8 tag pipeTag) =>
+                    match (recurse t) [Result ParseError (Pair Expr (List Token))] {
+                      | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                      | Ok condRes =>
+                        let condExpr = fstExprToken condRes in
+                        let afterCond = sndExprToken condRes in
+                        match (expect afterCond fatArrowTag) [Result ParseError (Pair Expr (List Token))] {
+                          | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                          | Ok afterArrow =>
+                            match (recurse afterArrow) [Result ParseError (Pair Expr (List Token))] {
+                              | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                              | Ok bodyRes =>
+                                let bodyExpr = fstExprToken bodyRes in
+                                let afterBody = sndExprToken bodyRes in
+                                parseCondArms recurse afterBody (cons [(Expr, Expr)] (MkPair [Expr] [Expr] condExpr bodyExpr) acc)
+                            }
+                        }
+                    } |
+                    otherwise => Err [ParseError] [Pair Expr (List Token)] parseError
+                  }
+          )
+
+poly parseCondWith =
+  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+    \toks : List Token =>
+      match (expect toks lBracketTag) [Result ParseError ((Expr, (List Token)))] {
+        | Err e => Err [ParseError] [(Expr, (List Token))] e
+        | Ok afterOpen =>
+          match (parseType afterOpen) [Result ParseError ((Expr, (List Token)))] {
+            | Err e => Err [ParseError] [(Expr, (List Token))] e
+            | Ok typeRes =>
+              let afterType = sndTypeToken typeRes in
+              match (expect afterType rBracketTag) [Result ParseError ((Expr, (List Token)))] {
+                | Err e => Err [ParseError] [(Expr, (List Token))] e
+                | Ok afterClose =>
+                  match (expect afterClose lBraceTag) [Result ParseError ((Expr, (List Token)))] {
+                    | Err e => Err [ParseError] [(Expr, (List Token))] e
+                    | Ok inside => parseCondArms recurse inside (nil [(Expr, Expr)])
+                  }
+              }
+          }
+      }
+
 poly parseAtomWith =
   \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
     \toks : List Token =>
@@ -964,10 +1059,9 @@ poly parseAtomWith =
                 [Result ParseError (Pair Expr (List Token))]
                 {|
                   (eqU8 tag identTag) =>
-                  Ok
-                  [ParseError]
-                  [Pair Expr (List Token)]
-                  (MkPair [Expr] [List Token] (E_Var (tokenText h)) t) |
+                  if [Result ParseError (Pair Expr (List Token))] (eqListU8 (tokenText h) "cond")
+                    (\u : U8 => parseCondWith recurse t)
+                    (\u : U8 => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)) |
                   (eqU8 tag natTag) =>
                   Ok
                   [ParseError]

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -34,7 +34,11 @@ import Prelude ltU8
 
 import Prelude addU8
 
+import Prelude append
+
 import Prelude subU8
+
+import Prelude u8ToDigits
 
 import Prelude U8
 
@@ -955,6 +959,89 @@ poly parseBraceBodyWith =
             )
       }
 
+poly rec prependArmBodies =
+  \arms : List (Pair Pattern Expr) =>
+    \rest : List Expr =>
+      matchList
+        [Pair Pattern Expr]
+        [List Expr]
+        arms
+        rest
+        (
+          \h : Pair Pattern Expr =>
+            \t : List (Pair Pattern Expr) =>
+              prependArmBodies t (cons [Expr] (snd [Pattern] [Expr] h) rest)
+        )
+
+poly rec exprListMentionsName =
+  \name : List U8 =>
+    \exprs : List Expr =>
+      matchList
+        [Expr]
+        [Bool]
+        exprs
+        false
+        (
+          \expr : Expr =>
+            \rest : List Expr =>
+              match expr [Bool] {
+                | E_Var varName =>
+                  if [Bool] (eqListU8 name varName)
+                    (\u : U8 => true)
+                    (\u : U8 => exprListMentionsName name rest)
+                | E_App l r =>
+                  exprListMentionsName name (cons [Expr] l (cons [Expr] r rest))
+                | E_Lam varName body =>
+                  if [Bool] (eqListU8 name varName)
+                    (\u : U8 => true)
+                    (\u : U8 => exprListMentionsName name (cons [Expr] body rest))
+                | E_Let varName value body =>
+                  if [Bool] (eqListU8 name varName)
+                    (\u : U8 => true)
+                    (\u : U8 => exprListMentionsName name (cons [Expr] value (cons [Expr] body rest)))
+                | E_Nat n => exprListMentionsName name rest
+                | E_Match scrutinee arms =>
+                  exprListMentionsName name (cons [Expr] scrutinee (prependArmBodies arms rest))
+              }
+        )
+
+poly exprMentionsName =
+  \name : List U8 =>
+    \expr : Expr =>
+      exprListMentionsName name (cons [Expr] expr ({Expr |}))
+
+poly rec freshCondDelayNameFrom =
+  \thenExpr : Expr =>
+    \elseExpr : Expr =>
+      \n : U8 =>
+        let candidate = append [U8] "__cond_u" (u8ToDigits n) in
+        if [List U8] (or (exprMentionsName candidate thenExpr) (exprMentionsName candidate elseExpr))
+          (
+            \u : U8 =>
+              if [List U8] (ltU8 n #u8(255))
+                (\u2 : U8 => freshCondDelayNameFrom thenExpr elseExpr (addU8 n #u8(1)))
+                (\u2 : U8 => "__cond_u_overflow")
+          )
+          (\u : U8 => candidate)
+
+poly freshCondDelayName =
+  \thenExpr : Expr =>
+    \elseExpr : Expr =>
+      if [List U8] (or (exprMentionsName "u" thenExpr) (exprMentionsName "u" elseExpr))
+        (\u : U8 => freshCondDelayNameFrom thenExpr elseExpr #u8(0))
+        (\u : U8 => "u")
+
+poly isOtherwiseExpr =
+  \expr : Expr =>
+    match expr [Bool] {
+      | E_Var name => eqListU8 name "otherwise"
+      | E_App l r => false
+      | E_Lam name body => false
+      | E_Let name value body => false
+      | E_Nat n => false
+      | E_Match scrutinee arms => false
+    }
+
 poly rec desugarCondLoop =
   \arms : List ((Expr, Expr)) =>
     \currentElse : Expr =>
@@ -968,8 +1055,9 @@ poly rec desugarCondLoop =
             \t : List ((Expr, Expr)) =>
               let condExpr = fst [Expr] [Expr] h in
               let bodyExpr = snd [Expr] [Expr] h in
-              let lazyThen = E_Lam ("u") bodyExpr in
-              let lazyElse = E_Lam ("u") currentElse in
+              let delayName = freshCondDelayName bodyExpr currentElse in
+              let lazyThen = E_Lam delayName bodyExpr in
+              let lazyElse = E_Lam delayName currentElse in
               let ifCall = E_App (E_App (E_App (E_Var "if") condExpr) lazyThen) lazyElse in
               desugarCondLoop t ifCall
         )
@@ -1003,10 +1091,7 @@ poly rec parseCondArms =
                   [Result ParseError (Pair Expr (List Token))]
                   {|
                     (eqU8 tag rBraceTag) =>
-                    Ok
-                    [ParseError]
-                    [Pair Expr (List Token)]
-                    (MkPair [Expr] [List Token] (desugarCond acc) t) |
+                    Err [ParseError] [Pair Expr (List Token)] parseError |
                     (eqU8 tag pipeTag) =>
                     match (recurse t) [Result ParseError (Pair Expr (List Token))] {
                       | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -1021,7 +1106,19 @@ poly rec parseCondArms =
                               | Ok bodyRes =>
                                 let bodyExpr = fstExprToken bodyRes in
                                 let afterBody = sndExprToken bodyRes in
-                                parseCondArms recurse afterBody (cons [(Expr, Expr)] (MkPair [Expr] [Expr] condExpr bodyExpr) acc)
+                                if [Result ParseError (Pair Expr (List Token))] (isOtherwiseExpr condExpr)
+                                  (
+                                    \u : U8 =>
+                                      match (expect afterBody rBraceTag) [Result ParseError (Pair Expr (List Token))] {
+                                        | Err e => Err [ParseError] [Pair Expr (List Token)] e
+                                        | Ok rest =>
+                                          Ok
+                                            [ParseError]
+                                            [Pair Expr (List Token)]
+                                            (MkPair [Expr] [List Token] (desugarCond (cons [(Expr, Expr)] (MkPair [Expr] [Expr] condExpr bodyExpr) acc)) rest)
+                                      }
+                                  )
+                                  (\u : U8 => parseCondArms recurse afterBody (cons [(Expr, Expr)] (MkPair [Expr] [Expr] condExpr bodyExpr) acc))
                             }
                         }
                     } |

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -116,6 +116,8 @@ import Lexer T_KwType
 
 import Lexer T_KwData
 
+import Lexer T_KwCond
+
 import Lexer T_Ident
 
 import Lexer T_Nat
@@ -235,6 +237,8 @@ export kwCombinatorTag
 export kwTypeTag
 
 export kwDataTag
+
+export kwCondTag
 
 export fstNameToken
 
@@ -460,6 +464,9 @@ poly kwTypeTag =
 
 poly kwDataTag =
   tokenTag T_KwData
+
+poly kwCondTag =
+  tokenTag T_KwCond
 
 poly fstTypeToken =
   \p : (Type, (List Token)) => fst [Type] [List Token] p
@@ -1058,10 +1065,10 @@ poly parseAtomWith =
               cond
                 [Result ParseError (Pair Expr (List Token))]
                 {|
+                  (eqU8 tag kwCondTag) =>
+                  parseCondWith recurse t |
                   (eqU8 tag identTag) =>
-                  if [Result ParseError (Pair Expr (List Token))] (eqListU8 (tokenText h) "cond")
-                    (\u : U8 => parseCondWith recurse t)
-                    (\u : U8 => Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Var (tokenText h)) t)) |
+                  Ok [ParseError] [Pair Expr (List Token)] (MkPair [Expr] [List Token] (E_Var (tokenText h)) t) |
                   (eqU8 tag natTag) =>
                   Ok
                   [ParseError]

--- a/bootstrap/src/telemetry.trip
+++ b/bootstrap/src/telemetry.trip
@@ -61,14 +61,14 @@ export phase4
 poly phase1 =
   \source : List U8 =>
     match (tokenize source) [List Token] {
-      | Err e => nil [Token]
+      | Err e => {Token |}
       | Ok toks => toks
     }
 
 poly phase2 =
   \toks : List Token =>
     match (parseProgram toks) [List Decl] {
-      | Err e => nil [Decl]
+      | Err e => {Decl |}
       | Ok decls => decls
     }
 
@@ -83,14 +83,13 @@ poly phase4 =
   \globals : Avl (List U8) Lower =>
     let entries = toListEntries [List U8] [Lower] globals in
     map
-      [Pair (List U8) Lower]
-      [Pair (List U8) Comb]
+      [((List U8), Lower)]
+      [((List U8), Comb)]
       (
-        \entry : Pair (List U8) Lower =>
-          MkPair
-            [List U8]
-            [Comb]
-            (fst [List U8] [Lower] entry)
+        \entry : ((List U8), Lower) =>
+          {List U8, Comb |
+            (fst [List U8] [Lower] entry),
             (lowerToComb (snd [List U8] [Lower] entry))
+          }
       )
       entries

--- a/bootstrap/src/unparse.trip
+++ b/bootstrap/src/unparse.trip
@@ -138,34 +138,47 @@ poly singletonU8 =
 
 poly u8ToDigits =
   \n : U8 =>
-    if [List U8] (ltU8 n #u8(10))
-      (\u : U8 => singletonU8 (digitToAscii n))
-      (
-        \u : U8 =>
-          if [List U8] (ltU8 n #u8(100))
-            (
-              \u : U8 =>
-                cons
-                  [U8]
-                  (digitToAscii (divU8 n #u8(10)))
-                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
-            )
-            (
-              \u : U8 =>
-                let hundreds = divU8 n #u8(100) in
-                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-                let ones = modU8 n #u8(10) in
-                cons
-                  [U8]
-                  (digitToAscii hundreds)
-                  (
-                    cons
-                      [U8]
-                      (digitToAscii tens)
-                      (singletonU8 (digitToAscii ones))
-                  )
-            )
-      )
+    cond
+      [List U8]
+      {|
+        (ltU8 n #u8(10)) =>
+        singletonU8
+        (digitToAscii n) |
+        (ltU8 n #u8(100)) =>
+        cons
+        [U8]
+        (digitToAscii (divU8 n #u8(10)))
+        (singletonU8 (digitToAscii (modU8 n #u8(10)))) |
+        otherwise =>
+        let
+        hundreds =
+        divU8
+        n
+        #
+        u8
+        (100)
+        in
+        let
+        tens =
+        modU8
+        (divU8 n #u8(10))
+        #
+        u8
+        (10)
+        in
+        let
+        ones =
+        modU8
+        n
+        #
+        u8
+        (10)
+        in
+        cons
+        [U8]
+        (digitToAscii hundreds)
+        (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+      }
 
 poly terminalTag =
   \t : Terminal =>

--- a/lib/avl.trip
+++ b/lib/avl.trip
@@ -300,21 +300,19 @@ poly rec extractMin =
   #K =>
     #V =>
       \t : Avl K V =>
-        match t [Pair K (Pair V (Avl K V))] {
-          | Empty => error [Pair K (Pair V (Avl K V))]
+        match t [(K, (Pair V (Avl K V)))] {
+          | Empty => error [(K, (Pair V (Avl K V)))]
           | Node l k v _ r =>
-            match l [Pair K (Pair V (Avl K V))] {
+            match l [(K, (Pair V (Avl K V)))] {
               | Empty =>
-                MkPair [K] [Pair V (Avl K V)] k (MkPair [V] [Avl K V] v r)
+                {K, Pair V (Avl K V) | k, (MkPair [V] [Avl K V] v r)}
               | Node _ _ _ _ _ =>
-                match (extractMin [K] [V] l) [Pair K (Pair V (Avl K V))] {
+                match (extractMin [K] [V] l) [(K, (Pair V (Avl K V)))] {
                   | MkPair minK minRest =>
-                    match minRest [Pair V (Avl K V)] {
+                    match minRest [(V, (Avl K V))] {
                       | MkPair minV newLeft =>
-                        MkPair
-                          [K]
-                          [Pair V (Avl K V)]
-                          minK
+                        {K, Pair V (Avl K V) |
+                          minK,
                           (
                             MkPair
                               [V]
@@ -322,6 +320,7 @@ poly rec extractMin =
                               minV
                               (balance [K] [V] (mkNode [K] [V] newLeft k v r))
                           )
+                        }
                     }
                 }
             }
@@ -335,9 +334,9 @@ poly deleteRoot =
           match r [Avl K V] {
             | Empty => l
             | Node _ _ _ _ _ =>
-              match (extractMin [K] [V] r) [Pair K (Pair V (Avl K V))] {
+              match (extractMin [K] [V] r) [(K, (Pair V (Avl K V)))] {
                 | MkPair minK minRest =>
-                  match minRest [Pair V (Avl K V)] {
+                  match minRest [(V, (Avl K V))] {
                     | MkPair minV newRight =>
                       balance [K] [V] (mkNode [K] [V] l minK minV newRight)
                   }
@@ -398,7 +397,7 @@ poly rec toListKeys =
     #V =>
       \t : Avl K V =>
         match t [List K] {
-          | Empty => nil [K]
+          | Empty => {K |}
           | Node l k _ _ r =>
             append
               [K]
@@ -410,28 +409,28 @@ poly rec toListEntries =
   #K =>
     #V =>
       \t : Avl K V =>
-        match t [List (Pair K V)] {
-          | Empty => nil [Pair K V]
+        match t [List ((K, V))] {
+          | Empty => {Pair K V |}
           | Node l k v _ r =>
             append
-              [Pair K V]
+              [(K, V)]
               (toListEntries [K] [V] l)
-              (cons [Pair K V] (MkPair [K] [V] k v) (toListEntries [K] [V] r))
+              (cons [(K, V)] ({K, V | k, v}) (toListEntries [K] [V] r))
         }
 
 poly rec fromList =
   #K =>
     #V =>
       \lteKey : K -> K -> Bool =>
-        \entries : List (Pair K V) =>
+        \entries : List ((K, V)) =>
           matchList
-            [Pair K V]
+            [(K, V)]
             [Avl K V]
             entries
             (empty [K] [V])
             (
-              \entry : Pair K V =>
-                \rest : List (Pair K V) =>
+              \entry : (K, V) =>
+                \rest : List ((K, V)) =>
                   let acc = fromList [K] [V] lteKey rest in
                   insert
                     [K]

--- a/lib/bin.trip
+++ b/lib/bin.trip
@@ -184,8 +184,8 @@ poly rec divModBinAcc =
   \n : Bin =>
     \d : Bin =>
       \q : Bin =>
-        if [Pair Bin Bin] (ltBin n d)
-          (\u : U8 => MkPair [Bin] [Bin] q n)
+        if [(Bin, Bin)] (ltBin n d)
+          (\u : U8 => {Bin, Bin | q, n})
           (\u : U8 => divModBinAcc (subBin n d) d (incBin q))
 
 poly divModBin =
@@ -207,9 +207,9 @@ poly rec binToDigitsAcc =
             let res = divModBin val ten in
             let q = fst [Bin] [Bin] res in
             let r = snd [Bin] [Bin] res in
-            let digit = if [U8] (isZeroBin r) (\u : U8 => '0') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(1))) (\u : U8 => '1') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(2))) (\u : U8 => '2') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(3))) (\u : U8 => '3') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(4))) (\u : U8 => '4') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(5))) (\u : U8 => '5') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(6))) (\u : U8 => '6') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(7))) (\u : U8 => '7') (\u : U8 => if [U8] (eqBin r (u8ToBin #u8(8))) (\u : U8 => '8') (\u : U8 => '9'))))))))) in
+            let digit = cond [U8] {| (isZeroBin r) => '0' | (eqBin r (u8ToBin #u8(1))) => '1' | (eqBin r (u8ToBin #u8(2))) => '2' | (eqBin r (u8ToBin #u8(3))) => '3' | (eqBin r (u8ToBin #u8(4))) => '4' | (eqBin r (u8ToBin #u8(5))) => '5' | (eqBin r (u8ToBin #u8(6))) => '6' | (eqBin r (u8ToBin #u8(7))) => '7' | (eqBin r (u8ToBin #u8(8))) => '8' | otherwise => '9'} in
             binToDigitsAcc q (cons [U8] digit acc)
         )
 
 poly binToDigits =
-  \b : Bin => binToDigitsAcc b (nil [U8])
+  \b : Bin => binToDigitsAcc b ("")

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -1361,8 +1361,10 @@ function parseDelayLambda(
   if (idx >= stripped.length || stripped[idx]!.text !== "\\") return undefined;
   idx++;
   while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
-  if (idx >= stripped.length || stripped[idx]!.kind !== "ident")
+  const nameToken = stripped[idx];
+  if (idx >= stripped.length || !nameToken || nameToken.kind !== "ident")
     return undefined;
+  if (nameToken.text !== "u") return undefined;
   idx++;
   while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
   if (idx >= stripped.length || stripped[idx]!.text !== ":") return undefined;
@@ -1375,6 +1377,12 @@ function parseDelayLambda(
   idx++;
 
   const bodyTokens = stripped.slice(idx);
+  for (let i = 0; i < bodyTokens.length; i++) {
+    const token = bodyTokens[i]!;
+    if (token.kind !== "ident" || token.text !== nameToken.text) continue;
+    if (previousSyntax(bodyTokens, i)?.text === "\\") continue;
+    return undefined;
+  }
   return { bodyTokens, endIndex: arg.endIndex };
 }
 

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -1361,7 +1361,8 @@ function parseDelayLambda(
   if (idx >= stripped.length || stripped[idx]!.text !== "\\") return undefined;
   idx++;
   while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
-  if (idx >= stripped.length || stripped[idx]!.kind !== "ident") return undefined;
+  if (idx >= stripped.length || stripped[idx]!.kind !== "ident")
+    return undefined;
   idx++;
   while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
   if (idx >= stripped.length || stripped[idx]!.text !== ":") return undefined;
@@ -1645,7 +1646,9 @@ function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
     // 6. Degenerate if chain simplification to cond
     const condChainMatch = parseCondChain(tokens, i);
     if (condChainMatch) {
-      const armLines = condChainMatch.arms.map(arm => `| ${arm.condText} => ${arm.bodyText}`).join("\n      ");
+      const armLines = condChainMatch.arms
+        .map((arm) => `| ${arm.condText} => ${arm.bodyText}`)
+        .join("\n      ");
       const replacement = `cond [${condChainMatch.typeText}] {
       ${armLines}
       | otherwise => ${condChainMatch.defaultBodyText}

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -1348,6 +1348,140 @@ function matchPairType(
   };
 }
 
+function parseDelayLambda(
+  tokens: readonly Token[],
+  index: number,
+): { bodyTokens: Token[]; endIndex: number } | undefined {
+  const arg = parseArgExpression(tokens, index);
+  if (!arg) return undefined;
+
+  const stripped = stripOuterParens(arg.tokens);
+  let idx = 0;
+  while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
+  if (idx >= stripped.length || stripped[idx]!.text !== "\\") return undefined;
+  idx++;
+  while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
+  if (idx >= stripped.length || stripped[idx]!.kind !== "ident") return undefined;
+  idx++;
+  while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
+  if (idx >= stripped.length || stripped[idx]!.text !== ":") return undefined;
+  idx++;
+  while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
+  if (idx >= stripped.length || stripped[idx]!.text !== "U8") return undefined;
+  idx++;
+  while (idx < stripped.length && isComment(stripped[idx]!)) idx++;
+  if (idx >= stripped.length || stripped[idx]!.text !== "=>") return undefined;
+  idx++;
+
+  const bodyTokens = stripped.slice(idx);
+  return { bodyTokens, endIndex: arg.endIndex };
+}
+
+function matchIfExpression(
+  tokens: readonly Token[],
+  index: number,
+):
+  | {
+      typeText: string;
+      condText: string;
+      thenBody: Token[];
+      elseBody: Token[];
+      endIndex: number;
+    }
+  | undefined {
+  const token = tokens[index];
+  if (token?.text !== "if") return undefined;
+
+  const next1 = nextSyntaxWithIndex(tokens, index);
+  if (next1?.token.text !== "[") return undefined;
+
+  const typeTokens: Token[] = [];
+  let cursor = next1.index + 1;
+  let depth = 1;
+  while (cursor < tokens.length) {
+    const t = tokens[cursor]!;
+    if (t.text === "[") depth++;
+    if (t.text === "]") depth--;
+    if (depth === 0) break;
+    typeTokens.push(t);
+    cursor++;
+  }
+  if (cursor >= tokens.length) return undefined;
+  const endTypeIdx = cursor;
+
+  const condArg = parseArgExpression(tokens, endTypeIdx + 1);
+  if (!condArg) return undefined;
+
+  const thenLambda = parseDelayLambda(tokens, condArg.endIndex + 1);
+  if (!thenLambda) return undefined;
+
+  const elseLambda = parseDelayLambda(tokens, thenLambda.endIndex + 1);
+  if (!elseLambda) return undefined;
+
+  return {
+    typeText: formatInline(typeTokens),
+    condText: formatInline(condArg.tokens),
+    thenBody: thenLambda.bodyTokens,
+    elseBody: elseLambda.bodyTokens,
+    endIndex: elseLambda.endIndex,
+  };
+}
+
+function parseCondChain(
+  tokens: readonly Token[],
+  index: number,
+):
+  | {
+      typeText: string;
+      arms: { condText: string; bodyText: string }[];
+      defaultBodyText: string;
+      endIndex: number;
+    }
+  | undefined {
+  const firstIf = matchIfExpression(tokens, index);
+  if (!firstIf) return undefined;
+
+  const typeText = firstIf.typeText;
+  const arms: { condText: string; bodyText: string }[] = [];
+
+  arms.push({
+    condText: firstIf.condText,
+    bodyText: formatInline(firstIf.thenBody),
+  });
+
+  let currentElseTokens = firstIf.elseBody;
+  let currentEndIndex = firstIf.endIndex;
+
+  for (;;) {
+    const stripped = stripOuterParens(currentElseTokens);
+    const elseIfMatch = matchIfExpression(stripped, 0);
+    if (
+      elseIfMatch &&
+      elseIfMatch.typeText === typeText &&
+      elseIfMatch.endIndex === stripped.length - 1
+    ) {
+      arms.push({
+        condText: elseIfMatch.condText,
+        bodyText: formatInline(elseIfMatch.thenBody),
+      });
+      currentElseTokens = elseIfMatch.elseBody;
+      continue;
+    }
+    break;
+  }
+
+  if (arms.length < 2) return undefined;
+
+  const defaultBodyText = formatInline(currentElseTokens);
+
+  return {
+    typeText,
+    arms,
+    defaultBodyText,
+    endIndex: currentEndIndex,
+  };
+}
+
 function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
   const diagnostics: TripLintDiagnostic[] = [];
   const topLevel = collectTopLevelBindings(tokens);
@@ -1507,6 +1641,31 @@ function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
         continue;
       }
     }
+
+    // 6. Degenerate if chain simplification to cond
+    const condChainMatch = parseCondChain(tokens, i);
+    if (condChainMatch) {
+      const armLines = condChainMatch.arms.map(arm => `| ${arm.condText} => ${arm.bodyText}`).join("\n      ");
+      const replacement = `cond [${condChainMatch.typeText}] {
+      ${armLines}
+      | otherwise => ${condChainMatch.defaultBodyText}
+    }`;
+      diagnostics.push(
+        diagnostic(
+          "trip-degenerate-if",
+          `Use cond [${condChainMatch.typeText}] {...} to flatten nested if chains`,
+          tokens[i]!,
+          {
+            start: tokens[i]!.start,
+            end: tokens[condChainMatch.endIndex]!.end,
+            replacement,
+          },
+        ),
+      );
+      i = condChainMatch.endIndex;
+      continue;
+    }
+
     if (token.kind === "number") {
       const value = Number(token.text);
       if (
@@ -1836,6 +1995,7 @@ const AST_PRESERVING_FIX_CODES: ReadonlySet<string> = new Set([
   "trip-redundant-parens",
   "trip-u8-literal",
   "trip-formatting-deviation",
+  "trip-degenerate-if",
 ]);
 
 /**

--- a/lib/parser/systemFTerm.ts
+++ b/lib/parser/systemFTerm.ts
@@ -290,6 +290,104 @@ function parseLetExpression(
   ];
 }
 
+const DEFAULT_DELAY_PARAM = "u";
+const GENERATED_DELAY_PARAM_PREFIX = "__cond_u";
+
+function collectFreeSystemFTermNames(
+  term: SystemFTerm,
+  bound: ReadonlySet<string>,
+  free: Set<string>,
+): void {
+  switch (term.kind) {
+    case "systemF-var": {
+      if (
+        !bound.has(term.name) &&
+        parseNatLiteralIdentifier(term.name) === null &&
+        !/^__trip_u8_\d+$/.test(term.name)
+      ) {
+        free.add(term.name);
+      }
+      return;
+    }
+    case "non-terminal":
+      collectFreeSystemFTermNames(term.lft, bound, free);
+      collectFreeSystemFTermNames(term.rgt, bound, free);
+      return;
+    case "systemF-abs": {
+      const nextBound = new Set(bound);
+      nextBound.add(term.name);
+      collectFreeSystemFTermNames(term.body, nextBound, free);
+      return;
+    }
+    case "systemF-type-abs":
+      collectFreeSystemFTermNames(term.body, bound, free);
+      return;
+    case "systemF-type-app":
+      collectFreeSystemFTermNames(term.term, bound, free);
+      return;
+    case "systemF-let": {
+      collectFreeSystemFTermNames(term.value, bound, free);
+      const nextBound = new Set(bound);
+      nextBound.add(term.name);
+      collectFreeSystemFTermNames(term.body, nextBound, free);
+      return;
+    }
+    case "systemF-match":
+      collectFreeSystemFTermNames(term.scrutinee, bound, free);
+      for (const arm of term.arms) {
+        const armBound = new Set(bound);
+        for (const param of arm.params) {
+          armBound.add(param);
+        }
+        collectFreeSystemFTermNames(arm.body, armBound, free);
+      }
+      return;
+  }
+}
+
+function freshCondDelayParam(terms: readonly SystemFTerm[]): string {
+  const free = new Set<string>();
+  for (const term of terms) {
+    collectFreeSystemFTermNames(term, new Set(), free);
+  }
+  if (!free.has(DEFAULT_DELAY_PARAM)) return DEFAULT_DELAY_PARAM;
+
+  for (let i = 0; ; i++) {
+    const candidate = `${GENERATED_DELAY_PARAM_PREFIX}_${i}`;
+    if (!free.has(candidate)) return candidate;
+  }
+}
+
+function buildCondIf(
+  returnType: BaseType,
+  condition: SystemFTerm,
+  thenBody: SystemFTerm,
+  elseBody: SystemFTerm,
+): SystemFTerm {
+  const delayParam = freshCondDelayParam([thenBody, elseBody]);
+  const ifTyped = mkSystemFTypeApp(mkSystemFVar("if"), returnType);
+  return createSystemFApplication(
+    createSystemFApplication(
+      createSystemFApplication(ifTyped, condition),
+      mkSystemFAbs(delayParam, mkTypeVariable("U8"), thenBody),
+    ),
+    mkSystemFAbs(delayParam, mkTypeVariable("U8"), elseBody),
+  );
+}
+
+function desugarCond(
+  returnType: BaseType,
+  arms: readonly { cond: SystemFTerm; body: SystemFTerm }[],
+  defaultBody: SystemFTerm,
+): SystemFTerm {
+  let currentElse = defaultBody;
+  for (let i = arms.length - 1; i >= 0; i--) {
+    const arm = arms[i]!;
+    currentElse = buildCondIf(returnType, arm.cond, arm.body, currentElse);
+  }
+  return currentElse;
+}
+
 /**
  * Parses a cond expression:
  * `cond [Type] { | Cond_1 => Body_1 ... | otherwise => Default_Body }`
@@ -376,37 +474,7 @@ function parseCondExpression(
     );
   }
 
-  const u8Type = mkTypeVariable("U8");
-  const ifVar = mkSystemFVar("if");
-  const ifTyped = mkSystemFTypeApp(ifVar, returnType);
-
-  let finalTerm: SystemFTerm;
-  if (arms.length === 0) {
-    finalTerm = defaultArm.body;
-  } else {
-    let currentElse = mkSystemFAbs("u", u8Type, defaultArm.body);
-    for (let i = arms.length - 1; i > 0; i--) {
-      const arm = arms[i]!;
-      const thenBranch = mkSystemFAbs("u", u8Type, arm.body);
-      const ifCall = createSystemFApplication(
-        createSystemFApplication(
-          createSystemFApplication(ifTyped, arm.cond),
-          thenBranch,
-        ),
-        currentElse,
-      );
-      currentElse = mkSystemFAbs("u", u8Type, ifCall);
-    }
-    const outermostArm = arms[0]!;
-    const thenBranch = mkSystemFAbs("u", u8Type, outermostArm.body);
-    finalTerm = createSystemFApplication(
-      createSystemFApplication(
-        createSystemFApplication(ifTyped, outermostArm.cond),
-        thenBranch,
-      ),
-      currentElse,
-    );
-  }
+  const finalTerm = desugarCond(returnType, arms, defaultArm.body);
 
   const armLits = arms
     .map((arm) => `| ${arm.condLit} => ${arm.bodyLit}`)

--- a/lib/parser/systemFTerm.ts
+++ b/lib/parser/systemFTerm.ts
@@ -319,8 +319,14 @@ function parseCondExpression(
   currentState = matchCh(currentState, LEFT_BRACE);
   currentState = skipWhitespace(currentState);
 
-  const arms: { condLit: string; cond: SystemFTerm; bodyLit: string; body: SystemFTerm }[] = [];
-  let defaultArm: { bodyLit: string; body: SystemFTerm } | undefined = undefined;
+  const arms: {
+    condLit: string;
+    cond: SystemFTerm;
+    bodyLit: string;
+    body: SystemFTerm;
+  }[] = [];
+  let defaultArm: { bodyLit: string; body: SystemFTerm } | undefined =
+    undefined;
 
   for (let armLength = 0; ; armLength = armLength + 1) {
     currentState = skipWhitespace(currentState);
@@ -385,9 +391,9 @@ function parseCondExpression(
       const ifCall = createSystemFApplication(
         createSystemFApplication(
           createSystemFApplication(ifTyped, arm.cond),
-          thenBranch
+          thenBranch,
         ),
-        currentElse
+        currentElse,
       );
       currentElse = mkSystemFAbs("u", u8Type, ifCall);
     }
@@ -396,16 +402,19 @@ function parseCondExpression(
     finalTerm = createSystemFApplication(
       createSystemFApplication(
         createSystemFApplication(ifTyped, outermostArm.cond),
-        thenBranch
+        thenBranch,
       ),
-      currentElse
+      currentElse,
     );
   }
 
-  const armLits = arms.map(arm => `| ${arm.condLit} => ${arm.bodyLit}`).join(" ");
-  const literalStr = arms.length === 0
-    ? `cond [${returnTypeLit}] { | otherwise => ${defaultArm.bodyLit} }`
-    : `cond [${returnTypeLit}] { ${armLits} | otherwise => ${defaultArm.bodyLit} }`;
+  const armLits = arms
+    .map((arm) => `| ${arm.condLit} => ${arm.bodyLit}`)
+    .join(" ");
+  const literalStr =
+    arms.length === 0
+      ? `cond [${returnTypeLit}] { | otherwise => ${defaultArm.bodyLit} }`
+      : `cond [${returnTypeLit}] { ${armLits} | otherwise => ${defaultArm.bodyLit} }`;
 
   return [literalStr, finalTerm, currentState];
 }

--- a/lib/parser/systemFTerm.ts
+++ b/lib/parser/systemFTerm.ts
@@ -72,6 +72,9 @@ import { unparseSystemFType } from "./systemFType.ts";
  * - The start of a new definition line
  */
 function isTerminator(state: ParserState): boolean {
+  const [isFatArrow] = peekFatArrow(state);
+  if (isFatArrow) return true;
+
   const [ch, _] = peek(state);
 
   if (ch === null) return true;
@@ -285,6 +288,126 @@ function parseLetExpression(
     { kind: "systemF-let", name, value: valueTerm, body: bodyTerm },
     stateAfterBody,
   ];
+}
+
+/**
+ * Parses a cond expression:
+ * `cond [Type] { | Cond_1 => Body_1 ... | otherwise => Default_Body }`
+ */
+function parseCondExpression(
+  state: ParserState,
+): [string, SystemFTerm, ParserState] {
+  let currentState = skipWhitespace(state);
+  const [nextCh, peekState] = peek(currentState);
+  if (nextCh !== "[") {
+    throw new ParseError(
+      withParserState(
+        peekState,
+        "cond requires an explicit return type: cond [Type] { ... }",
+      ),
+    );
+  }
+  currentState = matchCh(peekState, "[");
+  currentState = skipWhitespace(currentState);
+  const [returnTypeLit, returnType, stateAfterType] =
+    parseSystemFType(currentState);
+
+  currentState = skipWhitespace(stateAfterType);
+  currentState = matchCh(currentState, "]");
+
+  currentState = skipWhitespace(currentState);
+  currentState = matchCh(currentState, LEFT_BRACE);
+  currentState = skipWhitespace(currentState);
+
+  const arms: { condLit: string; cond: SystemFTerm; bodyLit: string; body: SystemFTerm }[] = [];
+  let defaultArm: { bodyLit: string; body: SystemFTerm } | undefined = undefined;
+
+  for (let armLength = 0; ; armLength = armLength + 1) {
+    currentState = skipWhitespace(currentState);
+    const [nextArmCh] = peek(currentState);
+
+    if (nextArmCh === RIGHT_BRACE) {
+      currentState = matchCh(currentState, RIGHT_BRACE);
+      break;
+    }
+
+    if (nextArmCh !== "|") {
+      throw new ParseError(
+        withParserState(currentState, "expected '|' to start cond arm"),
+      );
+    }
+    currentState = matchCh(currentState, "|");
+    currentState = skipWhitespace(currentState);
+
+    const [condLit, condTerm, stateAfterCond] = parseSystemFTerm(currentState);
+    currentState = skipWhitespace(stateAfterCond);
+
+    const [isArrow, arrowState] = peekFatArrow(currentState);
+    if (!isArrow) {
+      throw new ParseError(
+        withParserState(currentState, "expected '=>' after cond arm condition"),
+      );
+    }
+    currentState = matchFatArrow(arrowState);
+    currentState = skipWhitespace(currentState);
+
+    const [bodyLit, bodyTerm, stateAfterBody] = parseSystemFTerm(currentState);
+    currentState = skipWhitespace(stateAfterBody);
+
+    if (condTerm.kind === "systemF-var" && condTerm.name === "otherwise") {
+      defaultArm = { bodyLit, body: bodyTerm };
+      currentState = skipWhitespace(currentState);
+      currentState = matchCh(currentState, RIGHT_BRACE);
+      break;
+    } else {
+      arms.push({ condLit, cond: condTerm, bodyLit, body: bodyTerm });
+    }
+  }
+
+  if (defaultArm === undefined) {
+    throw new ParseError(
+      withParserState(currentState, "cond requires a default 'otherwise' arm"),
+    );
+  }
+
+  const u8Type = mkTypeVariable("U8");
+  const ifVar = mkSystemFVar("if");
+  const ifTyped = mkSystemFTypeApp(ifVar, returnType);
+
+  let finalTerm: SystemFTerm;
+  if (arms.length === 0) {
+    finalTerm = defaultArm.body;
+  } else {
+    let currentElse = mkSystemFAbs("u", u8Type, defaultArm.body);
+    for (let i = arms.length - 1; i > 0; i--) {
+      const arm = arms[i]!;
+      const thenBranch = mkSystemFAbs("u", u8Type, arm.body);
+      const ifCall = createSystemFApplication(
+        createSystemFApplication(
+          createSystemFApplication(ifTyped, arm.cond),
+          thenBranch
+        ),
+        currentElse
+      );
+      currentElse = mkSystemFAbs("u", u8Type, ifCall);
+    }
+    const outermostArm = arms[0]!;
+    const thenBranch = mkSystemFAbs("u", u8Type, outermostArm.body);
+    finalTerm = createSystemFApplication(
+      createSystemFApplication(
+        createSystemFApplication(ifTyped, outermostArm.cond),
+        thenBranch
+      ),
+      currentElse
+    );
+  }
+
+  const armLits = arms.map(arm => `| ${arm.condLit} => ${arm.bodyLit}`).join(" ");
+  const literalStr = arms.length === 0
+    ? `cond [${returnTypeLit}] { | otherwise => ${defaultArm.bodyLit} }`
+    : `cond [${returnTypeLit}] { ${armLits} | otherwise => ${defaultArm.bodyLit} }`;
+
+  return [literalStr, finalTerm, currentState];
 }
 
 const ASCII_PRINTABLE_MIN = 32;
@@ -695,6 +818,9 @@ function parseAtomicSystemFTerm(
     }
     if (varLit === "let") {
       return parseLetExpression(stateAfterVar);
+    }
+    if (varLit === "cond") {
+      return parseCondExpression(stateAfterVar);
     }
     return [varLit, { kind: "systemF-var", name: varLit }, stateAfterVar];
   } else {

--- a/lib/prelude.trip
+++ b/lib/prelude.trip
@@ -132,7 +132,7 @@ type Bool = #B -> B -> B -> B
 
 type List = #A -> #R -> R -> (A -> R -> R) -> R
 
-type Parser = #A -> List Bin -> Result ParseError (Pair A (List Bin))
+type Parser = #A -> List Bin -> Result ParseError ((A, (List Bin)))
 
 data Pair A B =
   | MkPair A B
@@ -216,7 +216,7 @@ poly head =
 
 poly tail =
   #A =>
-    \l : List A => l [List A] (nil [A]) (\h : A => \t : List A => t)
+    \l : List A => l [List A] ({A |}) (\h : A => \t : List A => t)
 
 poly rec appendAcc =
   #A =>
@@ -242,7 +242,7 @@ poly rec map =
             [A]
             [List B]
             l
-            (nil [B])
+            ({B |})
             (\h : A => \t : List A => cons [B] (f h) (map [A] [B] f t))
 
 poly rec foldl =
@@ -266,13 +266,13 @@ poly rec takeWhile =
           [A]
           [List A]
           l
-          (nil [A])
+          ({A |})
           (
             \h : A =>
               \t : List A =>
                 if [List A] (p h)
                   (\u : U8 => cons [A] h (takeWhile [A] p t))
-                  (\u : U8 => nil [A])
+                  (\u : U8 => {A |})
           )
 
 poly rec dropWhile =
@@ -283,7 +283,7 @@ poly rec dropWhile =
           [A]
           [List A]
           l
-          (nil [A])
+          ({A |})
           (
             \h : A =>
               \t : List A =>
@@ -298,23 +298,22 @@ poly rec span =
       \l : List A =>
         matchList
           [A]
-          [Pair (List A) (List A)]
+          [((List A), (List A))]
           l
-          (MkPair [List A] [List A] (nil [A]) (nil [A]))
+          ({List A, List A | (nil [A]), (nil [A])})
           (
             \h : A =>
               \t : List A =>
-                if [Pair (List A) (List A)] (p h)
+                if [((List A), (List A))] (p h)
                   (
                     \u : U8 =>
                       let res = span [A] p t in
-                      MkPair
-                        [List A]
-                        [List A]
-                        (cons [A] h (fst [List A] [List A] res))
+                      {List A, List A |
+                        (cons [A] h (fst [List A] [List A] res)),
                         (snd [List A] [List A] res)
+                      }
                   )
-                  (\u : U8 => MkPair [List A] [List A] (nil [A]) l)
+                  (\u : U8 => {List A, List A | (nil [A]), l})
           )
 
 poly rec reverseAcc =
@@ -331,12 +330,7 @@ poly rec reverseAcc =
 poly reverse =
   #A =>
     \xs : List A =>
-      foldl
-        [A]
-        [List A]
-        (\acc : List A => \x : A => cons [A] x acc)
-        (nil [A])
-        xs
+      foldl [A] [List A] (\acc : List A => \x : A => cons [A] x acc) ({A |}) xs
 
 poly error =
   #A => (\x : A => x) (\x : A => x)
@@ -396,72 +390,110 @@ poly lteListU8 =
 
 poly digitToAscii =
   \n : U8 =>
-    if [U8] (eqU8 n #u8(0))
-      (\u : U8 => '0')
-      (
-        if [U8] (eqU8 n #u8(1))
-          (\u : U8 => '1')
-          (
-            if [U8] (eqU8 n #u8(2))
-              (\u : U8 => '2')
-              (
-                if [U8] (eqU8 n #u8(3))
-                  (\u : U8 => '3')
-                  (
-                    if [U8] (eqU8 n #u8(4))
-                      (\u : U8 => '4')
-                      (
-                        if [U8] (eqU8 n #u8(5))
-                          (\u : U8 => '5')
-                          (
-                            if [U8] (eqU8 n #u8(6))
-                              (\u : U8 => '6')
-                              (
-                                if [U8] (eqU8 n #u8(7))
-                                  (\u : U8 => '7')
-                                  (
-                                    if [U8] (eqU8 n #u8(8))
-                                      (\u : U8 => '8')
-                                      ('9')
-                                  )
-                              )
-                          )
-                      )
-                  )
-              )
-          )
-      )
+    cond
+      [U8]
+      {|
+        eqU8
+        n
+        #
+        u8
+        (0) =>
+        '0' |
+        eqU8
+        n
+        #
+        u8
+        (1) =>
+        '1' |
+        eqU8
+        n
+        #
+        u8
+        (2) =>
+        '2' |
+        eqU8
+        n
+        #
+        u8
+        (3) =>
+        '3' |
+        eqU8
+        n
+        #
+        u8
+        (4) =>
+        '4' |
+        eqU8
+        n
+        #
+        u8
+        (5) =>
+        '5' |
+        eqU8
+        n
+        #
+        u8
+        (6) =>
+        '6' |
+        eqU8
+        n
+        #
+        u8
+        (7) =>
+        '7' |
+        eqU8
+        n
+        #
+        u8
+        (8) =>
+        '8' |
+        otherwise =>
+        '9'
+      }
 
 poly singletonU8 =
-  \c : U8 => cons [U8] c (nil [U8])
+  \c : U8 => {U8 | c}
 
 poly u8ToDigits =
   \n : U8 =>
-    if [List U8] (ltU8 n #u8(10))
-      (\u : U8 => singletonU8 (digitToAscii n))
-      (
-        \u : U8 =>
-          if [List U8] (ltU8 n #u8(100))
-            (
-              \u : U8 =>
-                cons
-                  [U8]
-                  (digitToAscii (divU8 n #u8(10)))
-                  (singletonU8 (digitToAscii (modU8 n #u8(10))))
-            )
-            (
-              \u : U8 =>
-                let hundreds = divU8 n #u8(100) in
-                let tens = modU8 (divU8 n #u8(10)) #u8(10) in
-                let ones = modU8 n #u8(10) in
-                cons
-                  [U8]
-                  (digitToAscii hundreds)
-                  (
-                    cons
-                      [U8]
-                      (digitToAscii tens)
-                      (singletonU8 (digitToAscii ones))
-                  )
-            )
-      )
+    cond
+      [List U8]
+      {|
+        (ltU8 n #u8(10)) =>
+        singletonU8
+        (digitToAscii n) |
+        (ltU8 n #u8(100)) =>
+        cons
+        [U8]
+        (digitToAscii (divU8 n #u8(10)))
+        (singletonU8 (digitToAscii (modU8 n #u8(10)))) |
+        otherwise =>
+        let
+        hundreds =
+        divU8
+        n
+        #
+        u8
+        (100)
+        in
+        let
+        tens =
+        modU8
+        (divU8 n #u8(10))
+        #
+        u8
+        (10)
+        in
+        let
+        ones =
+        modU8
+        n
+        #
+        u8
+        (10)
+        in
+        cons
+        [U8]
+        (digitToAscii hundreds)
+        (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+      }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/inputs/preludeTest.trip
+++ b/test/compiler/inputs/preludeTest.trip
@@ -37,9 +37,9 @@ import Nat Nat
 export main
 
 poly main =
-  let a = (true) [Nat] (succ zero) zero in
-  let b = add a ((true) [Nat] (succ zero) zero) in
-  let c = add b ((true) [Nat] (succ zero) zero) in
+  let a = true [Nat] (succ zero) zero in
+  let b = add a (true [Nat] (succ zero) zero) in
+  let c = add b (true [Nat] (succ zero) zero) in
   let d = add c (pred (succ (succ zero))) in
   let e = add d (sub (succ (succ (succ zero))) (succ zero)) in
   let f = add e ((lte (succ zero) (succ (succ zero))) [Nat] (succ zero) zero) in

--- a/test/compiler/inputs/testParseDefinitionKinds.trip
+++ b/test/compiler/inputs/testParseDefinitionKinds.trip
@@ -154,28 +154,21 @@ poly main =
                                                                   if [Bool] (eqDefKind kind2 K_Combinator)
                                                                     (
                                                                       \u : U8 =>
-                                                                        if [Bool] isRec2
-                                                                          (
-                                                                            \u : U8 => false
-                                                                          )
-                                                                          (
-                                                                            \u : U8 =>
-                                                                              if [Bool] (eqListU8 name2 "c")
-                                                                                (
-                                                                                  \u : U8 =>
-                                                                                    matchList
-                                                                                      [Decl]
-                                                                                      [Bool]
-                                                                                      rest2
-                                                                                      true
-                                                                                      (
-                                                                                        \d3 : Decl => \rest3 : List Decl => false
-                                                                                      )
-                                                                                )
-                                                                                (
-                                                                                  \u : U8 => false
-                                                                                )
-                                                                          )
+                                                                        cond
+                                                                          [Bool]
+                                                                          {|
+                                                                            isRec2 =>
+                                                                            false |
+                                                                            (eqListU8 name2 "c") =>
+                                                                            matchList
+                                                                            [Decl]
+                                                                            [Bool]
+                                                                            rest2
+                                                                            true
+                                                                            (\d3 : Decl => \rest3 : List Decl => false) |
+                                                                            otherwise =>
+                                                                            false
+                                                                          }
                                                                     )
                                                                     (
                                                                       \u : U8 => false

--- a/test/compiler/inputs/testParseExprMatchTyped.trip
+++ b/test/compiler/inputs/testParseExprMatchTyped.trip
@@ -138,13 +138,13 @@ poly main =
             (
               \u : Bin =>
                 matchList
-                  [Pair Pattern Expr]
+                  [(Pattern, Expr)]
                   [Bool]
                   arms
                   false
                   (
-                    \arm1 : Pair Pattern Expr =>
-                      \rest1 : List (Pair Pattern Expr) =>
+                    \arm1 : (Pattern, Expr) =>
+                      \rest1 : List ((Pattern, Expr)) =>
                         let pat1 = fst [Pattern] [Expr] arm1 in
                         let body1 = snd [Pattern] [Expr] arm1 in
                         let arm1Ok = match pat1 [Bool] {| P_Ctor ctor args => if [Bool] (eqListU8 ctor "Some") (\u : Bin => if [Bool] (isSingleArg args "x") (\u : Bin => isVarNamed body1 "x") (\u : Bin => false)) (\u : Bin => false)} in
@@ -152,13 +152,13 @@ poly main =
                           (
                             \u : Bin =>
                               matchList
-                                [Pair Pattern Expr]
+                                [(Pattern, Expr)]
                                 [Bool]
                                 rest1
                                 false
                                 (
-                                  \arm2 : Pair Pattern Expr =>
-                                    \rest2 : List (Pair Pattern Expr) =>
+                                  \arm2 : (Pattern, Expr) =>
+                                    \rest2 : List ((Pattern, Expr)) =>
                                       let pat2 = fst [Pattern] [Expr] arm2 in
                                       let body2 = snd [Pattern] [Expr] arm2 in
                                       let arm2Ok = match pat2 [Bool] {| P_Ctor ctor args => if [Bool] (eqListU8 ctor "None") (\u : Bin => if [Bool] (isNoArgs args) (\u : Bin => isVarNamed body2 "res") (\u : Bin => false)) (\u : Bin => false)} in
@@ -166,12 +166,12 @@ poly main =
                                         (
                                           \u : Bin =>
                                             matchList
-                                              [Pair Pattern Expr]
+                                              [(Pattern, Expr)]
                                               [Bool]
                                               rest2
                                               true
                                               (
-                                                \extra : Pair Pattern Expr => \extraRest : List (Pair Pattern Expr) => false
+                                                \extra : (Pattern, Expr) => \extraRest : List ((Pattern, Expr)) => false
                                               )
                                         )
                                         (\u : Bin => false)

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -298,7 +298,7 @@ poly tokenize
 combinator 0
 module Parser
 declared Parser
-imports 62
+imports 64
 import Prelude eqListU8
 import Prelude List
 import Prelude nil
@@ -316,7 +316,9 @@ import Prelude snd
 import Prelude eqU8
 import Prelude ltU8
 import Prelude addU8
+import Prelude append
 import Prelude subU8
+import Prelude u8ToDigits
 import Prelude U8
 import Prelude Bool
 import Prelude true
@@ -496,7 +498,7 @@ ctor D_Def 4
 type 0
 opaque 0
 native 0
-poly 100
+poly 106
 poly parseError
 poly checkedIncrementU8
 poly identTag
@@ -561,6 +563,12 @@ poly buildListExpr
 poly parseLiteralAtomWith
 poly parseListElements
 poly parseBraceBodyWith
+poly prependArmBodies
+poly exprListMentionsName
+poly exprMentionsName
+poly freshCondDelayNameFrom
+poly freshCondDelayName
+poly isOtherwiseExpr
 poly desugarCondLoop
 poly desugarCond
 poly parseCondArms

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -103,7 +103,7 @@ import Prelude ltListU8
 import Prelude digitToAscii
 import Prelude singletonU8
 import Prelude u8ToDigits
-exports 66
+exports 67
 export ParseError
 export MkParseError
 export Token
@@ -135,6 +135,7 @@ export T_KwOpaque
 export T_KwCombinator
 export T_KwType
 export T_KwData
+export T_KwCond
 export T_Ident
 export T_Nat
 export T_EOF
@@ -180,7 +181,7 @@ ctor T_Nat 1
 type 0
 opaque 0
 native 0
-poly 112
+poly 113
 poly T_LParen
 poly T_RParen
 poly T_LBrace
@@ -209,6 +210,7 @@ poly T_KwOpaque
 poly T_KwCombinator
 poly T_KwType
 poly T_KwData
+poly T_KwCond
 poly T_EOF
 poly tokenTag
 poly tokenTaggedTextData
@@ -296,7 +298,7 @@ poly tokenize
 combinator 0
 module Parser
 declared Parser
-imports 61
+imports 62
 import Prelude eqListU8
 import Prelude List
 import Prelude nil
@@ -355,10 +357,11 @@ import Lexer T_KwOpaque
 import Lexer T_KwCombinator
 import Lexer T_KwType
 import Lexer T_KwData
+import Lexer T_KwCond
 import Lexer T_Ident
 import Lexer T_Nat
 import Lexer T_EOF
-exports 103
+exports 104
 export Pattern
 export P_Ctor
 export Expr
@@ -416,6 +419,7 @@ export kwOpaqueTag
 export kwCombinatorTag
 export kwTypeTag
 export kwDataTag
+export kwCondTag
 export fstNameToken
 export sndNameToken
 export fstExprToken
@@ -492,7 +496,7 @@ ctor D_Def 4
 type 0
 opaque 0
 native 0
-poly 95
+poly 100
 poly parseError
 poly checkedIncrementU8
 poly identTag
@@ -526,6 +530,7 @@ poly kwOpaqueTag
 poly kwCombinatorTag
 poly kwTypeTag
 poly kwDataTag
+poly kwCondTag
 poly fstTypeToken
 poly sndTypeToken
 poly fstNameToken
@@ -556,6 +561,10 @@ poly buildListExpr
 poly parseLiteralAtomWith
 poly parseListElements
 poly parseBraceBodyWith
+poly desugarCondLoop
+poly desugarCond
+poly parseCondArms
+poly parseCondWith
 poly parseAtomWith
 poly skipTypeArg
 poly parseSimpleTypeWith

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
@@ -103,7 +103,7 @@ import Prelude ltListU8
 import Prelude digitToAscii
 import Prelude singletonU8
 import Prelude u8ToDigits
-exports 66
+exports 67
 export ParseError
 export MkParseError
 export Token
@@ -135,6 +135,7 @@ export T_KwOpaque
 export T_KwCombinator
 export T_KwType
 export T_KwData
+export T_KwCond
 export T_Ident
 export T_Nat
 export T_EOF
@@ -180,7 +181,7 @@ ctor T_Nat 1
 type 0
 opaque 0
 native 0
-poly 112
+poly 113
 poly T_LParen
 poly T_RParen
 poly T_LBrace
@@ -209,6 +210,7 @@ poly T_KwOpaque
 poly T_KwCombinator
 poly T_KwType
 poly T_KwData
+poly T_KwCond
 poly T_EOF
 poly tokenTag
 poly tokenTaggedTextData

--- a/test/improvize/improvize.test.ts
+++ b/test/improvize/improvize.test.ts
@@ -207,6 +207,26 @@ poly main = append [Bin] {Bin | a} {Bin | b}
     );
     assert.match(result.fixed, /\{Bin \| a b\}/);
   });
+
+  it("reports and fixes degenerate if chains to cond blocks", () => {
+    const source = `module M
+poly main =
+  if [Lower] c1
+    (\\u : U8 => t1)
+    (\\u : U8 =>
+      if [Lower] c2
+        (\\u : U8 => t2)
+        (\\u : U8 => d))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-degenerate-if"),
+    );
+    assert.match(result.fixed, /cond \[Lower\]/);
+    assert.match(result.fixed, /\| c1 => t1/);
+    assert.match(result.fixed, /\| c2 => t2/);
+    assert.match(result.fixed, /\| otherwise => d/);
+  });
 });
 
 describe("improvize file discovery", () => {

--- a/test/improvize/improvize.test.ts
+++ b/test/improvize/improvize.test.ts
@@ -227,6 +227,40 @@ poly main =
     assert.match(result.fixed, /\| c2 => t2/);
     assert.match(result.fixed, /\| otherwise => d/);
   });
+
+  it("does not rewrite if chains with nonstandard delay binders", () => {
+    const source = `module M
+poly main =
+  if [Lower] c1
+    (\\x : U8 => t1)
+    (\\x : U8 =>
+      if [Lower] c2
+        (\\x : U8 => t2)
+        (\\x : U8 => d))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      !result.diagnostics.some((diag) => diag.code === "trip-degenerate-if"),
+    );
+    assert.doesNotMatch(result.fixed, /cond \[Lower\]/);
+  });
+
+  it("does not rewrite if chains when delay binders are used", () => {
+    const source = `module M
+poly main =
+  if [Lower] c1
+    (\\u : U8 => u)
+    (\\u : U8 =>
+      if [Lower] c2
+        (\\u : U8 => t2)
+        (\\u : U8 => d))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      !result.diagnostics.some((diag) => diag.code === "trip-degenerate-if"),
+    );
+    assert.doesNotMatch(result.fixed, /cond \[Lower\]/);
+  });
 });
 
 describe("improvize file discovery", () => {

--- a/test/linker/inputs/testLogic.trip
+++ b/test/linker/inputs/testLogic.trip
@@ -13,4 +13,4 @@ import Prelude or
 export main
 
 poly main =
-  and true (true)
+  and true true

--- a/test/linker/snat_like.trip
+++ b/test/linker/snat_like.trip
@@ -23,7 +23,7 @@ data SNat =
   | SS SNat
 
 poly toSNat =
-  \n : Nat => n [SNat] (SS) SZ
+  \n : Nat => n [SNat] SS SZ
 
 poly fromSNat =
-  \s : SNat => s [Nat] (succ) zero
+  \s : SNat => s [Nat] succ zero

--- a/test/parser/inputs/polyRec.trip
+++ b/test/parser/inputs/polyRec.trip
@@ -1,4 +1,4 @@
 module PolyRec
 
 poly rec fact =
-  \n : Nat => fact n
+  fact

--- a/test/parser/inputs/typedInc.trip
+++ b/test/parser/inputs/typedInc.trip
@@ -1,4 +1,4 @@
 module TypedInc
 
 poly inc : Int -> Int =
-  \x : Int => plus x 1
+  \x : Int => plus x #u8(1)

--- a/test/parser/parseErrors.test.ts
+++ b/test/parser/parseErrors.test.ts
@@ -189,8 +189,7 @@ describe("Parser Error Coverage", () => {
 
     it("cond requires otherwise to be the final arm", () => {
       assert.throws(
-        () =>
-          parseSystemF("cond [U8] { | otherwise => 1 | true => 2 }"),
+        () => parseSystemF("cond [U8] { | otherwise => 1 | true => 2 }"),
         {
           message: /expected '\}'/,
         },

--- a/test/parser/parseErrors.test.ts
+++ b/test/parser/parseErrors.test.ts
@@ -181,6 +181,22 @@ describe("Parser Error Coverage", () => {
       });
     });
 
+    it("cond requires an otherwise arm", () => {
+      assert.throws(() => parseSystemF("cond [U8] { | true => 1 }"), {
+        message: /cond requires a default 'otherwise' arm/,
+      });
+    });
+
+    it("cond requires otherwise to be the final arm", () => {
+      assert.throws(
+        () =>
+          parseSystemF("cond [U8] { | otherwise => 1 | true => 2 }"),
+        {
+          message: /expected '\}'/,
+        },
+      );
+    });
+
     it("expected 'in' after let binding", () => {
       assert.throws(() => parseSystemF("let x = 1"));
     });

--- a/test/parser/tripLang.test.ts
+++ b/test/parser/tripLang.test.ts
@@ -631,6 +631,24 @@ describe("parse single poly", () => {
   });
 });
 
+describe("parse cond expression", () => {
+  it("parses cond expression with multiple arms", () => {
+    const input = `poly foo =
+      cond [Maybe U8] {
+        | true => Some [U8] 1
+        | false => None [U8]
+        | otherwise => None [U8]
+      }`;
+    const result = parseTripLang(input);
+
+    assert.strictEqual(result.kind, "program");
+    assert.strictEqual(result.terms.length, 1);
+    const term = result.terms[0]!;
+    assert.strictEqual(term.kind, "poly");
+    assert.strictEqual(term.name, "foo");
+  });
+});
+
 describe("parse list literal", () => {
   it("parses list literal in a poly definition", () => {
     const input = "poly foo = {U8 | 102 111 111}";

--- a/test/parser/tripLang.test.ts
+++ b/test/parser/tripLang.test.ts
@@ -73,11 +73,7 @@ describe("parseTripLang", () => {
       name: "fact",
       rec: true,
       type: undefined,
-      term: mkSystemFAbs(
-        "n",
-        { kind: "type-var", typeName: "Nat" },
-        createSystemFApplication(mkSystemFVar("fact"), mkSystemFVar("n")),
-      ),
+      term: mkSystemFVar("fact"),
     });
   });
 

--- a/test/parser/tripLang.test.ts
+++ b/test/parser/tripLang.test.ts
@@ -643,6 +643,31 @@ describe("parse cond expression", () => {
     assert.strictEqual(term.kind, "poly");
     assert.strictEqual(term.name, "foo");
   });
+
+  it("does not capture an outer u when desugaring cond branches", () => {
+    const input = `poly foo =
+      \\u : U8 =>
+        cond [U8] {
+          | true => u
+          | otherwise => 0
+        }`;
+    const result = parseTripLang(input);
+    const term = requiredAt(result.terms, 0, "expected poly term");
+    assert.strictEqual(term.kind, "poly");
+    assert.strictEqual(term.term.kind, "systemF-abs");
+    assert.strictEqual(term.term.name, "u");
+
+    const ifApp = expectSystemFApp(term.term.body);
+    const elseBranch = ifApp.rgt;
+    assert.strictEqual(elseBranch.kind, "systemF-abs");
+    assert.notStrictEqual(elseBranch.name, "u");
+
+    const ifThenApp = expectSystemFApp(ifApp.lft);
+    const thenBranch = ifThenApp.rgt;
+    assert.strictEqual(thenBranch.kind, "systemF-abs");
+    assert.notStrictEqual(thenBranch.name, "u");
+    assert.deepStrictEqual(thenBranch.body, mkSystemFVar("u"));
+  });
 });
 
 describe("parse list literal", () => {


### PR DESCRIPTION
## Description

This PR introduces the new guarded conditional conditional syntax `cond` (Proposal A) to the `triplang` language. 

Highly nested, rightward-drifting conditional chains (degenerate `if` chains) previously required manual wrapping in dummy delay lambdas (`\u : U8 => ...`) to preserve strict laziness. This PR introduces a flat, linear `cond` expression that is automatically desugared by the parser into the equivalent nested `if` thunk representation.

Additionally, this PR adds automated detection and conversion support to the `improvize` linter tool under a new `"trip-degenerate-if"` AST-preserving rule, which has been run repository-wide to migrate all existing degenerate chains.

### Syntax Design

```hs
poly resolveNativeName =
  \name : List U8 =>
    cond [Maybe Lower] {
      | eqListU8 name "." => Some [Lower] (L_Native T_WriteOne)
      | eqListU8 name "," => Some [Lower] (L_Native T_ReadOne)
      | otherwise         => None [Lower]
    }