### PR TITLE
[codex] run improvize on bootstrap corpus

### DIFF
--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -171,12 +171,12 @@ poly wrapValue =
                 (AE_Var nm)
             | PVal => MkNormResult state binds value
             | PTail =>
-              MkNormResult state ({Binding |}) (applyBindings binds value)
+              MkNormResult state {Binding |} (applyBindings binds value)
           }
 
 poly trivialAt =
   \state : Bin =>
-    \atom : AnfExpr => \pos : Pos => MkNormResult state ({Binding |}) atom
+    \atom : AnfExpr => \pos : Pos => MkNormResult state {Binding |} atom
 
 poly rec atomizeArgs =
   \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
@@ -187,7 +187,7 @@ poly rec atomizeArgs =
             [MiniExpr]
             [AtomList]
             args
-            (MkAtomList state accBinds ({AnfExpr |}))
+            (MkAtomList state accBinds {AnfExpr |})
             (
               \h : MiniExpr =>
                 \t : List MiniExpr =>
@@ -213,7 +213,7 @@ poly rec normArms =
             [MiniExpr]
             [ArmsRes]
             arms
-            (MkArmsRes state ({AnfExpr |}))
+            (MkArmsRes state {AnfExpr |})
             (
               \h : MiniExpr =>
                 \t : List MiniExpr =>
@@ -291,7 +291,7 @@ poly rec normalizeFuncs =
       [MiniFunc]
       [List AnfFunc]
       funcs
-      ({AnfFunc |})
+      {AnfFunc |}
       (
         \h : MiniFunc =>
           \t : List MiniFunc =>

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -132,7 +132,7 @@ data EmitRes =
   | MkEmitRes Bin (List (List U8)) (List U8)
 
 poly rec lookupEnv =
-  \env : List (((List U8), (List U8))) =>
+  \env : List ((List U8), (List U8)) =>
     \name : List U8 =>
       matchList
         [((List U8), (List U8))]
@@ -141,14 +141,14 @@ poly rec lookupEnv =
         (None [List U8])
         (
           \h : ((List U8), (List U8)) =>
-            \t : List (((List U8), (List U8))) =>
+            \t : List ((List U8), (List U8)) =>
               if [Maybe (List U8)] (eqListU8 (fst [List U8] [List U8] h) name)
                 (\u : U8 => Some [List U8] (snd [List U8] [List U8] h))
                 (\u : U8 => lookupEnv t name)
         )
 
 poly atomOperand =
-  \env : List (((List U8), (List U8))) =>
+  \env : List ((List U8), (List U8)) =>
     \e : AnfExpr =>
       match e [Result (List U8) (List U8)] {
         | AE_Var n =>
@@ -186,7 +186,7 @@ poly atomOperand =
       }
 
 poly rec emitArgsString =
-  \env : List (((List U8), (List U8))) =>
+  \env : List ((List U8), (List U8)) =>
     \args : List AnfExpr =>
       \leading : Bool =>
         matchList
@@ -261,7 +261,7 @@ poly twoArgs =
 poly emitArithBin =
   \opcode : List U8 =>
     \name : List U8 =>
-      \env : List (((List U8), (List U8))) =>
+      \env : List ((List U8), (List U8)) =>
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
@@ -284,7 +284,7 @@ poly emitArithBin =
 poly emitCmpBin =
   \predOp : List U8 =>
     \name : List U8 =>
-      \env : List (((List U8), (List U8))) =>
+      \env : List ((List U8), (List U8)) =>
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
@@ -324,7 +324,7 @@ poly emitCmpBin =
 poly emitDivMod =
   \opcode : List U8 =>
     \name : List U8 =>
-      \env : List (((List U8), (List U8))) =>
+      \env : List ((List U8), (List U8)) =>
         \counter : Bin =>
           \instrs : List (List U8) =>
             \args : List AnfExpr =>
@@ -379,7 +379,7 @@ poly emitDivMod =
               }
 
 poly rec emitExpr =
-  \env : List (((List U8), (List U8))) =>
+  \env : List ((List U8), (List U8)) =>
     \counter : Bin =>
       \instrs : List (List U8) =>
         \e : AnfExpr =>
@@ -540,15 +540,15 @@ poly rec paramEnv =
   \params : List (List U8) =>
     matchList
       [List U8]
-      [List (((List U8), (List U8)))]
+      [List ((List U8), (List U8))]
       params
-      ({((List U8), (List U8)) |})
+      {((List U8), (List U8)) |}
       (
         \h : List U8 =>
           \t : List (List U8) =>
             cons
               [((List U8), (List U8))]
-              ({List U8, List U8 | h, (append [U8] "%" h)})
+              {List U8, List U8 | h, (append [U8] "%" h)}
               (paramEnv t)
       )
 
@@ -566,9 +566,9 @@ poly emitFunc =
   \fn : AnfFunc =>
     do [Result (List U8) (List U8)] {
       MkAnfFunc name params body = fn
-      res <- (emitExpr (paramEnv params) BZ ({List U8 |}) body)
+      res <- (emitExpr (paramEnv params) BZ {List U8 |} body)
       MkEmitRes c instrs op = res
-      instrText = joinLines ("") instrs
+      instrText = joinLines "" instrs
       return
         Ok
         [List U8]

--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -343,7 +343,7 @@ poly rec div2DigitsAcc =
             [U8]
             [((List U8), U8)]
             digits
-            ({List U8, U8 | (reverse [U8] accRev), carry})
+            {List U8, U8 | (reverse [U8] accRev), carry}
             (
               \h : U8 =>
                 \t : List U8 =>
@@ -457,7 +457,7 @@ poly resolveCoreName =
 
 poly rec findCtorInfoInArms =
   \dEnv : DataEnv =>
-    \arms : List ((Pattern, Expr)) =>
+    \arms : List (Pattern, Expr) =>
       matchList
         [(Pattern, Expr)]
         [Maybe CtorInfo]
@@ -465,7 +465,7 @@ poly rec findCtorInfoInArms =
         (None [CtorInfo])
         (
           \h : (Pattern, Expr) =>
-            \t : List ((Pattern, Expr)) =>
+            \t : List (Pattern, Expr) =>
               match (fst [Pattern] [Expr] h) [Maybe CtorInfo] {
                 | P_Ctor name args =>
                   match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Maybe CtorInfo] {
@@ -477,15 +477,15 @@ poly rec findCtorInfoInArms =
 
 poly rec findArmByName =
   \name : List U8 =>
-    \arms : List ((Pattern, Expr)) =>
+    \arms : List (Pattern, Expr) =>
       matchList
         [(Pattern, Expr)]
         [(Pattern, Expr)]
         arms
-        ({Pattern, Expr | (P_Ctor name ({List U8 |})), (E_Var "MISSING_ARM")})
+        {Pattern, Expr | (P_Ctor name {List U8 |}), (E_Var "MISSING_ARM")}
         (
           \h : (Pattern, Expr) =>
-            \t : List ((Pattern, Expr)) =>
+            \t : List (Pattern, Expr) =>
               match (fst [Pattern] [Expr] h) [(Pattern, Expr)] {
                 | P_Ctor cName args =>
                   if [(Pattern, Expr)] (eqListU8 name cName)
@@ -496,12 +496,12 @@ poly rec findArmByName =
 
 poly rec sortArms =
   \expectedNames : List (List U8) =>
-    \arms : List ((Pattern, Expr)) =>
+    \arms : List (Pattern, Expr) =>
       matchList
         [List U8]
-        [List ((Pattern, Expr))]
+        [List (Pattern, Expr)]
         expectedNames
-        ({(Pattern, Expr) |})
+        {(Pattern, Expr) |}
         (
           \name : List U8 =>
             \tNames : List (List U8) =>
@@ -533,15 +533,15 @@ poly rec prependAll =
 poly rec elaborateArms =
   \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
     \dEnv : DataEnv =>
-      \arms : List ((Pattern, Expr)) =>
+      \arms : List (Pattern, Expr) =>
         matchList
           [(Pattern, Expr)]
           [Result (List U8) (List Core)]
           arms
-          (Ok [List U8] [List Core] ({Core |}))
+          (Ok [List U8] [List Core] {Core |})
           (
             \h : (Pattern, Expr) =>
-              \t : List ((Pattern, Expr)) =>
+              \t : List (Pattern, Expr) =>
                 do [Result (List U8) (List Core)] {
                   MkPair pat body = h
                   P_Ctor name args = pat
@@ -556,7 +556,7 @@ poly elaborateMatchWith =
   \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
     \dEnv : DataEnv =>
       \scrut : Expr =>
-        \arms : List ((Pattern, Expr)) =>
+        \arms : List (Pattern, Expr) =>
           match (elaborate dEnv scrut) [Result (List U8) Core] {
             | Err e => Err [List U8] [Core] e
             | Ok coreScrut =>
@@ -629,7 +629,7 @@ poly rec checkedLengthU8 =
 
 poly rec populateDataEnv =
   \adtName : List U8 =>
-    \ctors : List (((List U8), U8)) =>
+    \ctors : List ((List U8), U8) =>
       \total : U8 =>
         \idx : U8 =>
           \datEnv : DataEnv =>
@@ -640,7 +640,7 @@ poly rec populateDataEnv =
               datEnv
               (
                 \h : ((List U8), U8) =>
-                  \t : List (((List U8), U8)) =>
+                  \t : List ((List U8), U8) =>
                     let ctorName = fst [List U8] [U8] h in
                     let arity = snd [List U8] [U8] h in
                     let info = MkCtorInfo idx total arity adtName in
@@ -657,15 +657,15 @@ poly rec populateDataEnv =
               )
 
 poly rec getCtorNames =
-  \ctors : List (((List U8), U8)) =>
+  \ctors : List ((List U8), U8) =>
     matchList
       [((List U8), U8)]
       [List (List U8)]
       ctors
-      ({List U8 |})
+      {List U8 |}
       (
         \h : ((List U8), U8) =>
-          \t : List (((List U8), U8)) => cons [List U8] (fst [List U8] [U8] h) (getCtorNames t)
+          \t : List ((List U8), U8) => cons [List U8] (fst [List U8] [U8] h) (getCtorNames t)
       )
 
 poly rec filterElaboratableDecls =
@@ -674,7 +674,7 @@ poly rec filterElaboratableDecls =
       [Decl]
       [List Decl]
       decls
-      ({Decl |})
+      {Decl |}
       (
         \h : Decl =>
           \t : List Decl =>
@@ -773,13 +773,13 @@ poly rec elaborateToCoreRec =
     \decls : List Decl =>
       matchList
         [Decl]
-        [Result (List U8) (List (((List U8), Core)))]
+        [Result (List U8) (List ((List U8), Core))]
         decls
-        (Ok [List U8] [List (((List U8), Core))] ({((List U8), Core) |}))
+        (Ok [List U8] [List ((List U8), Core)] {((List U8), Core) |})
         (
           \h : Decl =>
             \t : List Decl =>
-              match h [Result (List U8) (List (((List U8), Core)))] {
+              match h [Result (List U8) (List ((List U8), Core))] {
                 | D_Def kind isRec name body =>
                   match (elaborateExpr dEnv body) [Result (List U8) (List (((List U8), Core)))] {
                     | Err e => Err [List U8] [List (((List U8), Core))] e
@@ -799,8 +799,8 @@ poly rec elaborateToCoreRec =
                       }
                   }
                 | D_Data name ctors =>
-                  match (checkedLengthU8 [((List U8), U8)] ctors #u8(0)) [Result (List U8) (List (((List U8), Core)))] {
-                    | Err e => Err [List U8] [List (((List U8), Core))] e
+                  match (checkedLengthU8 [((List U8), U8)] ctors #u8(0)) [Result (List U8) (List ((List U8), Core))] {
+                    | Err e => Err [List U8] [List ((List U8), Core)] e
                     | Ok total =>
                       match (populateDataEnv name ctors total #u8(0) dEnv) [Result (List U8) (List (((List U8), Core)))] {
                         | MkDataEnv cEnv aEnv =>

--- a/bootstrap/src/bundleInventory.trip
+++ b/bootstrap/src/bundleInventory.trip
@@ -110,15 +110,15 @@ export main
 
 poly rec lookupMod =
   \key : List U8 =>
-    \table : List (((List U8), (List Decl))) =>
+    \table : List ((List U8), (List Decl)) =>
       matchList
-        [(((List U8), (List Decl)))]
+        [((List U8), (List Decl))]
         [Maybe (List Decl)]
         table
         (None [List Decl])
         (
-          \h : (((List U8), (List Decl))) =>
-            \t : List (((List U8), (List Decl))) =>
+          \h : ((List U8), (List Decl)) =>
+            \t : List ((List U8), (List Decl)) =>
               if [Maybe (List Decl)] (eqListU8 (fst [List U8] [List Decl] h) key)
                 (\u : U8 => Some [List Decl] (snd [List U8] [List Decl] h))
                 (\u : U8 => lookupMod key t)
@@ -126,15 +126,15 @@ poly rec lookupMod =
 
 poly rec lookupExp =
   \key : List U8 =>
-    \table : List (((List U8), (List (List U8)))) =>
+    \table : List ((List U8), (List (List U8))) =>
       matchList
-        [(((List U8), (List (List U8))))]
+        [((List U8), (List (List U8)))]
         [Maybe (List (List U8))]
         table
         (None [List (List U8)])
         (
-          \h : (((List U8), (List (List U8)))) =>
-            \t : List (((List U8), (List (List U8)))) =>
+          \h : ((List U8), (List (List U8))) =>
+            \t : List ((List U8), (List (List U8))) =>
               if [Maybe (List (List U8))] (eqListU8 (fst [List U8] [List (List U8)] h) key)
                 (
                   \u : U8 => Some [List (List U8)] (snd [List U8] [List (List U8)] h)
@@ -144,21 +144,21 @@ poly rec lookupExp =
 
 poly rec removeExpEntry =
   \k : List U8 =>
-    \tbl : List (((List U8), (List (List U8)))) =>
+    \tbl : List ((List U8), (List (List U8))) =>
       matchList
-        [(((List U8), (List (List U8))))]
-        [List (((List U8), (List (List U8))))]
+        [((List U8), (List (List U8)))]
+        [List ((List U8), (List (List U8)))]
         tbl
-        ({(((List U8), (List (List U8)))) |})
+        {((List U8), (List (List U8))) |}
         (
-          \hh : (((List U8), (List (List U8)))) =>
-            \tt : List (((List U8), (List (List U8)))) =>
-              if [List (((List U8), (List (List U8))))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
+          \hh : ((List U8), (List (List U8))) =>
+            \tt : List ((List U8), (List (List U8))) =>
+              if [List ((List U8), (List (List U8)))] (eqListU8 (fst [List U8] [List (List U8)] hh) k)
                 (\u : U8 => tt)
                 (
                   \u : U8 =>
                     cons
-                      [(((List U8), (List (List U8))))]
+                      [((List U8), (List (List U8)))]
                       hh
                       (removeExpEntry k tt)
                 )
@@ -167,18 +167,18 @@ poly rec removeExpEntry =
 poly rec updateGlobalTable =
   \exports : List (List U8) =>
     \modName : List U8 =>
-      \table : List (((List U8), (List (List U8)))) =>
+      \table : List ((List U8), (List (List U8))) =>
         matchList
           [List U8]
-          [List (((List U8), (List (List U8))))]
+          [List ((List U8), (List (List U8)))]
           exports
           table
           (
             \h : List U8 =>
               \t : List (List U8) =>
                 let current = lookupExp h table in
-                let nextList = match current [List (List U8)] {| None => {List U8 | modName} | Some mods => append [List U8] mods ({List U8 | modName})} in
-                let nextTable = cons [(((List U8), (List (List U8))))] ({List U8, List (List U8) | h, nextList}) (removeExpEntry h table) in
+                let nextList = match current [List (List U8)] {| None => {List U8 | modName} | Some mods => append [List U8] mods {List U8 | modName}} in
+                let nextTable = cons [((List U8), (List (List U8)))] {List U8, List (List U8) | h, nextList} (removeExpEntry h table) in
                 updateGlobalTable t modName nextTable
           )
 
@@ -207,22 +207,20 @@ poly rec collectModuleExports =
 
 poly rec populateInventoryAcc =
   \mods : List ModuleRecord =>
-    \modTable : List (((List U8), (List Decl))) =>
-      \expTable : List (((List U8), (List (List U8)))) =>
+    \modTable : List ((List U8), (List Decl)) =>
+      \expTable : List ((List U8), (List (List U8))) =>
         matchList
           [ModuleRecord]
-          [Result (List U8) (((List (((List U8), (List Decl)))), (List (((List U8), (List (List U8)))))))]
+          [Result (List U8) ((List ((List U8), (List Decl))), (List ((List U8), (List (List U8)))))]
           mods
           (
             Ok
               [List U8]
-              [((List (((List U8), (List Decl)))), (List (((List U8), (List (List U8))))))]
-              (
-                {List (((List U8), (List Decl))), List (((List U8), (List (List U8)))) |
-                  modTable,
-                  expTable
-                }
-              )
+              [((List ((List U8), (List Decl))), (List ((List U8), (List (List U8)))))]
+              {List ((List U8), (List Decl)), List ((List U8), (List (List U8))) |
+                modTable,
+                expTable
+              }
           )
           (
             \h : ModuleRecord =>
@@ -264,8 +262,8 @@ poly rec populateInventoryAcc =
 
 poly populateInventory =
   \mods : List ModuleRecord =>
-    \modTable : List (((List U8), (List Decl))) =>
-      \expTable : List (((List U8), (List (List U8)))) => populateInventoryAcc mods modTable expTable
+    \modTable : List ((List U8), (List Decl)) =>
+      \expTable : List ((List U8), (List (List U8))) => populateInventoryAcc mods modTable expTable
 
 poly rec symbolInList =
   \symbolName : List U8 =>
@@ -286,25 +284,25 @@ poly rec symbolInList =
 poly isExported =
   \modName : List U8 =>
     \symbolName : List U8 =>
-      \modTable : List (((List U8), (List Decl))) =>
+      \modTable : List ((List U8), (List Decl)) =>
         match (lookupMod modName modTable) [Bool] {
           | None => false
           | Some decls =>
-            let exports = collectModuleExports decls ({List U8 |}) in
+            let exports = collectModuleExports decls {List U8 |} in
             symbolInList symbolName exports
         }
 
 poly rec ctorNameInList =
   \name : List U8 =>
-    \cs : List (((List U8), U8)) =>
+    \cs : List ((List U8), U8) =>
       matchList
-        [(((List U8), U8))]
+        [((List U8), U8)]
         [Bool]
         cs
         false
         (
-          \h : (((List U8), U8)) =>
-            \t : List (((List U8), U8)) =>
+          \h : ((List U8), U8) =>
+            \t : List ((List U8), U8) =>
               if [Bool] (eqListU8 (fst [List U8] [U8] h) name)
                 (\u : U8 => true)
                 (\u : U8 => ctorNameInList name t)
@@ -330,7 +328,7 @@ poly rec isDefined =
 poly emitImportStatus =
   \from : List U8 =>
     \symbol : List U8 =>
-      \modTable : List (((List U8), (List Decl))) =>
+      \modTable : List ((List U8), (List Decl)) =>
         match (lookupMod from modTable) [List U8] {
           | None => "MISSING_MODULE"
           | Some decls =>
@@ -341,7 +339,7 @@ poly emitImportStatus =
 
 poly emitExportStatus =
   \symbol : List U8 =>
-    \expTable : List (((List U8), (List (List U8)))) =>
+    \expTable : List ((List U8), (List (List U8))) =>
       \decls : List Decl =>
         match (lookupExp symbol expTable) [List U8] {
           | None => "OK"
@@ -386,7 +384,7 @@ poly rec filterDeclsAcc =
           )
 
 poly filterDecls =
-  \kind : U8 => \decls : List Decl => filterDeclsAcc kind decls ({Decl |})
+  \kind : U8 => \decls : List Decl => filterDeclsAcc kind decls {Decl |}
 
 poly rec countList =
   #A =>
@@ -401,7 +399,7 @@ poly rec countList =
 
 poly rec emitImportsSummary =
   \decls : List Decl =>
-    \modTable : List (((List U8), (List Decl))) =>
+    \modTable : List ((List U8), (List Decl)) =>
       matchList
         [Decl]
         [List U8]
@@ -458,7 +456,7 @@ poly rec emitImportsSummary =
 
 poly rec emitExportsSummary =
   \decls : List Decl =>
-    \expTable : List (((List U8), (List (List U8)))) =>
+    \expTable : List ((List U8), (List (List U8))) =>
       \allDecls : List Decl =>
         matchList
           [Decl]
@@ -505,15 +503,15 @@ poly rec emitExportsSummary =
           )
 
 poly rec emitCtors =
-  \cs : List (((List U8), U8)) =>
+  \cs : List ((List U8), U8) =>
     matchList
-      [(((List U8), U8))]
+      [((List U8), U8)]
       [List U8]
       cs
       ""
       (
-        \h : (((List U8), U8)) =>
-          \t : List (((List U8), U8)) =>
+        \h : ((List U8), U8) =>
+          \t : List ((List U8), U8) =>
             append
               [U8]
               "ctor "
@@ -668,8 +666,8 @@ poly rec getDeclared =
 poly emitModuleInventory =
   \name : List U8 =>
     \decls : List Decl =>
-      \modTable : List (((List U8), (List Decl))) =>
-        \expTable : List (((List U8), (List (List U8)))) =>
+      \modTable : List ((List U8), (List Decl)) =>
+        \expTable : List ((List U8), (List (List U8))) =>
           let declared = getDeclared decls in
           let imps = filterDecls #u8(1) decls in
           let exps = filterDecls #u8(2) decls in
@@ -784,8 +782,8 @@ poly emitModuleInventory =
 
 poly rec emitInventorySummary =
   \mods : List ModuleRecord =>
-    \modTable : List (((List U8), (List Decl))) =>
-      \expTable : List (((List U8), (List (List U8)))) =>
+    \modTable : List ((List U8), (List Decl)) =>
+      \expTable : List ((List U8), (List (List U8))) =>
         matchList
           [ModuleRecord]
           [List U8]

--- a/bootstrap/src/bundleParseSummary.trip
+++ b/bootstrap/src/bundleParseSummary.trip
@@ -508,7 +508,7 @@ poly emitCtor =
     emitNameCountLine prefixCtor name arity
 
 poly rec emitCtorsAcc =
-  \ctors : List (((List U8), U8)) =>
+  \ctors : List ((List U8), U8) =>
     \acc : List U8 =>
       matchList
         [((List U8), U8)]
@@ -517,11 +517,11 @@ poly rec emitCtorsAcc =
         acc
         (
           \h : ((List U8), U8) =>
-            \t : List (((List U8), U8)) => emitCtorsAcc t (append [U8] (emitCtor h) acc)
+            \t : List ((List U8), U8) => emitCtorsAcc t (append [U8] (emitCtor h) acc)
         )
 
 poly emitCtors =
-  \ctors : List (((List U8), U8)) => emitCtorsAcc (reverse [((List U8), U8)] ctors) ""
+  \ctors : List ((List U8), U8) => emitCtorsAcc (reverse [((List U8), U8)] ctors) ""
 
 poly rec emitDataDefsAcc =
   \decls : List Decl =>

--- a/bootstrap/src/bundleSummary.trip
+++ b/bootstrap/src/bundleSummary.trip
@@ -593,7 +593,8 @@ poly parseBundleSummary =
       MkLine modsLine afterModules = modulesLineRes
       modsCountDigits <- requireModules modsLine
       modsCount <- parseDecimal modsCountDigits
-      parsed <- parseModules afterModules modsCount entry (None [List U8]) false ({ModuleRecord |})
+      parsed <- parseModules afterModules modsCount entry (None [List U8]) false
+      {ModuleRecord |}
       MkParsedModules found mods rest = parsed
       return
         Ok

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -83,7 +83,7 @@ poly rec mapWith =
         [Core]
         [List MiniExpr]
         exprs
-        ({MiniExpr |})
+        {MiniExpr |}
         (\h : Core => \t : List Core => cons [MiniExpr] (f h) (mapWith f t))
 
 poly rec applyAnon =
@@ -105,7 +105,7 @@ poly rec coreToMini =
       | Cr_Var name => ME_Var name
       | Cr_Lam name body => ME_Lam name (coreToMini body)
       | Cr_Native t => ME_Native t
-      | Cr_Ctor tag total arity => ME_Con tag total arity ({MiniExpr |})
+      | Cr_Ctor tag total arity => ME_Con tag total arity {MiniExpr |}
       | Cr_App lf rg =>
         match (collectSpine (Cr_App lf rg) ({Core |})) [MiniExpr] {
           | MkPair head args =>

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -781,23 +781,23 @@ poly mapResult =
 
 poly simpleTokensU8 =
   {(U8, Token) |
-    ({U8, Token | '(', T_LParen})
-    ({U8, Token | ')', T_RParen})
-    ({U8, Token | '{', T_LBrace})
-    ({U8, Token | '}', T_RBrace})
-    ({U8, Token | '[', T_LBracket})
-    ({U8, Token | ']', T_RBracket})
-    ({U8, Token | '\\', T_Backslash})
-    ({U8, Token | ':', T_Colon})
-    ({U8, Token | '#', T_Hash})
-    ({U8, Token | '|', T_Pipe})
-    ({U8, Token | '.', T_Dot})
-    ({U8, Token | ',', T_Comma})
+    {U8, Token | '(', T_LParen}
+    {U8, Token | ')', T_RParen}
+    {U8, Token | '{', T_LBrace}
+    {U8, Token | '}', T_RBrace}
+    {U8, Token | '[', T_LBracket}
+    {U8, Token | ']', T_RBracket}
+    {U8, Token | '\\', T_Backslash}
+    {U8, Token | ':', T_Colon}
+    {U8, Token | '#', T_Hash}
+    {U8, Token | '|', T_Pipe}
+    {U8, Token | '.', T_Dot}
+    {U8, Token | ',', T_Comma}
   }
 
 poly rec lookupTokenU8 =
   \c : U8 =>
-    \list : List ((U8, Token)) =>
+    \list : List (U8, Token) =>
       matchList
         [(U8, Token)]
         [Maybe Token]
@@ -805,7 +805,7 @@ poly rec lookupTokenU8 =
         (None [Token])
         (
           \h : (U8, Token) =>
-            \t : List ((U8, Token)) =>
+            \t : List (U8, Token) =>
               if [Maybe Token] (eqU8 c (fst [U8] [Token] h))
                 (\u : U8 => Some [Token] (snd [U8] [Token] h))
                 (\u : U8 => lookupTokenU8 c t)
@@ -818,7 +818,7 @@ poly rec consumeIdent =
         [U8]
         [((List U8), (List U8))]
         input
-        ({List U8, List U8 | (reverse [U8] acc), ""})
+        {List U8, List U8 | (reverse [U8] acc), ""}
         (
           \h : U8 =>
             \t : List U8 =>
@@ -834,7 +834,7 @@ poly rec consumeDigits =
         [U8]
         [((List U8), (List U8))]
         input
-        ({List U8, List U8 | (reverse [U8] acc), ""})
+        {List U8, List U8 | (reverse [U8] acc), ""}
         (
           \h : U8 =>
             \t : List U8 =>
@@ -848,19 +848,19 @@ poly rec consumeString =
     \input : List U8 =>
       matchList
         [U8]
-        [Result ParseError (((List U8), (List U8)))]
+        [Result ParseError ((List U8), (List U8))]
         input
         (Err [ParseError] [((List U8), (List U8))] (MkParseError ""))
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Result ParseError (((List U8), (List U8)))] (eqU8 h u8_quote)
+              if [Result ParseError ((List U8), (List U8))] (eqU8 h u8_quote)
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
                       [((List U8), (List U8))]
-                      ({List U8, List U8 | (reverse [U8] acc), t})
+                      {List U8, List U8 | (reverse [U8] acc), t}
                 )
                 (\u : U8 => consumeString (cons [U8] h acc) t)
         )
@@ -884,19 +884,19 @@ poly finishCharLiteral =
     \input : List U8 =>
       matchList
         [U8]
-        [Result ParseError ((U8, (List U8)))]
+        [Result ParseError (U8, (List U8))]
         input
         charLiteralError
         (
           \close : U8 =>
             \rest : List U8 =>
-              if [Result ParseError ((U8, (List U8)))] (eqU8 close u8_squote)
+              if [Result ParseError (U8, (List U8))] (eqU8 close u8_squote)
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
                       [(U8, (List U8))]
-                      ({U8, List U8 | value, rest})
+                      {U8, List U8 | value, rest}
                 )
                 (\u : U8 => charLiteralError)
         )
@@ -905,18 +905,18 @@ poly consumeCharLiteral =
   \input : List U8 =>
     matchList
       [U8]
-      [Result ParseError ((U8, (List U8)))]
+      [Result ParseError (U8, (List U8))]
       input
       charLiteralError
       (
         \h : U8 =>
           \t : List U8 =>
-            if [Result ParseError ((U8, (List U8)))] (eqU8 h u8_backslash)
+            if [Result ParseError (U8, (List U8))] (eqU8 h u8_backslash)
               (
                 \u : U8 =>
                   matchList
                     [U8]
-                    [Result ParseError ((U8, (List U8)))]
+                    [Result ParseError (U8, (List U8))]
                     t
                     charLiteralError
                     (
@@ -1059,7 +1059,7 @@ poly rec tokenizeAcc =
 poly tokenize =
   \input : List U8 =>
     do [Result ParseError (List Token)] {
-      revWithEnd <- (tokenizeAcc input ({Token |}))
+      revWithEnd <- (tokenizeAcc input {Token |})
       return
         Ok
         [ParseError]

--- a/bootstrap/src/llvm.trip
+++ b/bootstrap/src/llvm.trip
@@ -327,7 +327,7 @@ poly rec parseModuleRecords =
       [ModuleRecord]
       [Result (List U8) (List ParsedModule)]
       records
-      (Ok [List U8] [List ParsedModule] ({ParsedModule |}))
+      (Ok [List U8] [List ParsedModule] {ParsedModule |})
       (
         \h : ModuleRecord =>
           \t : List ModuleRecord =>

--- a/bootstrap/src/miniCore.trip
+++ b/bootstrap/src/miniCore.trip
@@ -87,16 +87,16 @@ data MiniProgram =
 poly rec peelLams =
   \expr : Core =>
     match expr [((List (List U8)), Core)] {
-      | Cr_Var n => {List (List U8), Core | ({List U8 |}), expr}
-      | Cr_App a b => {List (List U8), Core | ({List U8 |}), expr}
+      | Cr_Var n => {List (List U8), Core | {List U8 |}, expr}
+      | Cr_App a b => {List (List U8), Core | {List U8 |}, expr}
       | Cr_Lam name body =>
         match (peelLams body) [((List (List U8)), Core)] {
           | MkPair ps inner =>
             {List (List U8), Core | (cons [List U8] name ps), inner}
         }
-      | Cr_Native t => {List (List U8), Core | ({List U8 |}), expr}
-      | Cr_Ctor t n a => {List (List U8), Core | ({List U8 |}), expr}
-      | Cr_Match s arms => {List (List U8), Core | ({List U8 |}), expr}
+      | Cr_Native t => {List (List U8), Core | {List U8 |}, expr}
+      | Cr_Ctor t n a => {List (List U8), Core | {List U8 |}, expr}
+      | Cr_Match s arms => {List (List U8), Core | {List U8 |}, expr}
     }
 
 poly rec listAnyLam =
@@ -122,15 +122,15 @@ poly rec exprHasLam =
     }
 
 poly rec buildFuncs =
-  \defs : List (((List U8), Core)) =>
+  \defs : List ((List U8), Core) =>
     matchList
       [((List U8), Core)]
       [Result (List U8) (List MiniFunc)]
       defs
-      (Ok [List U8] [List MiniFunc] ({MiniFunc |}))
+      (Ok [List U8] [List MiniFunc] {MiniFunc |})
       (
         \h : ((List U8), Core) =>
-          \t : List (((List U8), Core)) =>
+          \t : List ((List U8), Core) =>
             let name = fst [List U8] [Core] h in
             let core = snd [List U8] [Core] h in
             match (peelLams core) [Result (List U8) (List MiniFunc)] {
@@ -159,7 +159,7 @@ poly rec buildFuncs =
       )
 
 poly buildMiniProgram =
-  \defs : List (((List U8), Core)) =>
+  \defs : List ((List U8), Core) =>
     \entry : List U8 =>
       do [Result (List U8) MiniProgram] {
         funcs <- (buildFuncs defs)

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -670,7 +670,7 @@ poly rec parseModulesAcc =
         )
 
 poly initialBuildState =
-  MkBuildState ({ModuleInfo |}) ({ImportInfo |}) ({ExportInfo |}) ({DefinitionInfo |}) ({DataTypeInfo | (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0)) (MkDataTypeInfo "Prelude.List" "List" #u8(1))}) ({OpaqueInfo |}) ({NativeInfo |}) #u8(2)
+  MkBuildState {ModuleInfo |} {ImportInfo |} {ExportInfo |} {DefinitionInfo |} {DataTypeInfo | (MkDataTypeInfo "Prelude.Bool" "Bool" #u8(0)) (MkDataTypeInfo "Prelude.List" "List" #u8(1))} {OpaqueInfo |} {NativeInfo |} #u8(2)
 
 poly rec findDataTypeId =
   \qName : List U8 =>
@@ -692,7 +692,7 @@ poly rec findDataTypeId =
         )
 
 poly rec countCtors =
-  \ctors : List (((List U8), U8)) =>
+  \ctors : List ((List U8), U8) =>
     \acc : U8 =>
       matchList
         [((List U8), U8)]
@@ -700,14 +700,14 @@ poly rec countCtors =
         ctors
         acc
         (
-          \h : ((List U8), U8) => \t : List (((List U8), U8)) => countCtors t (inc acc)
+          \h : ((List U8), U8) => \t : List ((List U8), U8) => countCtors t (inc acc)
         )
 
 poly rec addCtorMetas =
   \moduleName : List U8 =>
     \typeName : List U8 =>
       \dataId : U8 =>
-        \ctors : List (((List U8), U8)) =>
+        \ctors : List ((List U8), U8) =>
           \total : U8 =>
             \tag : U8 =>
               \symbolId : U8 =>
@@ -716,10 +716,10 @@ poly rec addCtorMetas =
                     [((List U8), U8)]
                     [((List ConstructorMeta), U8)]
                     ctors
-                    ({List ConstructorMeta, U8 | acc, symbolId})
+                    {List ConstructorMeta, U8 | acc, symbolId}
                     (
                       \h : ((List U8), U8) =>
-                        \t : List (((List U8), U8)) =>
+                        \t : List ((List U8), U8) =>
                           let ctorName = fst [List U8] [U8] h in
                           let arity = snd [List U8] [U8] h in
                           let qName = qualifyCtor moduleName typeName ctorName in
@@ -737,7 +737,7 @@ poly rec addCtorMetas =
                               append
                                 [ConstructorMeta]
                                 acc
-                                ({ConstructorMeta | meta})
+                                {ConstructorMeta | meta}
                             )
                     )
 
@@ -751,7 +751,7 @@ poly rec collectConstructorsFromDecls =
               [Decl]
               [((List ConstructorMeta), U8)]
               decls
-              ({List ConstructorMeta, U8 | acc, symbolId})
+              {List ConstructorMeta, U8 | acc, symbolId}
               (
                 \h : Decl =>
                   \t : List Decl =>
@@ -839,7 +839,7 @@ poly rec collectConstructors =
             [ModuleInfo]
             [((List ConstructorMeta), U8)]
             mods
-            ({List ConstructorMeta, U8 | acc, symbolId})
+            {List ConstructorMeta, U8 | acc, symbolId}
             (
               \h : ModuleInfo =>
                 \t : List ModuleInfo =>
@@ -876,11 +876,9 @@ poly rec addAlias =
           [ConstructorAliasInfo]
           [List ConstructorAliasInfo]
           aliases
-          (
-            {ConstructorAliasInfo |
-              (MkConstructorAliasInfo alias (Some [List U8] qName))
-            }
-          )
+          {ConstructorAliasInfo |
+            (MkConstructorAliasInfo alias (Some [List U8] qName))
+          }
           (
             \h : ConstructorAliasInfo =>
               \t : List ConstructorAliasInfo =>
@@ -952,7 +950,8 @@ poly buildModuleEnv =
       state <- (parseModulesAcc records initialBuildState)
       MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId = state
       MkPair ctors nextSymbolId = (collectConstructors mods dataTypes #u8(4) pseudoConstructors)
-      aliases = buildAliases ctors ({ConstructorAliasInfo |})
+      aliases = buildAliases ctors
+      {ConstructorAliasInfo |}
       primitives = primitivesStartingAt nextSymbolId
       return
         Ok
@@ -1548,9 +1547,7 @@ poly rec moduleImportsAcc =
 poly moduleImports =
   \moduleName : List U8 =>
     \imports : List ImportInfo =>
-      reverse
-        [ImportInfo]
-        (moduleImportsAcc moduleName imports ({ImportInfo |}))
+      reverse [ImportInfo] (moduleImportsAcc moduleName imports {ImportInfo |})
 
 poly rec moduleExportsAcc =
   \moduleName : List U8 =>
@@ -1577,9 +1574,7 @@ poly rec moduleExportsAcc =
 poly moduleExports =
   \moduleName : List U8 =>
     \exports : List ExportInfo =>
-      reverse
-        [ExportInfo]
-        (moduleExportsAcc moduleName exports ({ExportInfo |}))
+      reverse [ExportInfo] (moduleExportsAcc moduleName exports {ExportInfo |})
 
 poly rec moduleDefsAcc =
   \moduleName : List U8 =>
@@ -1608,7 +1603,7 @@ poly moduleDefs =
     \defs : List DefinitionInfo =>
       reverse
         [DefinitionInfo]
-        (moduleDefsAcc moduleName defs ({DefinitionInfo |}))
+        (moduleDefsAcc moduleName defs {DefinitionInfo |})
 
 poly rec moduleOpaquesAcc =
   \moduleName : List U8 =>
@@ -1635,9 +1630,7 @@ poly rec moduleOpaquesAcc =
 poly moduleOpaques =
   \moduleName : List U8 =>
     \opaques : List OpaqueInfo =>
-      reverse
-        [OpaqueInfo]
-        (moduleOpaquesAcc moduleName opaques ({OpaqueInfo |}))
+      reverse [OpaqueInfo] (moduleOpaquesAcc moduleName opaques {OpaqueInfo |})
 
 poly rec moduleNativesAcc =
   \moduleName : List U8 =>
@@ -1664,9 +1657,7 @@ poly rec moduleNativesAcc =
 poly moduleNatives =
   \moduleName : List U8 =>
     \natives : List NativeInfo =>
-      reverse
-        [NativeInfo]
-        (moduleNativesAcc moduleName natives ({NativeInfo |}))
+      reverse [NativeInfo] (moduleNativesAcc moduleName natives {NativeInfo |})
 
 poly emitDataType =
   \info : DataTypeInfo =>
@@ -1856,7 +1847,7 @@ poly rec ctorNamesForData =
         [ConstructorMeta]
         [List (List U8)]
         ctors
-        ({List U8 |})
+        {List U8 |}
         (
           \h : ConstructorMeta =>
             \t : List ConstructorMeta =>

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -521,16 +521,16 @@ poly sndArgsToken =
   \p : ((List (List U8)), (List Token)) => snd [List (List U8)] [List Token] p
 
 poly fstPatternExprToken =
-  \p : (((Pattern, Expr)), (List Token)) => fst [(Pattern, Expr)] [List Token] p
+  \p : ((Pattern, Expr), (List Token)) => fst [(Pattern, Expr)] [List Token] p
 
 poly sndPatternExprToken =
-  \p : (((Pattern, Expr)), (List Token)) => snd [(Pattern, Expr)] [List Token] p
+  \p : ((Pattern, Expr), (List Token)) => snd [(Pattern, Expr)] [List Token] p
 
 poly fstArmsToken =
-  \p : ((List ((Pattern, Expr))), (List Token)) => fst [List ((Pattern, Expr))] [List Token] p
+  \p : ((List (Pattern, Expr)), (List Token)) => fst [List (Pattern, Expr)] [List Token] p
 
 poly sndArmsToken =
-  \p : ((List ((Pattern, Expr))), (List Token)) => snd [List ((Pattern, Expr))] [List Token] p
+  \p : ((List (Pattern, Expr)), (List Token)) => snd [List (Pattern, Expr)] [List Token] p
 
 poly fstDeclToken =
   \p : (Decl, (List Token)) => fst [Decl] [List Token] p
@@ -573,19 +573,19 @@ poly expectIdent =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (((List U8), (List Token)))]
+      [Result ParseError ((List U8), (List Token))]
       toks
       (Err [ParseError] [((List U8), (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
-            if [Result ParseError (((List U8), (List Token)))] (eqU8 (tokenTag h) identTag)
+            if [Result ParseError ((List U8), (List Token))] (eqU8 (tokenTag h) identTag)
               (
                 \u : U8 =>
                   Ok
                     [ParseError]
                     [((List U8), (List Token))]
-                    ({List U8, List Token | (tokenText h), t})
+                    {List U8, List Token | (tokenText h), t}
               )
               (
                 \u : U8 => Err [ParseError] [((List U8), (List Token))] parseError
@@ -630,7 +630,7 @@ poly rec skipToTopLevelDecl =
       [Token]
       [Result ParseError (List Token)]
       toks
-      (Ok [ParseError] [List Token] ({Token |}))
+      (Ok [ParseError] [List Token] {Token |})
       (
         \h : Token =>
           \t : List Token =>
@@ -647,24 +647,19 @@ poly rec parsePatternArgs =
     \acc : List (List U8) =>
       matchList
         [Token]
-        [Result ParseError (((List (List U8)), (List Token)))]
+        [Result ParseError ((List (List U8)), (List Token))]
         toks
         (Err [ParseError] [((List (List U8)), (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              cond [Result ParseError (((List (List U8)), (List Token)))] {
+              cond [Result ParseError ((List (List U8)), (List Token))] {
                 | (eqU8 tag fatArrowTag) =>
                   Ok
                     [ParseError]
                     [((List (List U8)), (List Token))]
-                    (
-                      {List (List U8), List Token |
-                        (reverse [List U8] acc),
-                        toks
-                      }
-                    )
+                    {List (List U8), List Token | (reverse [List U8] acc), toks}
                 | (eqU8 tag identTag) =>
                   parsePatternArgs t (cons [List U8] (tokenText h) acc)
                 | otherwise =>
@@ -673,14 +668,14 @@ poly rec parsePatternArgs =
         )
 
 poly parseMatchArmWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
-      do [Result ParseError (((Pair Pattern Expr), (List Token)))] {
+      do [Result ParseError ((Pattern, Expr), (List Token))] {
         afterPipe <- (expect toks pipeTag)
         ctorRes <- (expectIdent afterPipe)
         ctorName = fstNameToken ctorRes
         afterCtor = sndNameToken ctorRes
-        argRes <- (parsePatternArgs afterCtor ({List U8 |}))
+        argRes <- (parsePatternArgs afterCtor {List U8 |})
         args = fstArgsToken argRes
         atArrow = sndArgsToken argRes
         bodyToks <- (expect atArrow fatArrowTag)
@@ -690,44 +685,35 @@ poly parseMatchArmWith =
         return
           Ok
           [ParseError]
-          [((Pair Pattern Expr), (List Token))]
-          (
-            {Pair Pattern Expr, List Token |
-              (MkPair [Pattern] [Expr] (P_Ctor ctorName args) body),
-              rest
-            }
-          )
+          [((Pattern, Expr), (List Token))]
+          {(Pattern, Expr), List Token |
+            {Pattern, Expr | (P_Ctor ctorName args), body},
+            rest
+          }
       }
 
 poly rec parseMatchArmsWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
-      \acc : List ((Pattern, Expr)) =>
+      \acc : List (Pattern, Expr) =>
         matchList
           [Token]
-          [Result ParseError (((List ((Pattern, Expr))), (List Token)))]
+          [Result ParseError ((List (Pattern, Expr)), (List Token))]
           toks
-          (
-            Err
-              [ParseError]
-              [((List ((Pattern, Expr))), (List Token))]
-              parseError
-          )
+          (Err [ParseError] [((List (Pattern, Expr)), (List Token))] parseError)
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                cond [Result ParseError (((List ((Pattern, Expr))), (List Token)))] {
+                cond [Result ParseError ((List (Pattern, Expr)), (List Token))] {
                   | (eqU8 tag rBraceTag) =>
                     Ok
                       [ParseError]
-                      [((List ((Pattern, Expr))), (List Token))]
-                      (
-                        {List ((Pattern, Expr)), List Token |
-                          (reverse [(Pattern, Expr)] acc),
-                          t
-                        }
-                      )
+                      [((List (Pattern, Expr)), (List Token))]
+                      {List (Pattern, Expr), List Token |
+                        (reverse [(Pattern, Expr)] acc),
+                        t
+                      }
                   | (eqU8 tag pipeTag) =>
                     match (parseMatchArmWith recurse toks) [Result ParseError (Pair (List (Pair Pattern Expr)) (List Token))] {
                       | Err e =>
@@ -746,7 +732,7 @@ poly rec parseMatchArmsWith =
                   | otherwise =>
                     Err
                       [ParseError]
-                      [((List ((Pattern, Expr))), (List Token))]
+                      [((List (Pattern, Expr)), (List Token))]
                       parseError
                 }
           )
@@ -779,30 +765,30 @@ poly rec buildListExpr =
       )
 
 poly parseLiteralAtomWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError ((Expr, (List Token)))]
+        [Result ParseError (Expr, (List Token))]
         toks
         (Err [ParseError] [(Expr, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              cond [Result ParseError ((Expr, (List Token)))] {
+              cond [Result ParseError (Expr, (List Token))] {
                 | (eqU8 tag identTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var (tokenText h)), t})
+                    {Expr, List Token | (E_Var (tokenText h)), t}
                 | (eqU8 tag natTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Nat (tokenNatValue h)), t})
+                    {Expr, List Token | (E_Nat (tokenNatValue h)), t}
                 | (eqU8 tag lParenTag) =>
-                  do [Result ParseError (Pair Expr (List Token))] {
+                  do [Result ParseError (Expr, (List Token))] {
                     res <- (recurse t)
                     inner = fstExprToken res
                     rest = sndExprToken res
@@ -810,19 +796,19 @@ poly parseLiteralAtomWith =
                     return
                       Ok
                       [ParseError]
-                      [Pair Expr (List Token)]
-                      (MkPair [Expr] [List Token] inner final)
+                      [(Expr, (List Token))]
+                      {Expr, List Token | inner, final}
                   }
                 | (eqU8 tag commaTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var ","), t})
+                    {Expr, List Token | (E_Var ","), t}
                 | (eqU8 tag dotTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var "."), t})
+                    {Expr, List Token | (E_Var "."), t}
                 | (eqU8 tag hashTag) =>
                   match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
                     | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -883,30 +869,31 @@ poly parseLiteralAtomWith =
                             )
                       }
                   }
+                | (eqU8 tag lBraceTag) => parseBraceBodyWith recurse t
                 | otherwise => Err [ParseError] [(Expr, (List Token))] parseError
               }
         )
 
 poly rec parseListElements =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       \acc : List Expr =>
         matchList
           [Token]
-          [Result ParseError (((List Expr), (List Token)))]
+          [Result ParseError ((List Expr), (List Token))]
           toks
           (Err [ParseError] [((List Expr), (List Token))] parseError)
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (((List Expr), (List Token)))] (eqU8 tag rBraceTag)
+                if [Result ParseError ((List Expr), (List Token))] (eqU8 tag rBraceTag)
                   (
                     \u : U8 =>
                       Ok
                         [ParseError]
                         [((List Expr), (List Token))]
-                        ({List Expr, List Token | (reverse [Expr] acc), t})
+                        {List Expr, List Token | (reverse [Expr] acc), t}
                   )
                   (
                     \u : U8 =>
@@ -921,7 +908,7 @@ poly rec parseListElements =
           )
 
 poly parseBraceBodyWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \afterBrace : List Token =>
       match (parseType afterBrace) [Result ParseError ((Expr, (List Token)))] {
         | Err e => Err [ParseError] [(Expr, (List Token))] e
@@ -1003,7 +990,7 @@ poly parseBraceBodyWith =
       }
 
 poly rec prependArmBodies =
-  \arms : List ((Pattern, Expr)) =>
+  \arms : List (Pattern, Expr) =>
     \rest : List Expr =>
       matchList
         [(Pattern, Expr)]
@@ -1012,7 +999,7 @@ poly rec prependArmBodies =
         rest
         (
           \h : (Pattern, Expr) =>
-            \t : List ((Pattern, Expr)) =>
+            \t : List (Pattern, Expr) =>
               prependArmBodies t (cons [Expr] (snd [Pattern] [Expr] h) rest)
         )
 
@@ -1059,7 +1046,7 @@ poly rec exprListMentionsName =
 
 poly exprMentionsName =
   \name : List U8 =>
-    \expr : Expr => exprListMentionsName name (cons [Expr] expr ({Expr |}))
+    \expr : Expr => exprListMentionsName name (cons [Expr] expr {Expr |})
 
 poly rec freshCondDelayNameFrom =
   \thenExpr : Expr =>
@@ -1096,7 +1083,7 @@ poly isOtherwiseExpr =
     }
 
 poly rec desugarCondLoop =
-  \arms : List ((Expr, Expr)) =>
+  \arms : List (Expr, Expr) =>
     \currentElse : Expr =>
       matchList
         [(Expr, Expr)]
@@ -1105,7 +1092,7 @@ poly rec desugarCondLoop =
         currentElse
         (
           \h : (Expr, Expr) =>
-            \t : List ((Expr, Expr)) =>
+            \t : List (Expr, Expr) =>
               let condExpr = fst [Expr] [Expr] h in
               let bodyExpr = snd [Expr] [Expr] h in
               let delayName = freshCondDelayName bodyExpr currentElse in
@@ -1116,7 +1103,7 @@ poly rec desugarCondLoop =
         )
 
 poly desugarCond =
-  \arms : List ((Expr, Expr)) =>
+  \arms : List (Expr, Expr) =>
     matchList
       [(Expr, Expr)]
       [Expr]
@@ -1124,23 +1111,23 @@ poly desugarCond =
       (E_Var "error")
       (
         \h : (Expr, Expr) =>
-          \t : List ((Expr, Expr)) => desugarCondLoop t (snd [Expr] [Expr] h)
+          \t : List (Expr, Expr) => desugarCondLoop t (snd [Expr] [Expr] h)
       )
 
 poly rec parseCondArms =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
-      \acc : List ((Expr, Expr)) =>
+      \acc : List (Expr, Expr) =>
         matchList
           [Token]
-          [Result ParseError ((Expr, (List Token)))]
+          [Result ParseError (Expr, (List Token))]
           toks
           (Err [ParseError] [(Expr, (List Token))] parseError)
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                cond [Result ParseError ((Expr, (List Token)))] {
+                cond [Result ParseError (Expr, (List Token))] {
                   | (eqU8 tag rBraceTag) => Err [ParseError] [(Expr, (List Token))] parseError
                   | (eqU8 tag pipeTag) =>
                     match (recurse t) [Result ParseError (Pair Expr (List Token))] {
@@ -1214,7 +1201,7 @@ poly rec parseCondArms =
           )
 
 poly parseCondWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       match (expect toks lBracketTag) [Result ParseError ((Expr, (List Token)))] {
         | Err e => Err [ParseError] [(Expr, (List Token))] e
@@ -1235,32 +1222,32 @@ poly parseCondWith =
       }
 
 poly parseAtomWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError ((Expr, (List Token)))]
+        [Result ParseError (Expr, (List Token))]
         toks
         (Err [ParseError] [(Expr, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              cond [Result ParseError ((Expr, (List Token)))] {
+              cond [Result ParseError (Expr, (List Token))] {
                 | (eqU8 tag kwCondTag) => parseCondWith recurse t
                 | (eqU8 tag identTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var (tokenText h)), t})
+                    {Expr, List Token | (E_Var (tokenText h)), t}
                 | (eqU8 tag kwDoTag) => parseDoWith recurse t
                 | (eqU8 tag natTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Nat (tokenNatValue h)), t})
+                    {Expr, List Token | (E_Nat (tokenNatValue h)), t}
                 | (eqU8 tag lParenTag) =>
-                  do [Result ParseError (Pair Expr (List Token))] {
+                  do [Result ParseError (Expr, (List Token))] {
                     res <- (recurse t)
                     inner = fstExprToken res
                     rest = sndExprToken res
@@ -1268,19 +1255,19 @@ poly parseAtomWith =
                     return
                       Ok
                       [ParseError]
-                      [Pair Expr (List Token)]
-                      (MkPair [Expr] [List Token] inner final)
+                      [(Expr, (List Token))]
+                      {Expr, List Token | inner, final}
                   }
                 | (eqU8 tag commaTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var ","), t})
+                    {Expr, List Token | (E_Var ","), t}
                 | (eqU8 tag dotTag) =>
                   Ok
                     [ParseError]
                     [(Expr, (List Token))]
-                    ({Expr, List Token | (E_Var "."), t})
+                    {Expr, List Token | (E_Var "."), t}
                 | (eqU8 tag hashTag) =>
                   match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
                     | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -1354,18 +1341,18 @@ poly skipTypeArg =
     }
 
 poly parseSimpleTypeWith =
-  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Type, (List Token))) =>
     \toks : List Token =>
       matchList
         [Token]
-        [Result ParseError ((Type, (List Token)))]
+        [Result ParseError (Type, (List Token))]
         toks
         (Err [ParseError] [(Type, (List Token))] parseError)
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              cond [Result ParseError ((Type, (List Token)))] {
+              cond [Result ParseError (Type, (List Token))] {
                 | (eqU8 tag lParenTag) =>
                   match (recurse t) [Result ParseError (Pair Type (List Token))] {
                     | Err e => Err [ParseError] [Pair Type (List Token)] e
@@ -1435,7 +1422,7 @@ poly parseSimpleTypeWith =
                   Ok
                     [ParseError]
                     [(Type, (List Token))]
-                    ({Type, List Token | (Ty_Var (tokenText h)), t})
+                    {Type, List Token | (Ty_Var (tokenText h)), t}
                 | otherwise => Err [ParseError] [(Type, (List Token))] parseError
               }
         )
@@ -1447,24 +1434,24 @@ poly isTypeAtomStartTag =
       (\u : U8 => eqU8 tag lParenTag)
 
 poly rec parseTypeAppLoopWith =
-  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Type, (List Token))) =>
     \lhs : Type =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError ((Type, (List Token)))]
+          [Result ParseError (Type, (List Token))]
           toks
           (
             Ok
               [ParseError]
               [(Type, (List Token))]
-              ({Type, List Token | lhs, toks})
+              {Type, List Token | lhs, toks}
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError ((Type, (List Token)))] (isTypeAtomStartTag tag)
+                if [Result ParseError (Type, (List Token))] (isTypeAtomStartTag tag)
                   (
                     \u : U8 =>
                       match (parseSimpleTypeWith recurse toks) [Result ParseError ((Type, (List Token)))] {
@@ -1480,12 +1467,12 @@ poly rec parseTypeAppLoopWith =
                       Ok
                         [ParseError]
                         [(Type, (List Token))]
-                        ({Type, List Token | lhs, toks})
+                        {Type, List Token | lhs, toks}
                   )
           )
 
 poly parseTypeApplicationWith =
-  \recurse : (List Token -> Result ParseError ((Type, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Type, (List Token))) =>
     \toks : List Token =>
       match (parseSimpleTypeWith recurse toks) [Result ParseError ((Type, (List Token)))] {
         | Err e => Err [ParseError] [(Type, (List Token))] e
@@ -1499,17 +1486,17 @@ poly rec parseType =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError ((Type, (List Token)))]
+      [Result ParseError (Type, (List Token))]
       toks
       (Err [ParseError] [(Type, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            if [Result ParseError ((Type, (List Token)))] (eqU8 tag hashTag)
+            if [Result ParseError (Type, (List Token))] (eqU8 tag hashTag)
               (
                 \u : U8 =>
-                  do [Result ParseError ((Type, (List Token)))] {
+                  do [Result ParseError (Type, (List Token))] {
                     idRes <- (expectIdent t)
                     tyVar = fstNameToken idRes
                     afterVar = sndNameToken idRes
@@ -1521,7 +1508,7 @@ poly rec parseType =
                       Ok
                       [ParseError]
                       [(Type, (List Token))]
-                      ({Type, List Token | (Ty_Forall tyVar bodyTy), rest})
+                      {Type, List Token | (Ty_Forall tyVar bodyTy), rest}
                   }
               )
               (
@@ -1573,24 +1560,24 @@ poly parseTypeApplication =
   \toks : List Token => parseTypeApplicationWith parseType toks
 
 poly rec parseAppLoopWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \lhs : Expr =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError ((Expr, (List Token)))]
+          [Result ParseError (Expr, (List Token))]
           toks
           (
             Ok
               [ParseError]
               [(Expr, (List Token))]
-              ({Expr, List Token | lhs, toks})
+              {Expr, List Token | lhs, toks}
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                cond [Result ParseError ((Expr, (List Token)))] {
+                cond [Result ParseError (Expr, (List Token))] {
                   | (eqU8 tag lBracketTag) =>
                     match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
                       | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -1608,34 +1595,34 @@ poly rec parseAppLoopWith =
                     Ok
                       [ParseError]
                       [(Expr, (List Token))]
-                      ({Expr, List Token | lhs, toks})
+                      {Expr, List Token | lhs, toks}
                 }
           )
 
 poly rec parseAppLoopNoBraceWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \lhs : Expr =>
       \toks : List Token =>
         matchList
           [Token]
-          [Result ParseError ((Expr, (List Token)))]
+          [Result ParseError (Expr, (List Token))]
           toks
           (
             Ok
               [ParseError]
               [(Expr, (List Token))]
-              ({Expr, List Token | lhs, toks})
+              {Expr, List Token | lhs, toks}
           )
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                cond [Result ParseError ((Expr, (List Token)))] {
+                cond [Result ParseError (Expr, (List Token))] {
                   | (eqU8 tag lBraceTag) =>
                     Ok
                       [ParseError]
                       [(Expr, (List Token))]
-                      ({Expr, List Token | lhs, toks})
+                      {Expr, List Token | lhs, toks}
                   | (eqU8 tag lBracketTag) =>
                     match (skipTypeArg toks) [Result ParseError (Pair Expr (List Token))] {
                       | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -1653,12 +1640,12 @@ poly rec parseAppLoopNoBraceWith =
                     Ok
                       [ParseError]
                       [(Expr, (List Token))]
-                      ({Expr, List Token | lhs, toks})
+                      {Expr, List Token | lhs, toks}
                 }
           )
 
 poly parseAppNoBraceWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       match (parseAtomWith recurse toks) [Result ParseError ((Expr, (List Token)))] {
         | Err e => Err [ParseError] [(Expr, (List Token))] e
@@ -1669,7 +1656,7 @@ poly parseAppNoBraceWith =
       }
 
 poly parseAppWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       match (parseAtomWith recurse toks) [Result ParseError ((Expr, (List Token)))] {
         | Err e => Err [ParseError] [(Expr, (List Token))] e
@@ -1689,20 +1676,20 @@ poly parseMatchArm =
   \toks : List Token => parseMatchArmWith parseExpr toks
 
 poly parseMatchArms =
-  \toks : List Token => parseMatchArmsWith parseExpr toks ({(Pattern, Expr) |})
+  \toks : List Token => parseMatchArmsWith parseExpr toks {(Pattern, Expr) |}
 
 poly rec parseExpr =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError ((Expr, (List Token)))]
+      [Result ParseError (Expr, (List Token))]
       toks
       (Err [ParseError] [(Expr, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            cond [Result ParseError ((Expr, (List Token)))] {
+            cond [Result ParseError (Expr, (List Token))] {
               | (eqU8 tag hashTag) =>
                 match (expectIdent t) [Result ParseError (Pair Expr (List Token))] {
                   | Err e => Err [ParseError] [Pair Expr (List Token)] e
@@ -1768,7 +1755,7 @@ poly rec parseExpr =
                     }
                 }
               | (eqU8 tag backslashTag) =>
-                do [Result ParseError (Pair Expr (List Token))] {
+                do [Result ParseError (Expr, (List Token))] {
                   idRes <- (expectIdent t)
                   name = fstNameToken idRes
                   afterName = sndNameToken idRes
@@ -1779,11 +1766,11 @@ poly rec parseExpr =
                   return
                     Ok
                     [ParseError]
-                    [Pair Expr (List Token)]
-                    (MkPair [Expr] [List Token] (E_Lam name body) rest)
+                    [(Expr, (List Token))]
+                    {Expr, List Token | (E_Lam name body), rest}
                 }
               | (eqU8 tag kwLetTag) =>
-                do [Result ParseError (Pair Expr (List Token))] {
+                do [Result ParseError (Expr, (List Token))] {
                   idRes <- (expectIdent t)
                   name = fstNameToken idRes
                   afterName = sndNameToken idRes
@@ -1798,14 +1785,8 @@ poly rec parseExpr =
                   return
                     Ok
                     [ParseError]
-                    [Pair Expr (List Token)]
-                    (
-                      MkPair
-                        [Expr]
-                        [List Token]
-                        (E_Let name valExpr bodyExpr)
-                        rest
-                    )
+                    [(Expr, (List Token))]
+                    {Expr, List Token | (E_Let name valExpr bodyExpr), rest}
                 }
               | (eqU8 tag kwMatchTag) =>
                 match (parseAppNoBraceWith parseExpr t) [Result ParseError (Pair Expr (List Token))] {
@@ -1842,7 +1823,7 @@ poly parseNamedDef =
   \defKind : DefKind =>
     \isRecursive : Bool =>
       \toks : List Token =>
-        do [Result ParseError ((Decl, (List Token)))] {
+        do [Result ParseError (Decl, (List Token))] {
           nameRes <- (expectIdent toks)
           name = fstNameToken nameRes
           afterName = sndNameToken nameRes
@@ -1854,7 +1835,7 @@ poly parseNamedDef =
             Ok
             [ParseError]
             [(Decl, (List Token))]
-            ({Decl, List Token | (D_Def defKind isRecursive name body), rest})
+            {Decl, List Token | (D_Def defKind isRecursive name body), rest}
         }
 
 poly rec parseCtorArity =
@@ -1862,20 +1843,20 @@ poly rec parseCtorArity =
     \acc : U8 =>
       matchList
         [Token]
-        [Result ParseError ((U8, (List Token)))]
+        [Result ParseError (U8, (List Token))]
         toks
-        (Ok [ParseError] [(U8, (List Token))] ({U8, List Token | acc, toks}))
+        (Ok [ParseError] [(U8, (List Token))] {U8, List Token | acc, toks})
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              if [Result ParseError ((U8, (List Token)))] (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
+              if [Result ParseError (U8, (List Token))] (or (eqU8 tag pipeTag) (isTopLevelStartTag tag))
                 (
                   \u : U8 =>
                     Ok
                       [ParseError]
                       [(U8, (List Token))]
-                      ({U8, List Token | acc, toks})
+                      {U8, List Token | acc, toks}
                 )
                 (
                   \u : U8 =>
@@ -1893,37 +1874,33 @@ poly rec parseCtorArity =
 
 poly rec parseDataCtors =
   \toks : List Token =>
-    \acc : List (((List U8), U8)) =>
+    \acc : List ((List U8), U8) =>
       matchList
         [Token]
-        [Result ParseError (((List (((List U8), U8))), (List Token)))]
+        [Result ParseError ((List ((List U8), U8)), (List Token))]
         toks
         (
           Ok
             [ParseError]
-            [((List (((List U8), U8))), (List Token))]
-            (
-              {List (((List U8), U8)), List Token |
-                (reverse [((List U8), U8)] acc),
-                toks
-              }
-            )
+            [((List ((List U8), U8)), (List Token))]
+            {List ((List U8), U8), List Token |
+              (reverse [((List U8), U8)] acc),
+              toks
+            }
         )
         (
           \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
-              cond [Result ParseError (((List (((List U8), U8))), (List Token)))] {
+              cond [Result ParseError ((List ((List U8), U8)), (List Token))] {
                 | (isTopLevelStartTag tag) =>
                   Ok
                     [ParseError]
-                    [((List (((List U8), U8))), (List Token))]
-                    (
-                      {List (((List U8), U8)), List Token |
-                        (reverse [((List U8), U8)] acc),
-                        toks
-                      }
-                    )
+                    [((List ((List U8), U8)), (List Token))]
+                    {List ((List U8), U8), List Token |
+                      (reverse [((List U8), U8)] acc),
+                      toks
+                    }
                 | (eqU8 tag pipeTag) =>
                   match (expectIdent t) [Result ParseError (Pair (List (Pair (List U8) U8)) (List Token))] {
                     | Err e =>
@@ -1976,14 +1953,14 @@ poly rec parseDataCtors =
                 | otherwise =>
                   Err
                     [ParseError]
-                    [((List (((List U8), U8))), (List Token))]
+                    [((List ((List U8), U8)), (List Token))]
                     parseError
               }
         )
 
 poly parseModuleDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       modRes <- (expectIdent toks)
       name = fstNameToken modRes
       rest = sndNameToken modRes
@@ -1991,12 +1968,12 @@ poly parseModuleDecl =
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Module name), rest})
+        {Decl, List Token | (D_Module name), rest}
     }
 
 poly parseImportDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       modRes <- (expectIdent toks)
       modName = fstNameToken modRes
       afterMod = sndNameToken modRes
@@ -2007,12 +1984,12 @@ poly parseImportDecl =
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Import modName sym), rest})
+        {Decl, List Token | (D_Import modName sym), rest}
     }
 
 poly parseExportDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       expRes <- (expectIdent toks)
       name = fstNameToken expRes
       rest = sndNameToken expRes
@@ -2020,12 +1997,12 @@ poly parseExportDecl =
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Export name), rest})
+        {Decl, List Token | (D_Export name), rest}
     }
 
 poly parseOpaqueDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       afterType <- (expect toks kwTypeTag)
       opqRes <- (expectIdent afterType)
       name = fstNameToken opqRes
@@ -2034,7 +2011,7 @@ poly parseOpaqueDecl =
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Opaque name), afterName})
+        {Decl, List Token | (D_Opaque name), afterName}
     }
 
 poly parseNativeDecl =
@@ -2061,7 +2038,7 @@ poly parseNativeDecl =
 
 poly parseTypeDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       tyRes <- (expectIdent toks)
       name = fstNameToken tyRes
       afterName = sndNameToken tyRes
@@ -2070,37 +2047,37 @@ poly parseTypeDecl =
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Type name), rest})
+        {Decl, List Token | (D_Type name), rest}
     }
 
 poly parseDataDecl =
   \toks : List Token =>
-    do [Result ParseError ((Decl, (List Token)))] {
+    do [Result ParseError (Decl, (List Token))] {
       datRes <- (expectIdent toks)
       name = fstNameToken datRes
       afterName = sndNameToken datRes
       afterEq <- (skipAfter afterName eqTag)
-      ctorsRes <- (parseDataCtors afterEq ({Pair (List U8) U8 |}))
-      ctors = fst [List (((List U8), U8))] [List Token] ctorsRes
-      rest = snd [List (((List U8), U8))] [List Token] ctorsRes
+      ctorsRes <- (parseDataCtors afterEq {((List U8), U8) |})
+      ctors = fst [List ((List U8), U8)] [List Token] ctorsRes
+      rest = snd [List ((List U8), U8)] [List Token] ctorsRes
       return
         Ok
         [ParseError]
         [(Decl, (List Token))]
-        ({Decl, List Token | (D_Data name ctors), rest})
+        {Decl, List Token | (D_Data name ctors), rest}
     }
 
 poly parsePolyDecl =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError ((Decl, (List Token)))]
+      [Result ParseError (Decl, (List Token))]
       toks
       (Err [ParseError] [(Decl, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
-            if [Result ParseError ((Decl, (List Token)))] (eqU8 (tokenTag h) kwRecTag)
+            if [Result ParseError (Decl, (List Token))] (eqU8 (tokenTag h) kwRecTag)
               (\u : U8 => parseNamedDef K_Poly true t)
               (\u : U8 => parseNamedDef K_Poly false toks)
       )
@@ -2109,14 +2086,14 @@ poly parseDecl =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError ((Decl, (List Token)))]
+      [Result ParseError (Decl, (List Token))]
       toks
       (Err [ParseError] [(Decl, (List Token))] parseError)
       (
         \h : Token =>
           \t : List Token =>
             let tag = tokenTag h in
-            cond [Result ParseError ((Decl, (List Token)))] {
+            cond [Result ParseError (Decl, (List Token))] {
               | (eqU8 tag kwModuleTag) => parseModuleDecl t
               | (eqU8 tag kwImportTag) => parseImportDecl t
               | (eqU8 tag kwExportTag) => parseExportDecl t
@@ -2157,7 +2134,7 @@ poly rec parseProgramAcc =
         )
 
 poly parseProgram =
-  \toks : List Token => parseProgramAcc toks ({Decl |})
+  \toks : List Token => parseProgramAcc toks {Decl |}
 
 poly isUppercaseU8 =
   \c : U8 => and (ltU8 #u8(64) c) (ltU8 c #u8(91))
@@ -2218,7 +2195,7 @@ poly rec splitCondErrorAcc =
           [Token]
           [((List Token), (List Token))]
           toks
-          ({List Token, List Token | (reverse [Token] acc), (nil [Token])})
+          {List Token, List Token | (reverse [Token] acc), {Token |}}
           (
             \h : Token =>
               \t : List Token =>
@@ -2264,7 +2241,7 @@ poly rec splitPatternExprAcc =
           [Token]
           [((List Token), (List Token))]
           toks
-          ({List Token, List Token | (reverse [Token] acc), (nil [Token])})
+          {List Token, List Token | (reverse [Token] acc), {Token |}}
           (
             \h : Token =>
               \t : List Token =>
@@ -2337,7 +2314,7 @@ poly rec splitNextStepAcc =
           [Token]
           [((List Token), (List Token))]
           toks
-          ({List Token, List Token | (reverse [Token] acc), (nil [Token])})
+          {List Token, List Token | (reverse [Token] acc), {Token |}}
           (
             \h : Token =>
               \t : List Token =>
@@ -2430,7 +2407,7 @@ poly rec mapIdents =
       [Token]
       [List (List U8)]
       ts
-      ({List U8 |})
+      {List U8 |}
       (
         \h : Token =>
           \t : List Token => cons [List U8] (tokenText h) (mapIdents t)
@@ -2440,20 +2417,20 @@ poly parsePatternToks =
   \toks : List Token =>
     matchList
       [Token]
-      [Result ParseError (((List U8), (List (List U8))))]
+      [Result ParseError ((List U8), (List (List U8)))]
       toks
       (Err [ParseError] [((List U8), (List (List U8)))] parseError)
       (
         \h : Token =>
           \t : List Token =>
-            if [Result ParseError (((List U8), (List (List U8))))] (eqU8 (tokenTag h) identTag)
+            if [Result ParseError ((List U8), (List (List U8)))] (eqU8 (tokenTag h) identTag)
               (
                 \u : U8 =>
                   let ctor = tokenText h in
                   Ok
                     [ParseError]
                     [((List U8), (List (List U8)))]
-                    ({List U8, List (List U8) | ctor, (mapIdents t)})
+                    {List U8, List (List U8) | ctor, (mapIdents t)}
               )
               (
                 \u : U8 => Err [ParseError] [((List U8), (List (List U8)))] parseError
@@ -2471,7 +2448,7 @@ poly rec desugarDoLoop =
         (
           \h : DoStep =>
             \t : List DoStep =>
-              let nextTerm = match h [Expr] {| S_Bind name expr => E_Match expr {(Pattern, Expr) | ({Pattern, Expr | (P_Ctor "Err" {List U8 | "e"}), (E_App (E_Var "Err") (E_Var "e"))}) ({Pattern, Expr | (P_Ctor "Ok" {List U8 | name}), currentTerm})} | S_Match ctor params expr => E_Match expr {(Pattern, Expr) | ({Pattern, Expr | (P_Ctor ctor params), currentTerm})} | S_Let name expr => E_Let name expr currentTerm | S_Assert condVal err => E_App (E_App (E_App (E_Var "if") condVal) (E_Lam "u" currentTerm)) (E_Lam "u" (E_App (E_Var "Err") err)) | S_Return expr => E_Let "_" expr currentTerm | S_Expr expr => E_Let "_" expr currentTerm} in
+              let nextTerm = match h [Expr] {| S_Bind name expr => E_Match expr {(Pattern, Expr) | {Pattern, Expr | (P_Ctor "Err" {List U8 | "e"}), (E_App (E_Var "Err") (E_Var "e"))} {Pattern, Expr | (P_Ctor "Ok" {List U8 | name}), currentTerm}} | S_Match ctor params expr => E_Match expr {(Pattern, Expr) | {Pattern, Expr | (P_Ctor ctor params), currentTerm}} | S_Let name expr => E_Let name expr currentTerm | S_Assert condVal err => E_App (E_App (E_App (E_Var "if") condVal) (E_Lam "u" currentTerm)) (E_Lam "u" (E_App (E_Var "Err") err)) | S_Return expr => E_Let "_" expr currentTerm | S_Expr expr => E_Let "_" expr currentTerm} in
               desugarDoLoop t nextTerm
         )
 
@@ -2490,7 +2467,7 @@ poly desugarDo =
       )
 
 poly parseSingleStep =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       matchList
         [Token]
@@ -2503,7 +2480,7 @@ poly parseSingleStep =
               let tag = tokenTag h in
               cond [Result ParseError DoStep] {
                 | (and (eqU8 tag identTag) (eqListU8 (tokenText h) "assert")) =>
-                  let splitRes = splitCondErrorAcc t #u8(0) ({Token |}) in
+                  let splitRes = splitCondErrorAcc t #u8(0) {Token |} in
                   let condToks = fst [List Token] [List Token] splitRes in
                   let elseToks = snd [List Token] [List Token] splitRes in
                   match (expect elseToks identTag) [Result ParseError DoStep] {
@@ -2538,7 +2515,7 @@ poly parseSingleStep =
                     [Result ParseError DoStep]
                     t
                     (
-                      let splitRes = splitPatternExprAcc toks #u8(0) ({Token |}) in
+                      let splitRes = splitPatternExprAcc toks #u8(0) {Token |} in
                       let patToks = fst [List Token] [List Token] splitRes in
                       let exprToks = snd [List Token] [List Token] splitRes in
                       matchList
@@ -2627,7 +2604,7 @@ poly parseSingleStep =
                             )
                             (
                               \u : U8 =>
-                                let splitRes = splitPatternExprAcc toks #u8(0) ({Token |}) in
+                                let splitRes = splitPatternExprAcc toks #u8(0) {Token |} in
                                 let patToks = fst [List Token] [List Token] splitRes in
                                 let exprToks = snd [List Token] [List Token] splitRes in
                                 matchList
@@ -2710,29 +2687,29 @@ poly parseSingleStep =
         )
 
 poly rec parseDoStepsRec =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       \acc : List DoStep =>
         matchList
           [Token]
-          [Result ParseError (((List DoStep), (List Token)))]
+          [Result ParseError ((List DoStep), (List Token))]
           toks
           (Err [ParseError] [((List DoStep), (List Token))] parseError)
           (
             \h : Token =>
               \t : List Token =>
                 let tag = tokenTag h in
-                if [Result ParseError (((List DoStep), (List Token)))] (eqU8 tag rBraceTag)
+                if [Result ParseError ((List DoStep), (List Token))] (eqU8 tag rBraceTag)
                   (
                     \u : U8 =>
                       Ok
                         [ParseError]
                         [((List DoStep), (List Token))]
-                        ({List DoStep, List Token | acc, t})
+                        {List DoStep, List Token | acc, t}
                   )
                   (
                     \u : U8 =>
-                      let splitRes = splitNextStepAcc toks #u8(0) ({Token |}) in
+                      let splitRes = splitNextStepAcc toks #u8(0) {Token |} in
                       let stepToks = fst [List Token] [List Token] splitRes in
                       let remaining = snd [List Token] [List Token] splitRes in
                       match (parseSingleStep recurse stepToks) [Result ParseError DoStep] {
@@ -2748,7 +2725,7 @@ poly rec parseDoStepsRec =
           )
 
 poly parseDoWith =
-  \recurse : (List Token -> Result ParseError ((Expr, (List Token)))) =>
+  \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       match (skipTypeArg toks) [Result ParseError (List Token)] {
         | Err e => Err [ParseError] [(Expr, (List Token))] e

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/bootstrapParseLiterals.test.ts
+++ b/test/compiler/bootstrapParseLiterals.test.ts
@@ -113,13 +113,14 @@ poly main =
     (cons [List U8] (renderExprSrc "cons a (cons b nil)")
     (cons [List U8] (renderExprSrc "{U8, U8 | a, b}")
     (cons [List U8] (renderExprSrc "MkPair a b")
+    (cons [List U8] (renderExprSrc "{(U8, U8) | {U8, U8 | a, b}}")
     (cons [List U8] (renderExprSrc "{U8 | }")
     (cons [List U8] (renderExprSrc "{U8 | (f x) y}")
     (cons [List U8] (renderTypeSrc "(U8, U8)")
     (cons [List U8] (renderTypeSrc "Pair U8 U8")
     (cons [List U8] (renderTypeSrc "(U8)")
     (cons [List U8] (renderTypeSrc "(U8 -> U8)")
-    (nil [List U8])))))))))))
+    (nil [List U8]))))))))))))
 `;
 
 /** Decodes a Scott/ADT-encoded `List U8` MiniCore value to a byte array. */
@@ -165,6 +166,7 @@ describe("bootstrap parser list/tuple literals", () => {
       listDesugared,
       pairLiteral,
       pairDesugared,
+      barePairInList,
       emptyList,
       nestedList,
       tupleType,
@@ -180,6 +182,9 @@ describe("bootstrap parser list/tuple literals", () => {
     // Pair-term literal `{T1, T2 | a, b}` == `MkPair a b`.
     assert.equal(pairLiteral, "((MkPair a) b)");
     assert.equal(pairLiteral, pairDesugared);
+
+    // Pair literals can be list elements without extra parentheses.
+    assert.equal(barePairInList, "((cons ((MkPair a) b)) nil)");
 
     // Empty list desugars to bare `nil`.
     assert.equal(emptyList, "nil");


### PR DESCRIPTION
## Summary
- bump package version to 0.27.2
- run `improvize lint --fix` to convergence across `bootstrap/src`, then format the bootstrap corpus
- teach the bootstrap parser to accept bare pair literals inside list literals and cover that with a regression test

## Validation
- `pnpm exec node --disable-warning=ExperimentalWarning scripts/generate_version.mjs --package-json package.json --ts-out lib/shared/version.generated.ts --jsr-json jsr.json --verify`
- `git diff --check`
- `pnpm run build:ts`
- `pnpm exec node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js format --check bootstrap/src`
- parsed all 20 `bootstrap/src/**/*.trip` files through `parseTripLang`
- `TYPED_SKI_CLANG="C:\Program Files\LLVM\bin\clang.exe" pnpm exec node --disable-warning=ExperimentalWarning --test --enable-source-maps --experimental-test-module-mocks --test-global-setup ts_out/test/globalSetup.js --preserve-symlinks --preserve-symlinks-main ts_out/test/compiler/bootstrapParseLiterals.test.js ts_out/test/compiler/llvm/bundleV1.test.js`
- `TYPED_SKI_CLANG="C:\Program Files\LLVM\bin\clang.exe" pnpm test` (682 pass, 1 skipped: `TYPED_SKI_LLVM_AS` not configured)