### PR TITLE
feat(compiler): emit nullary constructors as their i8 tag in AnfLlvm

### DIFF
--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -180,7 +180,19 @@ poly atomOperand =
         | AE_Lam n b => Err [List U8] [List U8] "Unsupported atom: lambda"
         | AE_Call f args => Err [List U8] [List U8] "Unsupported atom: call"
         | AE_Con tag total arity args =>
-          Err [List U8] [List U8] "Unsupported atom: constructor"
+          matchList
+            [AnfExpr]
+            [Result (List U8) (List U8)]
+            args
+            (Ok [List U8] [List U8] (u8ToDigits tag))
+            (
+              \h : AnfExpr =>
+                \t : List AnfExpr =>
+                  Err
+                    [List U8]
+                    [List U8]
+                    "Unsupported atom: constructor with fields"
+            )
         | AE_Case scrut arms => Err [List U8] [List U8] "Unsupported atom: case"
         | AE_Let name val body => Err [List U8] [List U8] "Unsupported atom: let"
       }
@@ -679,7 +691,24 @@ poly rec emitExpr =
                       )
                 )
             | AE_Con tag total arity args =>
-              Err [List U8] [EmitRes] "Unsupported expression: constructor"
+              matchList
+                [AnfExpr]
+                [Result (List U8) EmitRes]
+                args
+                (
+                  Ok
+                    [List U8]
+                    [EmitRes]
+                    (MkEmitRes counter instrs (u8ToDigits tag))
+                )
+                (
+                  \h : AnfExpr =>
+                    \t : List AnfExpr =>
+                      Err
+                        [List U8]
+                        [EmitRes]
+                        "Unsupported expression: constructor with fields"
+                )
             | AE_Case scrut arms =>
               Err [List U8] [EmitRes] "Unsupported expression: case"
             | AE_Let name val body =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.3",
+  "version": "0.27.4",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/anfLlvmEmit.test.ts
+++ b/test/compiler/anfLlvmEmit.test.ts
@@ -2,10 +2,11 @@
  * Stage-0 verification of the .trip ANF -> LLVM emitter (anfLlvm.trip).
  *
  * Runs `AnfLlvm.compileSourceToLlvmText` under the TypeScript MiniCore
- * evaluator on a small straight-line `U8` corpus (params, let-bindings,
- * and direct known-symbol calls) and asserts the emitted LLVM text. This
- * is the minimal slice of the ANF->LLVM tail: no constructors, cases,
- * inner lambdas, or runtime primitives yet.
+ * evaluator on a small `U8` corpus (params, let-bindings, direct
+ * known-symbol calls, the read/write runtime primitives, and nullary
+ * constructors emitted as their i8 tag) and asserts the emitted LLVM
+ * text. Constructors with fields, cases, and inner lambdas are not yet
+ * supported by the emitter.
  */
 
 import { describe, it } from "../util/test_shim.ts";
@@ -266,6 +267,34 @@ define i8 @main(i8 %u) {
 entry:
   %__ll0 = call i8 @trip_read_one()
   ret i8 %__ll0
+}
+
+`,
+      ],
+      [
+        "nullary constructor emits its i8 tag (first arm = 0)",
+        `module Demo
+data Color = | Red | Green | Blue
+export main
+poly main = Red
+`,
+        `define i8 @main() {
+entry:
+  ret i8 0
+}
+
+`,
+      ],
+      [
+        "declaration order drives the tag (middle arm = 1)",
+        `module Demo
+data Color = | Red | Green | Blue
+export main
+poly main = Green
+`,
+        `define i8 @main() {
+entry:
+  ret i8 1
 }
 
 `,


### PR DESCRIPTION
The self-hosted AnfLlvm ANF->LLVM emitter now lowers a saturated nullary constructor (AE_Con with no fields) to its declaration-order i8 tag, in both emitExpr (tail position) and atomOperand (call operand), mirroring the existing T_Byte handling. Constructors with fields, AE_Case, and AE_Lam still error (now with sharper messages). Adds two MiniCore- evaluator tests asserting declaration-ordered tags (first arm = 0, middle arm = 1). Bumps patch to 0.27.4.