### PR TITLE
feat: emit U8 literals and arithmetic primitives in AnfLlvm

### DIFF
--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -50,6 +50,44 @@ import Bin incBin
 
 import Bin binToDigits
 
+import Prelude u8ToDigits
+
+import Unparse Terminal
+
+import Unparse T_S
+
+import Unparse T_K
+
+import Unparse T_I
+
+import Unparse T_B
+
+import Unparse T_C
+
+import Unparse T_SPrime
+
+import Unparse T_BPrime
+
+import Unparse T_CPrime
+
+import Unparse T_WriteOne
+
+import Unparse T_ReadOne
+
+import Unparse T_EqU8
+
+import Unparse T_LtU8
+
+import Unparse T_DivU8
+
+import Unparse T_ModU8
+
+import Unparse T_AddU8
+
+import Unparse T_SubU8
+
+import Unparse T_Byte
+
 import Lexer tokenize
 
 import Parser parseProgram
@@ -117,7 +155,26 @@ poly atomOperand =
               Err [List U8] [List U8] (append [U8] "Unbound variable: " n)
             | Some op => Ok [List U8] [List U8] op
           }
-        | AE_Native t => Err [List U8] [List U8] "Unsupported atom: native"
+        | AE_Native t =>
+          match t [Result (List U8) (List U8)] {
+            | T_Byte b => Ok [List U8] [List U8] (u8ToDigits b)
+            | T_S => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_K => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_I => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_B => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_C => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_SPrime => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_BPrime => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_CPrime => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_WriteOne => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_ReadOne => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_EqU8 => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_LtU8 => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_DivU8 => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_ModU8 => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_AddU8 => Err [List U8] [List U8] "Unsupported atom: native"
+            | T_SubU8 => Err [List U8] [List U8] "Unsupported atom: native"
+          }
         | AE_Lam n b => Err [List U8] [List U8] "Unsupported atom: lambda"
         | AE_Call f args => Err [List U8] [List U8] "Unsupported atom: call"
         | AE_Con tag total arity args =>
@@ -149,6 +206,265 @@ poly rec emitArgsString =
                 }
           )
 
+poly emitArithBin =
+  \opcode : List U8 =>
+    \name : List U8 =>
+      \env : List (((List U8), (List U8))) =>
+        \counter : Bin =>
+          \instrs : List (List U8) =>
+            \args : List AnfExpr =>
+              matchList
+                [AnfExpr]
+                [Result (List U8) EmitRes]
+                args
+                (
+                  Err
+                    [List U8]
+                    [EmitRes]
+                    (append [U8] name " expects two arguments")
+                )
+                (
+                  \a1 : AnfExpr =>
+                    \r1 : List AnfExpr =>
+                      matchList
+                        [AnfExpr]
+                        [Result (List U8) EmitRes]
+                        r1
+                        (
+                          Err
+                            [List U8]
+                            [EmitRes]
+                            (append [U8] name " expects two arguments")
+                        )
+                        (
+                          \a2 : AnfExpr =>
+                            \r2 : List AnfExpr =>
+                              matchList
+                                [AnfExpr]
+                                [Result (List U8) EmitRes]
+                                r2
+                                (
+                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
+                                    | Err e => Err [List U8] [EmitRes] e
+                                    | Ok op1 =>
+                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
+                                        | Err e => Err [List U8] [EmitRes] e
+                                        | Ok op2 =>
+                                          let dest = append [U8] "%__ll" (binToDigits counter) in
+                                          let counter1 = incBin counter in
+                                          let line = append [U8] "  " (append [U8] dest (append [U8] " = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n"))))))) in
+                                          Ok
+                                            [List U8]
+                                            [EmitRes]
+                                            (
+                                              MkEmitRes
+                                                counter1
+                                                (cons [List U8] line instrs)
+                                                dest
+                                            )
+                                      }
+                                  }
+                                )
+                                (
+                                  \x : AnfExpr =>
+                                    \y : List AnfExpr =>
+                                      Err
+                                        [List U8]
+                                        [EmitRes]
+                                        (
+                                          append
+                                            [U8]
+                                            name
+                                            " expects two arguments"
+                                        )
+                                )
+                        )
+                )
+
+poly emitCmpBin =
+  \predOp : List U8 =>
+    \name : List U8 =>
+      \env : List (((List U8), (List U8))) =>
+        \counter : Bin =>
+          \instrs : List (List U8) =>
+            \args : List AnfExpr =>
+              matchList
+                [AnfExpr]
+                [Result (List U8) EmitRes]
+                args
+                (
+                  Err
+                    [List U8]
+                    [EmitRes]
+                    (append [U8] name " expects two arguments")
+                )
+                (
+                  \a1 : AnfExpr =>
+                    \r1 : List AnfExpr =>
+                      matchList
+                        [AnfExpr]
+                        [Result (List U8) EmitRes]
+                        r1
+                        (
+                          Err
+                            [List U8]
+                            [EmitRes]
+                            (append [U8] name " expects two arguments")
+                        )
+                        (
+                          \a2 : AnfExpr =>
+                            \r2 : List AnfExpr =>
+                              matchList
+                                [AnfExpr]
+                                [Result (List U8) EmitRes]
+                                r2
+                                (
+                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
+                                    | Err e => Err [List U8] [EmitRes] e
+                                    | Ok op1 =>
+                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
+                                        | Err e => Err [List U8] [EmitRes] e
+                                        | Ok op2 =>
+                                          let dest = append [U8] "%__ll" (binToDigits counter) in
+                                          let counter1 = incBin counter in
+                                          let cmpLine = append [U8] "  " (append [U8] dest (append [U8] "_c = icmp " (append [U8] predOp (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n"))))))) in
+                                          let extLine = append [U8] "  " (append [U8] dest (append [U8] " = zext i1 " (append [U8] dest "_c to i8\n"))) in
+                                          Ok
+                                            [List U8]
+                                            [EmitRes]
+                                            (
+                                              MkEmitRes
+                                                counter1
+                                                (
+                                                  cons
+                                                    [List U8]
+                                                    extLine
+                                                    (
+                                                      cons
+                                                        [List U8]
+                                                        cmpLine
+                                                        instrs
+                                                    )
+                                                )
+                                                dest
+                                            )
+                                      }
+                                  }
+                                )
+                                (
+                                  \x : AnfExpr =>
+                                    \y : List AnfExpr =>
+                                      Err
+                                        [List U8]
+                                        [EmitRes]
+                                        (
+                                          append
+                                            [U8]
+                                            name
+                                            " expects two arguments"
+                                        )
+                                )
+                        )
+                )
+
+poly emitDivMod =
+  \opcode : List U8 =>
+    \name : List U8 =>
+      \env : List (((List U8), (List U8))) =>
+        \counter : Bin =>
+          \instrs : List (List U8) =>
+            \args : List AnfExpr =>
+              matchList
+                [AnfExpr]
+                [Result (List U8) EmitRes]
+                args
+                (
+                  Err
+                    [List U8]
+                    [EmitRes]
+                    (append [U8] name " expects two arguments")
+                )
+                (
+                  \a1 : AnfExpr =>
+                    \r1 : List AnfExpr =>
+                      matchList
+                        [AnfExpr]
+                        [Result (List U8) EmitRes]
+                        r1
+                        (
+                          Err
+                            [List U8]
+                            [EmitRes]
+                            (append [U8] name " expects two arguments")
+                        )
+                        (
+                          \a2 : AnfExpr =>
+                            \r2 : List AnfExpr =>
+                              matchList
+                                [AnfExpr]
+                                [Result (List U8) EmitRes]
+                                r2
+                                (
+                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
+                                    | Err e => Err [List U8] [EmitRes] e
+                                    | Ok op1 =>
+                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
+                                        | Err e => Err [List U8] [EmitRes] e
+                                        | Ok op2 =>
+                                          let dest = append [U8] "%__ll" (binToDigits counter) in
+                                          let counter1 = incBin counter in
+                                          let zeroLine = append [U8] "  " (append [U8] dest (append [U8] "_zero = icmp eq i8 " (append [U8] op2 ", 0\n"))) in
+                                          let safeLine = append [U8] "  " (append [U8] dest (append [U8] "_safe = select i1 " (append [U8] dest (append [U8] "_zero, i8 1, i8 " (append [U8] op2 "\n"))))) in
+                                          let rawLine = append [U8] "  " (append [U8] dest (append [U8] "_raw = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] dest "_safe\n"))))))) in
+                                          let resLine = append [U8] "  " (append [U8] dest (append [U8] " = select i1 " (append [U8] dest (append [U8] "_zero, i8 0, i8 " (append [U8] dest "_raw\n"))))) in
+                                          Ok
+                                            [List U8]
+                                            [EmitRes]
+                                            (
+                                              MkEmitRes
+                                                counter1
+                                                (
+                                                  cons
+                                                    [List U8]
+                                                    resLine
+                                                    (
+                                                      cons
+                                                        [List U8]
+                                                        rawLine
+                                                        (
+                                                          cons
+                                                            [List U8]
+                                                            safeLine
+                                                            (
+                                                              cons
+                                                                [List U8]
+                                                                zeroLine
+                                                                instrs
+                                                            )
+                                                        )
+                                                    )
+                                                )
+                                                dest
+                                            )
+                                      }
+                                  }
+                                )
+                                (
+                                  \x : AnfExpr =>
+                                    \y : List AnfExpr =>
+                                      Err
+                                        [List U8]
+                                        [EmitRes]
+                                        (
+                                          append
+                                            [U8]
+                                            name
+                                            " expects two arguments"
+                                        )
+                                )
+                        )
+                )
+
 poly rec emitExpr =
   \env : List (((List U8), (List U8))) =>
     \counter : Bin =>
@@ -163,22 +479,111 @@ poly rec emitExpr =
                   Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
               }
             | AE_Native t =>
-              Err [List U8] [EmitRes] "Unsupported expression: native"
+              match t [Result (List U8) EmitRes] {
+                | T_Byte b =>
+                  Ok
+                    [List U8]
+                    [EmitRes]
+                    (MkEmitRes counter instrs (u8ToDigits b))
+                | T_S =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_K =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_I =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_B =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_C =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_SPrime =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_BPrime =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_CPrime =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_WriteOne =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_ReadOne =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_EqU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_LtU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_DivU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_ModU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_AddU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+                | T_SubU8 =>
+                  Err [List U8] [EmitRes] "Unsupported expression: native"
+              }
             | AE_Lam n b =>
               Err [List U8] [EmitRes] "Unsupported expression: lambda"
             | AE_Call f args =>
-              do [Result (List U8) EmitRes] {
-                argStr <- (emitArgsString env args true)
-                dest = append [U8]
-                "%__ll" (binToDigits counter)
-                counter1 = incBin counter
-                line = append [U8] "  " (append [U8] dest (append [U8] " = call i8 @" (append [U8] f (append [U8] "(" (append [U8] argStr ")\n")))))
-                return
-                  Ok
-                  [List U8]
-                  [EmitRes]
-                  (MkEmitRes counter1 (cons [List U8] line instrs) dest)
-              }
+              if [Result (List U8) EmitRes] (eqListU8 f "addU8")
+                (\u : U8 => emitArithBin "add" "addU8" env counter instrs args)
+                (
+                  \u : U8 =>
+                    if [Result (List U8) EmitRes] (eqListU8 f "subU8")
+                      (
+                        \u2 : U8 => emitArithBin "sub" "subU8" env counter instrs args
+                      )
+                      (
+                        \u2 : U8 =>
+                          if [Result (List U8) EmitRes] (eqListU8 f "divU8")
+                            (
+                              \u3 : U8 => emitDivMod "udiv" "divU8" env counter instrs args
+                            )
+                            (
+                              \u3 : U8 =>
+                                if [Result (List U8) EmitRes] (eqListU8 f "modU8")
+                                  (
+                                    \u4 : U8 => emitDivMod "urem" "modU8" env counter instrs args
+                                  )
+                                  (
+                                    \u4 : U8 =>
+                                      if [Result (List U8) EmitRes] (eqListU8 f "eqU8")
+                                        (
+                                          \u5 : U8 => emitCmpBin "eq" "eqU8" env counter instrs args
+                                        )
+                                        (
+                                          \u5 : U8 =>
+                                            if [Result (List U8) EmitRes] (eqListU8 f "ltU8")
+                                              (
+                                                \u6 : U8 => emitCmpBin "ult" "ltU8" env counter instrs args
+                                              )
+                                              (
+                                                \u6 : U8 =>
+                                                  do [Result (List U8) EmitRes] {
+                                                    argStr <- (emitArgsString env args true)
+                                                    dest = append [U8]
+                                                    "%__ll"
+                                                      (binToDigits counter)
+                                                    counter1 = incBin counter
+                                                    line = append [U8] "  " (append [U8] dest (append [U8] " = call i8 @" (append [U8] f (append [U8] "(" (append [U8] argStr ")\n")))))
+                                                    return
+                                                      Ok
+                                                      [List U8]
+                                                      [EmitRes]
+                                                      (
+                                                        MkEmitRes
+                                                          counter1
+                                                          (
+                                                            cons
+                                                              [List U8]
+                                                              line
+                                                              instrs
+                                                          )
+                                                          dest
+                                                      )
+                                                  }
+                                              )
+                                        )
+                                  )
+                            )
+                      )
+                )
             | AE_Con tag total arity args =>
               Err [List U8] [EmitRes] "Unsupported expression: constructor"
             | AE_Case scrut arms =>

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -206,6 +206,56 @@ poly rec emitArgsString =
                 }
           )
 
+poly twoArgs =
+  \name : List U8 =>
+    \args : List AnfExpr =>
+      matchList
+        [AnfExpr]
+        [Result (List U8) (AnfExpr, AnfExpr)]
+        args
+        (
+          Err
+            [List U8]
+            [(AnfExpr, AnfExpr)]
+            (append [U8] name " expects two arguments")
+        )
+        (
+          \a1 : AnfExpr =>
+            \r1 : List AnfExpr =>
+              matchList
+                [AnfExpr]
+                [Result (List U8) (AnfExpr, AnfExpr)]
+                r1
+                (
+                  Err
+                    [List U8]
+                    [(AnfExpr, AnfExpr)]
+                    (append [U8] name " expects two arguments")
+                )
+                (
+                  \a2 : AnfExpr =>
+                    \r2 : List AnfExpr =>
+                      matchList
+                        [AnfExpr]
+                        [Result (List U8) (AnfExpr, AnfExpr)]
+                        r2
+                        (
+                          Ok
+                            [List U8]
+                            [(AnfExpr, AnfExpr)]
+                            {AnfExpr, AnfExpr | a1, a2}
+                        )
+                        (
+                          \x : AnfExpr =>
+                            \y : List AnfExpr =>
+                              Err
+                                [List U8]
+                                [(AnfExpr, AnfExpr)]
+                                (append [U8] name " expects two arguments")
+                        )
+                )
+        )
+
 poly emitArithBin =
   \opcode : List U8 =>
     \name : List U8 =>
@@ -213,73 +263,21 @@ poly emitArithBin =
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
-              matchList
-                [AnfExpr]
-                [Result (List U8) EmitRes]
-                args
-                (
-                  Err
-                    [List U8]
-                    [EmitRes]
-                    (append [U8] name " expects two arguments")
-                )
-                (
-                  \a1 : AnfExpr =>
-                    \r1 : List AnfExpr =>
-                      matchList
-                        [AnfExpr]
-                        [Result (List U8) EmitRes]
-                        r1
-                        (
-                          Err
-                            [List U8]
-                            [EmitRes]
-                            (append [U8] name " expects two arguments")
-                        )
-                        (
-                          \a2 : AnfExpr =>
-                            \r2 : List AnfExpr =>
-                              matchList
-                                [AnfExpr]
-                                [Result (List U8) EmitRes]
-                                r2
-                                (
-                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
-                                    | Err e => Err [List U8] [EmitRes] e
-                                    | Ok op1 =>
-                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
-                                        | Err e => Err [List U8] [EmitRes] e
-                                        | Ok op2 =>
-                                          let dest = append [U8] "%__ll" (binToDigits counter) in
-                                          let counter1 = incBin counter in
-                                          let line = append [U8] "  " (append [U8] dest (append [U8] " = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n"))))))) in
-                                          Ok
-                                            [List U8]
-                                            [EmitRes]
-                                            (
-                                              MkEmitRes
-                                                counter1
-                                                (cons [List U8] line instrs)
-                                                dest
-                                            )
-                                      }
-                                  }
-                                )
-                                (
-                                  \x : AnfExpr =>
-                                    \y : List AnfExpr =>
-                                      Err
-                                        [List U8]
-                                        [EmitRes]
-                                        (
-                                          append
-                                            [U8]
-                                            name
-                                            " expects two arguments"
-                                        )
-                                )
-                        )
-                )
+              do [Result (List U8) EmitRes] {
+                pair <- (twoArgs name args)
+                MkPair a1 a2 = pair
+                op1 <- (atomOperand env a1)
+                op2 <- (atomOperand env a2)
+                dest = append [U8]
+                "%__ll" (binToDigits counter)
+                counter1 = incBin counter
+                line = append [U8] "  " (append [U8] dest (append [U8] " = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n")))))))
+                return
+                  Ok
+                  [List U8]
+                  [EmitRes]
+                  (MkEmitRes counter1 (cons [List U8] line instrs) dest)
+              }
 
 poly emitCmpBin =
   \predOp : List U8 =>
@@ -288,84 +286,54 @@ poly emitCmpBin =
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
-              matchList
-                [AnfExpr]
-                [Result (List U8) EmitRes]
-                args
-                (
-                  Err
-                    [List U8]
-                    [EmitRes]
-                    (append [U8] name " expects two arguments")
-                )
-                (
-                  \a1 : AnfExpr =>
-                    \r1 : List AnfExpr =>
-                      matchList
-                        [AnfExpr]
-                        [Result (List U8) EmitRes]
-                        r1
-                        (
-                          Err
-                            [List U8]
-                            [EmitRes]
-                            (append [U8] name " expects two arguments")
-                        )
-                        (
-                          \a2 : AnfExpr =>
-                            \r2 : List AnfExpr =>
-                              matchList
-                                [AnfExpr]
-                                [Result (List U8) EmitRes]
-                                r2
-                                (
-                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
-                                    | Err e => Err [List U8] [EmitRes] e
-                                    | Ok op1 =>
-                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
-                                        | Err e => Err [List U8] [EmitRes] e
-                                        | Ok op2 =>
-                                          let dest = append [U8] "%__ll" (binToDigits counter) in
-                                          let counter1 = incBin counter in
-                                          let cmpLine = append [U8] "  " (append [U8] dest (append [U8] "_c = icmp " (append [U8] predOp (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n"))))))) in
-                                          let extLine = append [U8] "  " (append [U8] dest (append [U8] " = zext i1 " (append [U8] dest "_c to i8\n"))) in
-                                          Ok
-                                            [List U8]
-                                            [EmitRes]
-                                            (
-                                              MkEmitRes
-                                                counter1
-                                                (
-                                                  cons
-                                                    [List U8]
-                                                    extLine
-                                                    (
-                                                      cons
-                                                        [List U8]
-                                                        cmpLine
-                                                        instrs
-                                                    )
-                                                )
-                                                dest
-                                            )
-                                      }
-                                  }
-                                )
-                                (
-                                  \x : AnfExpr =>
-                                    \y : List AnfExpr =>
-                                      Err
-                                        [List U8]
-                                        [EmitRes]
-                                        (
-                                          append
-                                            [U8]
-                                            name
-                                            " expects two arguments"
-                                        )
-                                )
-                        )
-                )
+              do [Result (List U8) EmitRes] {
+                pair <- (twoArgs name args)
+                MkPair a1 a2 = pair
+                op1 <- (atomOperand env a1)
+                op2 <- (atomOperand env a2)
+                dest = append [U8]
+                "%__ll" (binToDigits counter)
+                counter1 = incBin counter
+                cmpLine = append [U8]
+                "  "
+                  (
+                    append
+                      [U8]
+                      dest
+                      (
+                        append
+                          [U8]
+                          "_c = icmp "
+                          (
+                            append
+                              [U8]
+                              predOp
+                              (
+                                append
+                                  [U8]
+                                  " i8 "
+                                  (
+                                    append
+                                      [U8]
+                                      op1
+                                      (append [U8] ", " (append [U8] op2 "\n"))
+                                  )
+                              )
+                          )
+                      )
+                  )
+                extLine = append [U8] "  " (append [U8] dest (append [U8] " = zext i1 " (append [U8] dest "_c to i8\n")))
+                return
+                  Ok
+                  [List U8]
+                  [EmitRes]
+                  (
+                    MkEmitRes
+                      counter1
+                      (cons [List U8] extLine (cons [List U8] cmpLine instrs))
+                      dest
+                  )
+              }
 
 poly emitDivMod =
   \opcode : List U8 =>
@@ -374,96 +342,110 @@ poly emitDivMod =
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
-              matchList
-                [AnfExpr]
-                [Result (List U8) EmitRes]
-                args
-                (
-                  Err
-                    [List U8]
-                    [EmitRes]
-                    (append [U8] name " expects two arguments")
-                )
-                (
-                  \a1 : AnfExpr =>
-                    \r1 : List AnfExpr =>
-                      matchList
-                        [AnfExpr]
-                        [Result (List U8) EmitRes]
-                        r1
-                        (
-                          Err
-                            [List U8]
-                            [EmitRes]
-                            (append [U8] name " expects two arguments")
-                        )
-                        (
-                          \a2 : AnfExpr =>
-                            \r2 : List AnfExpr =>
-                              matchList
-                                [AnfExpr]
-                                [Result (List U8) EmitRes]
-                                r2
-                                (
-                                  match (atomOperand env a1) [Result (List U8) EmitRes] {
-                                    | Err e => Err [List U8] [EmitRes] e
-                                    | Ok op1 =>
-                                      match (atomOperand env a2) [Result (List U8) EmitRes] {
-                                        | Err e => Err [List U8] [EmitRes] e
-                                        | Ok op2 =>
-                                          let dest = append [U8] "%__ll" (binToDigits counter) in
-                                          let counter1 = incBin counter in
-                                          let zeroLine = append [U8] "  " (append [U8] dest (append [U8] "_zero = icmp eq i8 " (append [U8] op2 ", 0\n"))) in
-                                          let safeLine = append [U8] "  " (append [U8] dest (append [U8] "_safe = select i1 " (append [U8] dest (append [U8] "_zero, i8 1, i8 " (append [U8] op2 "\n"))))) in
-                                          let rawLine = append [U8] "  " (append [U8] dest (append [U8] "_raw = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] dest "_safe\n"))))))) in
-                                          let resLine = append [U8] "  " (append [U8] dest (append [U8] " = select i1 " (append [U8] dest (append [U8] "_zero, i8 0, i8 " (append [U8] dest "_raw\n"))))) in
-                                          Ok
-                                            [List U8]
-                                            [EmitRes]
-                                            (
-                                              MkEmitRes
-                                                counter1
-                                                (
-                                                  cons
-                                                    [List U8]
-                                                    resLine
-                                                    (
-                                                      cons
-                                                        [List U8]
-                                                        rawLine
-                                                        (
-                                                          cons
-                                                            [List U8]
-                                                            safeLine
-                                                            (
-                                                              cons
-                                                                [List U8]
-                                                                zeroLine
-                                                                instrs
-                                                            )
-                                                        )
-                                                    )
-                                                )
-                                                dest
-                                            )
-                                      }
-                                  }
-                                )
-                                (
-                                  \x : AnfExpr =>
-                                    \y : List AnfExpr =>
-                                      Err
-                                        [List U8]
-                                        [EmitRes]
-                                        (
-                                          append
-                                            [U8]
-                                            name
-                                            " expects two arguments"
-                                        )
-                                )
-                        )
-                )
+              do [Result (List U8) EmitRes] {
+                pair <- (twoArgs name args)
+                MkPair a1 a2 = pair
+                op1 <- (atomOperand env a1)
+                op2 <- (atomOperand env a2)
+                dest = append [U8]
+                "%__ll" (binToDigits counter)
+                counter1 = incBin counter
+                zeroLine = append [U8]
+                "  "
+                  (
+                    append
+                      [U8]
+                      dest
+                      (
+                        append
+                          [U8]
+                          "_zero = icmp eq i8 "
+                          (append [U8] op2 ", 0\n")
+                      )
+                  )
+                safeLine = append [U8]
+                "  "
+                  (
+                    append
+                      [U8]
+                      dest
+                      (
+                        append
+                          [U8]
+                          "_safe = select i1 "
+                          (
+                            append
+                              [U8]
+                              dest
+                              (
+                                append
+                                  [U8]
+                                  "_zero, i8 1, i8 "
+                                  (append [U8] op2 "\n")
+                              )
+                          )
+                      )
+                  )
+                rawLine = append [U8]
+                "  "
+                  (
+                    append
+                      [U8]
+                      dest
+                      (
+                        append
+                          [U8]
+                          "_raw = "
+                          (
+                            append
+                              [U8]
+                              opcode
+                              (
+                                append
+                                  [U8]
+                                  " i8 "
+                                  (
+                                    append
+                                      [U8]
+                                      op1
+                                      (
+                                        append
+                                          [U8]
+                                          ", "
+                                          (append [U8] dest "_safe\n")
+                                      )
+                                  )
+                              )
+                          )
+                      )
+                  )
+                resLine = append [U8] "  " (append [U8] dest (append [U8] " = select i1 " (append [U8] dest (append [U8] "_zero, i8 0, i8 " (append [U8] dest "_raw\n")))))
+                return
+                  Ok
+                  [List U8]
+                  [EmitRes]
+                  (
+                    MkEmitRes
+                      counter1
+                      (
+                        cons
+                          [List U8]
+                          resLine
+                          (
+                            cons
+                              [List U8]
+                              rawLine
+                              (
+                                cons
+                                  [List U8]
+                                  safeLine
+                                  (cons [List U8] zeroLine instrs)
+                              )
+                          )
+                      )
+                      dest
+                  )
+              }
 
 poly rec emitExpr =
   \env : List (((List U8), (List U8))) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.26.2",
+  "version": "0.27.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/anfLlvmEmit.test.ts
+++ b/test/compiler/anfLlvmEmit.test.ts
@@ -79,31 +79,165 @@ entry:
 
 `;
 
-describe("ANF -> LLVM emitter (.trip)", () => {
-  it("emits LLVM for the straight-line U8 subset (params, lets, calls)", async () => {
-    const modules: Array<{ name: string; source: string }> = await Promise.all(
-      MODULE_NAMES.map(async (name) => ({
-        name,
-        source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
-      })),
-    );
-    modules.push({
-      name: "Verify",
-      source: `module Verify
+/**
+ * Runs `AnfLlvm.compileSourceToLlvmText` on `source` under the host MiniCore
+ * evaluator and returns the emitted LLVM text.
+ */
+async function compileSourceToLlvm(source: string): Promise<string> {
+  const modules: Array<{ name: string; source: string }> = await Promise.all(
+    MODULE_NAMES.map(async (name) => ({
+      name,
+      source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+    })),
+  );
+  modules.push({
+    name: "Verify",
+    source: `module Verify
 import Prelude List
 import Prelude U8
 import AnfLlvm compileSourceToLlvmText
 
 export main
 
-poly main = compileSourceToLlvmText ${JSON.stringify(DEMO_SOURCE)}
+poly main = compileSourceToLlvmText ${JSON.stringify(source)}
 `,
-    });
+  });
 
-    const program = compileMiniCoreModules(modules, "Verify");
-    const result = evaluateMiniCore(program);
-    const actual = Buffer.from(valueToBytes(result.value)).toString("utf8");
+  const program = compileMiniCoreModules(modules, "Verify");
+  const result = evaluateMiniCore(program);
+  return Buffer.from(valueToBytes(result.value)).toString("utf8");
+}
 
-    assert.equal(actual, EXPECTED_LLVM);
+/** Wraps a function body as `module Demo` with `main` taking U8 params `names`. */
+function demoMain(names: readonly string[], body: string): string {
+  const binders = names.map((n) => `\\${n} : U8 => `).join("");
+  return `module Demo
+export main
+poly main = ${binders}${body}
+`;
+}
+
+describe("ANF -> LLVM emitter (.trip)", () => {
+  it("emits LLVM for the straight-line U8 subset (params, lets, calls)", async () => {
+    assert.equal(await compileSourceToLlvm(DEMO_SOURCE), EXPECTED_LLVM);
+  });
+
+  it("emits inline LLVM for U8 literals and arithmetic/comparison primitives", async () => {
+    const cases: ReadonlyArray<readonly [string, string, string]> = [
+      [
+        "byte literal",
+        `module Demo
+export main
+poly main = #u8(7)
+`,
+        `define i8 @main() {
+entry:
+  ret i8 7
+}
+
+`,
+      ],
+      [
+        "addU8",
+        demoMain(["a", "b"], "addU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0 = add i8 %a, %b
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "subU8",
+        demoMain(["a", "b"], "subU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0 = sub i8 %a, %b
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "divU8 (guards divide-by-zero)",
+        demoMain(["a", "b"], "divU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0_zero = icmp eq i8 %b, 0
+  %__ll0_safe = select i1 %__ll0_zero, i8 1, i8 %b
+  %__ll0_raw = udiv i8 %a, %__ll0_safe
+  %__ll0 = select i1 %__ll0_zero, i8 0, i8 %__ll0_raw
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "modU8 (guards divide-by-zero)",
+        demoMain(["a", "b"], "modU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0_zero = icmp eq i8 %b, 0
+  %__ll0_safe = select i1 %__ll0_zero, i8 1, i8 %b
+  %__ll0_raw = urem i8 %a, %__ll0_safe
+  %__ll0 = select i1 %__ll0_zero, i8 0, i8 %__ll0_raw
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "eqU8 (zext i1 result to i8)",
+        demoMain(["a", "b"], "eqU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0_c = icmp eq i8 %a, %b
+  %__ll0 = zext i1 %__ll0_c to i8
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "ltU8 (zext i1 result to i8)",
+        demoMain(["a", "b"], "ltU8 a b"),
+        `define i8 @main(i8 %a, i8 %b) {
+entry:
+  %__ll0_c = icmp ult i8 %a, %b
+  %__ll0 = zext i1 %__ll0_c to i8
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "byte literal as an operand",
+        demoMain(["a"], "addU8 a #u8(1)"),
+        `define i8 @main(i8 %a) {
+entry:
+  %__ll0 = add i8 %a, 1
+  ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "nested arithmetic threads SSA temps through a let",
+        demoMain(["a", "b", "c"], "addU8 (addU8 a b) c"),
+        `define i8 @main(i8 %a, i8 %b, i8 %c) {
+entry:
+  %__ll0 = add i8 %a, %b
+  %__ll1 = add i8 %__ll0, %c
+  ret i8 %__ll1
+}
+
+`,
+      ],
+    ];
+
+    for (const [label, source, expected] of cases) {
+      assert.equal(await compileSourceToLlvm(source), expected, label);
+    }
   });
 });


### PR DESCRIPTION
Scopes down #181 to its first shippable rung: the self-hosted ANF→LLVM emitter (`bootstrap/src/anfLlvm.trip`) now covers the **U8 scalar-compute subset** on top of the existing params/lets/calls rung, staying on `i8`.

## What's in
- **Byte literals** — `AE_Native (T_Byte b)` in `atomOperand` and `emitExpr` → the decimal operand.
- **Arithmetic** — `addU8`/`subU8` → `add`/`sub i8`.
- **Comparison** — `eqU8`/`ltU8` → `icmp eq`/`icmp ult` + `zext i1 to i8`.
- **Division** — `divU8`/`modU8` → `udiv`/`urem` with a divide-by-zero guard.

Primitives dispatch on the **call-head name** (`addU8`, …), which is the shape the front half actually normalizes them to — `AE_Call "addU8" [a, b]`, not the `_`/`AE_Native` anonymous form. Comparison and div/mod semantics mirror the host emitter (`lib/compiler/llvm/emitLlvm.ts`), so the bootstrap stays behaviorally consistent. Nine assertion cases in `anfLlvmEmit.test.ts`, all verified clang-free under the MiniCore evaluator.

## What's deferred (later rungs)
- **IO (`writeOne`/`readOne`)** — blocked on the front half: `miniCore.trip:buildFuncs` rejects any residual lambda (`escaping lambda in function …`), and a continuation is exactly that. Needs continuation lambda-lifting in the front half first.
- **`AE_Con`/`AE_Case`** (boxed runtime), the **`i64` widening** (only motivated once pointers exist), and the **`index.trip` bundle-seam re-point**.

+571/−32 across 3 files. `improvize format`, `prettier`, and the test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)