### PR TITLE
feat(prelude): add concat; flatten AnfLlvm U8 emitters with it

### DIFF
--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -474,7 +474,7 @@ poly rec emitExpr =
                                                     "%__ll"
                                                       (binToDigits counter)
                                                     counter1 = incBin counter
-                                                    line = append [U8] "  " (append [U8] dest (append [U8] " = call i8 @" (append [U8] f (append [U8] "(" (append [U8] argStr ")\n")))))
+                                                    line = concat [U8] {List U8 | "  " dest " = call i8 @" f "(" argStr ")\n"}
                                                     return
                                                       Ok
                                                       [List U8]
@@ -574,40 +574,19 @@ poly emitFunc =
         [List U8]
         [List U8]
         (
-          append
+          concat
             [U8]
-            "define i8 @"
-            (
-              append
-                [U8]
-                name
-                (
-                  append
-                    [U8]
-                    "("
-                    (
-                      append
-                        [U8]
-                        (paramDeclsString params true)
-                        (
-                          append
-                            [U8]
-                            ") {\nentry:\n"
-                            (
-                              append
-                                [U8]
-                                instrText
-                                (
-                                  append
-                                    [U8]
-                                    "  ret i8 "
-                                    (append [U8] op "\n}\n\n")
-                                )
-                            )
-                        )
-                    )
-                )
-            )
+            {List U8 |
+              "define i8 @"
+              name
+              "("
+              (paramDeclsString params true)
+              ") {\nentry:\n"
+              instrText
+              "  ret i8 "
+              op
+              "\n}\n\n"
+            }
         )
     }
 

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -10,6 +10,8 @@ import Prelude matchList
 
 import Prelude append
 
+import Prelude concat
+
 import Prelude Result
 
 import Prelude Ok
@@ -271,7 +273,7 @@ poly emitArithBin =
                 dest = append [U8]
                 "%__ll" (binToDigits counter)
                 counter1 = incBin counter
-                line = append [U8] "  " (append [U8] dest (append [U8] " = " (append [U8] opcode (append [U8] " i8 " (append [U8] op1 (append [U8] ", " (append [U8] op2 "\n")))))))
+                line = concat [U8] {List U8 | "  " dest " = " opcode " i8 " op1 ", " op2 "\n"}
                 return
                   Ok
                   [List U8]
@@ -294,35 +296,19 @@ poly emitCmpBin =
                 dest = append [U8]
                 "%__ll" (binToDigits counter)
                 counter1 = incBin counter
-                cmpLine = append [U8]
-                "  "
-                  (
-                    append
-                      [U8]
-                      dest
-                      (
-                        append
-                          [U8]
-                          "_c = icmp "
-                          (
-                            append
-                              [U8]
-                              predOp
-                              (
-                                append
-                                  [U8]
-                                  " i8 "
-                                  (
-                                    append
-                                      [U8]
-                                      op1
-                                      (append [U8] ", " (append [U8] op2 "\n"))
-                                  )
-                              )
-                          )
-                      )
-                  )
-                extLine = append [U8] "  " (append [U8] dest (append [U8] " = zext i1 " (append [U8] dest "_c to i8\n")))
+                cmpLine = concat [U8]
+                {List U8 |
+                  "  "
+                  dest
+                  "_c = icmp "
+                  predOp
+                  " i8 "
+                  op1
+                  ", "
+                  op2
+                  "\n"
+                }
+                extLine = concat [U8] {List U8 | "  " dest " = zext i1 " dest "_c to i8\n"}
                 return
                   Ok
                   [List U8]
@@ -330,7 +316,7 @@ poly emitCmpBin =
                   (
                     MkEmitRes
                       counter1
-                      (cons [List U8] extLine (cons [List U8] cmpLine instrs))
+                      (append [List U8] {List U8 | extLine cmpLine} instrs)
                       dest
                   )
               }
@@ -350,76 +336,31 @@ poly emitDivMod =
                 dest = append [U8]
                 "%__ll" (binToDigits counter)
                 counter1 = incBin counter
-                zeroLine = append [U8]
-                "  "
-                  (
-                    append
-                      [U8]
-                      dest
-                      (
-                        append
-                          [U8]
-                          "_zero = icmp eq i8 "
-                          (append [U8] op2 ", 0\n")
-                      )
-                  )
-                safeLine = append [U8]
-                "  "
-                  (
-                    append
-                      [U8]
-                      dest
-                      (
-                        append
-                          [U8]
-                          "_safe = select i1 "
-                          (
-                            append
-                              [U8]
-                              dest
-                              (
-                                append
-                                  [U8]
-                                  "_zero, i8 1, i8 "
-                                  (append [U8] op2 "\n")
-                              )
-                          )
-                      )
-                  )
-                rawLine = append [U8]
-                "  "
-                  (
-                    append
-                      [U8]
-                      dest
-                      (
-                        append
-                          [U8]
-                          "_raw = "
-                          (
-                            append
-                              [U8]
-                              opcode
-                              (
-                                append
-                                  [U8]
-                                  " i8 "
-                                  (
-                                    append
-                                      [U8]
-                                      op1
-                                      (
-                                        append
-                                          [U8]
-                                          ", "
-                                          (append [U8] dest "_safe\n")
-                                      )
-                                  )
-                              )
-                          )
-                      )
-                  )
-                resLine = append [U8] "  " (append [U8] dest (append [U8] " = select i1 " (append [U8] dest (append [U8] "_zero, i8 0, i8 " (append [U8] dest "_raw\n")))))
+                zeroLine = concat [U8]
+                {List U8 | "  " dest "_zero = icmp eq i8 " op2 ", 0\n"}
+                safeLine = concat [U8]
+                {List U8 |
+                  "  "
+                  dest
+                  "_safe = select i1 "
+                  dest
+                  "_zero, i8 1, i8 "
+                  op2
+                  "\n"
+                }
+                rawLine = concat [U8]
+                {List U8 |
+                  "  "
+                  dest
+                  "_raw = "
+                  opcode
+                  " i8 "
+                  op1
+                  ", "
+                  dest
+                  "_safe\n"
+                }
+                resLine = concat [U8] {List U8 | "  " dest " = select i1 " dest "_zero, i8 0, i8 " dest "_raw\n"}
                 return
                   Ok
                   [List U8]
@@ -428,20 +369,10 @@ poly emitDivMod =
                     MkEmitRes
                       counter1
                       (
-                        cons
+                        append
                           [List U8]
-                          resLine
-                          (
-                            cons
-                              [List U8]
-                              rawLine
-                              (
-                                cons
-                                  [List U8]
-                                  safeLine
-                                  (cons [List U8] zeroLine instrs)
-                              )
-                          )
+                          {List U8 | resLine rawLine safeLine zeroLine}
+                          instrs
                       )
                       dest
                   )

--- a/bootstrap/src/llvm.trip
+++ b/bootstrap/src/llvm.trip
@@ -128,10 +128,10 @@ poly u8ToDigits =
         let hundreds = divU8 n #u8(100) in
         let tens = modU8 (divU8 n #u8(10)) #u8(10) in
         let ones = modU8 n #u8(10) in
-        cons
+        append
           [U8]
-          (digitToAscii hundreds)
-          (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+          {U8 | (digitToAscii hundreds) (digitToAscii tens)}
+          (singletonU8 (digitToAscii ones))
     }
 
 poly digitValue =

--- a/bootstrap/src/miniVerify.trip
+++ b/bootstrap/src/miniVerify.trip
@@ -97,10 +97,10 @@ poly u8ToDigits =
         let hundreds = divU8 n #u8(100) in
         let tens = modU8 (divU8 n #u8(10)) #u8(10) in
         let ones = modU8 n #u8(10) in
-        cons
+        append
           [U8]
-          (digitToAscii hundreds)
-          (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+          {U8 | (digitToAscii hundreds) (digitToAscii tens)}
+          (singletonU8 (digitToAscii ones))
     }
 
 poly rec renderList =

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -1033,7 +1033,7 @@ poly rec exprListMentionsName =
                     (\u : U8 => true)
                     (\u : U8 => exprListMentionsName name rest)
                 | E_App l r =>
-                  exprListMentionsName name (cons [Expr] l (cons [Expr] r rest))
+                  exprListMentionsName name (append [Expr] {Expr | l r} rest)
                 | E_Lam varName body =>
                   if [Bool] (eqListU8 name varName)
                     (\u : U8 => true)
@@ -1047,7 +1047,7 @@ poly rec exprListMentionsName =
                       \u : U8 =>
                         exprListMentionsName
                           name
-                          (cons [Expr] value (cons [Expr] body rest))
+                          (append [Expr] {Expr | value body} rest)
                     )
                 | E_Nat n => exprListMentionsName name rest
                 | E_Match scrutinee arms =>

--- a/bootstrap/src/unparse.trip
+++ b/bootstrap/src/unparse.trip
@@ -149,10 +149,10 @@ poly u8ToDigits =
         let hundreds = divU8 n #u8(100) in
         let tens = modU8 (divU8 n #u8(10)) #u8(10) in
         let ones = modU8 n #u8(10) in
-        cons
+        append
           [U8]
-          (digitToAscii hundreds)
-          (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
+          {U8 | (digitToAscii hundreds) (digitToAscii tens)}
+          (singletonU8 (digitToAscii ones))
     }
 
 poly terminalTag =

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -1415,6 +1415,32 @@ function stripOuterParens(tokens: readonly Token[]): Token[] {
   return list;
 }
 
+function parseBracketedTypeArgument(
+  tokens: readonly Token[],
+  index: number,
+): { typeText: string; endIndex: number } | undefined {
+  const next = nextSyntaxWithIndex(tokens, index);
+  if (next?.token.text !== "[") return undefined;
+
+  const typeTokens: Token[] = [];
+  let cursor = next.index + 1;
+  let depth = 1;
+  while (cursor < tokens.length) {
+    const t = tokens[cursor]!;
+    if (t.text === "[") depth++;
+    if (t.text === "]") depth--;
+    if (depth === 0) break;
+    typeTokens.push(t);
+    cursor++;
+  }
+  if (cursor >= tokens.length) return undefined;
+
+  return {
+    typeText: formatInline(typeTokens),
+    endIndex: cursor,
+  };
+}
+
 function parseListChain(
   tokens: readonly Token[],
   index: number,
@@ -1482,6 +1508,52 @@ function parseListChain(
   }
 
   return undefined;
+}
+
+function parseConsPrefixChain(
+  tokens: readonly Token[],
+  index: number,
+):
+  | {
+      typeText: string;
+      elements: Token[][];
+      tailTokens: Token[];
+      endIndex: number;
+    }
+  | undefined {
+  const token = tokens[index];
+  if (token?.text !== "cons") return undefined;
+
+  const typeArg = parseBracketedTypeArgument(tokens, index);
+  if (!typeArg) return undefined;
+
+  const firstArg = parseArgExpression(tokens, typeArg.endIndex + 1);
+  if (!firstArg) return undefined;
+
+  const secondArg = parseArgExpression(tokens, firstArg.endIndex + 1);
+  if (!secondArg) return undefined;
+
+  const innerTokens = stripOuterParens(secondArg.tokens);
+  const nested = parseConsPrefixChain(innerTokens, 0);
+  if (
+    nested &&
+    nested.typeText === typeArg.typeText &&
+    nested.endIndex === innerTokens.length - 1
+  ) {
+    return {
+      typeText: typeArg.typeText,
+      elements: [firstArg.tokens, ...nested.elements],
+      tailTokens: nested.tailTokens,
+      endIndex: secondArg.endIndex,
+    };
+  }
+
+  return {
+    typeText: typeArg.typeText,
+    elements: [firstArg.tokens],
+    tailTokens: secondArg.tokens,
+    endIndex: secondArg.endIndex,
+  };
 }
 
 function parseListLiteral(
@@ -1568,6 +1640,78 @@ function parseAppendChain(
   }
 
   return undefined;
+}
+
+function parseAppendSegmentChain(
+  tokens: readonly Token[],
+  index: number,
+):
+  | {
+      typeText: string;
+      segments: Token[][];
+      appendCount: number;
+      endIndex: number;
+    }
+  | undefined {
+  const token = tokens[index];
+  if (token?.text !== "append") return undefined;
+
+  const typeArg = parseBracketedTypeArgument(tokens, index);
+  if (!typeArg) return undefined;
+
+  const arg1 = parseArgExpression(tokens, typeArg.endIndex + 1);
+  if (!arg1) return undefined;
+
+  const arg2 = parseArgExpression(tokens, arg1.endIndex + 1);
+  if (!arg2) return undefined;
+
+  const left = parseNestedAppendSegment(arg1.tokens, typeArg.typeText);
+  const right = parseNestedAppendSegment(arg2.tokens, typeArg.typeText);
+
+  return {
+    typeText: typeArg.typeText,
+    segments: [
+      ...(left?.segments ?? [arg1.tokens]),
+      ...(right?.segments ?? [arg2.tokens]),
+    ],
+    appendCount: 1 + (left?.appendCount ?? 0) + (right?.appendCount ?? 0),
+    endIndex: arg2.endIndex,
+  };
+}
+
+function parseNestedAppendSegment(
+  tokens: readonly Token[],
+  typeText: string,
+):
+  | {
+      segments: Token[][];
+      appendCount: number;
+    }
+  | undefined {
+  const stripped = stripOuterParens(tokens);
+  const nested = parseAppendSegmentChain(stripped, 0);
+  if (
+    nested &&
+    nested.typeText === typeText &&
+    nested.endIndex === stripped.length - 1
+  ) {
+    return {
+      segments: nested.segments,
+      appendCount: nested.appendCount,
+    };
+  }
+  return undefined;
+}
+
+function typeTextForListElementType(typeText: string): string {
+  const trimmed = typeText.trim();
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
+    return `List ${trimmed}`;
+  }
+  if (trimmed.startsWith("(") && trimmed.endsWith(")")) {
+    return `List ${trimmed}`;
+  }
+  return `List (${trimmed})`;
 }
 
 function resolveAsStaticList(
@@ -2276,6 +2420,37 @@ function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
       continue;
     }
 
+    // 1b. Append chain simplification to concat
+    const appendSegmentMatch = parseAppendSegmentChain(tokens, i);
+    if (
+      appendSegmentMatch &&
+      appendSegmentMatch.appendCount >= 2 &&
+      canUsePrelude(topLevel, "append") &&
+      canUsePrelude(topLevel, "concat")
+    ) {
+      const segmentTypeText = typeTextForListElementType(
+        appendSegmentMatch.typeText,
+      );
+      const segmentsStr = appendSegmentMatch.segments
+        .map((t) => formatInline(t))
+        .join(" ");
+      const replacement = `concat [${appendSegmentMatch.typeText}] {${segmentTypeText} | ${segmentsStr}}`;
+      diagnostics.push(
+        diagnostic(
+          "trip-append-concat",
+          `Use concat [${appendSegmentMatch.typeText}] to flatten nested append calls`,
+          tokens[i]!,
+          {
+            start: tokens[i]!.start,
+            end: tokens[appendSegmentMatch.endIndex]!.end,
+            replacement,
+          },
+        ),
+      );
+      i = appendSegmentMatch.endIndex;
+      continue;
+    }
+
     // 2. List cons/nil chain simplification
     const listChainMatch = parseListChain(tokens, i);
     if (listChainMatch) {
@@ -2317,6 +2492,38 @@ function lintTokens(source: string, tokens: Token[]): TripLintDiagnostic[] {
       );
       i = listChainMatch.endIndex;
       continue;
+    }
+
+    // 2b. Cons prefix simplification to a literal chunk plus tail append
+    const consPrefixMatch = parseConsPrefixChain(tokens, i);
+    if (
+      consPrefixMatch &&
+      consPrefixMatch.elements.length >= 2 &&
+      canUsePrelude(topLevel, "cons") &&
+      canUsePrelude(topLevel, "append")
+    ) {
+      const staticTail = resolveAsStaticList(consPrefixMatch.tailTokens);
+      if (staticTail?.typeText !== consPrefixMatch.typeText) {
+        const elementsStr = consPrefixMatch.elements
+          .map((t) => formatInline(t))
+          .join(" ");
+        const tailText = formatInline(consPrefixMatch.tailTokens);
+        const replacement = `append [${consPrefixMatch.typeText}] {${consPrefixMatch.typeText} | ${elementsStr}} ${tailText}`;
+        diagnostics.push(
+          diagnostic(
+            "trip-cons-prefix",
+            `Use syntactic sugar {${consPrefixMatch.typeText} | ...} for nested cons prefix`,
+            tokens[i]!,
+            {
+              start: tokens[i]!.start,
+              end: tokens[consPrefixMatch.endIndex]!.end,
+              replacement,
+            },
+          ),
+        );
+        i = consPrefixMatch.endIndex;
+        continue;
+      }
     }
 
     // 3. List literal to string literal conversion (for U8 chars)

--- a/lib/prelude.trip
+++ b/lib/prelude.trip
@@ -60,6 +60,8 @@ export None
 
 export append
 
+export concat
+
 export map
 
 export foldl
@@ -232,6 +234,16 @@ poly rec appendAcc =
 poly append =
   #A =>
     \xs : List A => \ys : List A => appendAcc [A] (reverse [A] xs) ys
+
+poly rec concat =
+  #A =>
+    \xss : List (List A) =>
+      matchList
+        [List A]
+        [List A]
+        xss
+        ({A |})
+        (\h : List A => \t : List (List A) => append [A] h (concat [A] t))
 
 poly rec map =
   #A =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -649,7 +649,7 @@ combinator 0
 module Prelude
 declared Prelude
 imports 0
-exports 54
+exports 55
 export Bool
 export id
 export true
@@ -680,6 +680,7 @@ export Maybe
 export Some
 export None
 export append
+export concat
 export map
 export foldl
 export takeWhile
@@ -734,7 +735,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 33
+poly 34
 poly id
 poly true
 poly false
@@ -754,6 +755,7 @@ poly head
 poly tail
 poly appendAcc
 poly append
+poly concat
 poly map
 poly foldl
 poly takeWhile

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
@@ -308,7 +308,7 @@ combinator 0
 module Prelude
 declared Prelude
 imports 0
-exports 54
+exports 55
 export Bool
 export id
 export true
@@ -339,6 +339,7 @@ export Maybe
 export Some
 export None
 export append
+export concat
 export map
 export foldl
 export takeWhile
@@ -393,7 +394,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 33
+poly 34
 poly id
 poly true
 poly false
@@ -413,6 +414,7 @@ poly head
 poly tail
 poly appendAcc
 poly append
+poly concat
 poly map
 poly foldl
 poly takeWhile

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude.txt
@@ -7,7 +7,7 @@ modules 1
 module Prelude
 declared Prelude
 imports 0
-exports 54
+exports 55
 export Bool
 export id
 export true
@@ -38,6 +38,7 @@ export Maybe
 export Some
 export None
 export append
+export concat
 export map
 export foldl
 export takeWhile
@@ -92,7 +93,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 33
+poly 34
 poly id
 poly true
 poly false
@@ -112,6 +113,7 @@ poly head
 poly tail
 poly appendAcc
 poly append
+poly concat
 poly map
 poly foldl
 poly takeWhile

--- a/test/improvize/improvize.test.ts
+++ b/test/improvize/improvize.test.ts
@@ -246,6 +246,19 @@ poly main = cons [Bin] a (cons [Bin] b (nil [Bin]))
     assert.match(result.fixed, /\{Bin \| a b\}/);
   });
 
+  it("reports and fixes nested cons prefixes to list literal chunks", () => {
+    const source = `module M
+import Prelude cons
+import Prelude append
+poly main = cons [Bin] a (cons [Bin] b (cons [Bin] c rest))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-cons-prefix"),
+    );
+    assert.match(result.fixed, /append \[Bin\] \{Bin \| a b c\} rest/);
+  });
+
   it("reports and fixes U8 list to double-quoted string literals", () => {
     const source = `module M
 poly main = cons [U8] 'h' (cons [U8] 'i' (nil [U8]))
@@ -277,6 +290,31 @@ poly main = append [Bin] {Bin | a} {Bin | b}
       result.diagnostics.some((diag) => diag.code === "trip-list-append"),
     );
     assert.match(result.fixed, /\{Bin \| a b\}/);
+  });
+
+  it("reports and fixes nested append chains to concat", () => {
+    const source = `module M
+import Prelude append
+import Prelude concat
+poly main = append [U8] "a" (append [U8] b (append [U8] c d))
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      result.diagnostics.some((diag) => diag.code === "trip-append-concat"),
+    );
+    assert.match(result.fixed, /concat \[U8\] \{List U8 \| "a" b c d\}/);
+  });
+
+  it("does not introduce concat without the Prelude import", () => {
+    const source = `module M
+import Prelude append
+poly main = append [U8] a (append [U8] b c)
+`;
+    const result = lintTripSource(source, { fix: true });
+    assert.ok(
+      !result.diagnostics.some((diag) => diag.code === "trip-append-concat"),
+    );
+    assert.doesNotMatch(result.fixed, /concat \[U8\]/);
   });
 
   it("reports and fixes degenerate if chains to cond blocks", () => {


### PR DESCRIPTION
Add a polymorphic concat : List (List T) -> List T to the Prelude (mirrors append), and use it in the bootstrap ANF->LLVM U8 emitters: the deep append/cons spines collapse to flat concat [U8] {List U8 | ...} and append [List U8] {List U8 | ...} instrs. Emitted LLVM is byte-identical (emitter tests unchanged); anfLlvm.trip drops ~90 lines.