### PR TITLE
build: enable Bun for the fast local test feedback loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ Bazel setup does not expose a runfiles tree by default.
 
 ### Running a singular test
 
+Prefer [Bun](https://bun.sh) for local iteration when it is installed — it runs
+the TypeScript source directly with no build step, so the feedback loop is much
+faster:
+
+```bash
+bun test test/path/to/test.ts
+```
+
+Bun does not typecheck, and the native LLVM and dist/CLI tests still require
+Bazel, so tsgo and Bazel remain the authoritative path. `pnpm test:bun` runs the
+whole in-process suite this way.
+
 With Node directly:
 
 ```powershell

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,13 @@
+# Bun configuration.
+#
+# `bun test` is the fast local feedback loop: it runs the in-process test suite
+# directly from TypeScript source with no separate build step. The canonical /
+# full suite (including the native LLVM and dist-bundle tests that require clang
+# and built artifacts) still runs via Node + Bazel — see package.json `test`
+# and the BUILD.bazel test targets.
+
+[test]
+# Discover tests only under the source tree. Without an explicit root, a
+# positional filter such as `bun test parser` also matches the compiled
+# ts_out/test/** mirror by path substring, double-running stale .js output.
+root = "test"

--- a/lib/shared/workspaceRoot.ts
+++ b/lib/shared/workspaceRoot.ts
@@ -1,4 +1,5 @@
-import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __file = dirname(fileURLToPath(import.meta.url));
@@ -10,10 +11,30 @@ const __file = dirname(fileURLToPath(import.meta.url));
  *   1. TYPED_SKI_PROJECT_ROOT env var — set by scripts/bazel.ts before
  *      spawning the test child process, and by Bazel test rules. This is the
  *      authoritative value; no directory-level arithmetic needed in consumers.
- *   2. __dirname-relative fallback: this file compiles to
- *      ts_out/lib/shared/workspaceRoot.js, so three parent hops reach the
- *      repo root. The fallback is correct for direct `node ts_out/...`
- *      invocations that bypass scripts/bazel.ts.
+ *   2. Nearest ancestor directory that contains a package.json. This is
+ *      location-independent, so it resolves correctly whether this module runs
+ *      from source (lib/shared/workspaceRoot.ts, e.g. under `bun test`) or from
+ *      compiled output (ts_out/lib/shared/workspaceRoot.js, under
+ *      `node ts_out/...`). The previous fixed three-hop fallback assumed the
+ *      compiled depth and pointed one level above the repo when run from source.
+ *   3. __dirname-relative fallback (compiled layout: three parent hops) for the
+ *      degenerate case where no package.json is found while walking up.
  */
+function findPackageRoot(start: string): string | undefined {
+  let dir = start;
+  for (;;) {
+    if (existsSync(join(dir, "package.json"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
 export const workspaceRoot: string =
-  process.env["TYPED_SKI_PROJECT_ROOT"] ?? resolve(__file, "..", "..", "..");
+  process.env["TYPED_SKI_PROJECT_ROOT"] ??
+  findPackageRoot(__file) ??
+  resolve(__file, "..", "..", "..");

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dist": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/bazel.js dist",
     "typecheck": "node scripts/tsgo.mjs --noEmit",
     "test": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/bazel.js test",
+    "test:bun": "bun test test/parser test/types test/ski test/consts test/shared test/meta test/improvize test/minicore test/avlMiniCore.test.ts test/tripSourceLoader.test.ts",
     "bootstrap:format": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js format --write bootstrap/src",
     "bootstrap:lint": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js lint --fix bootstrap/src",
     "bootstrap:prune": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js prune bootstrap/src Compiler.main,MiniVerify.verifyToAnfText,BundleSummary.main,BundleParseSummary.main,BundleInventory.main,ModuleEnv.main,Llvm.compileSourceToLlvm,AnfLlvm.compileSourceToLlvmText,Llvm.compileBundleSummaryToLlvm"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.8",
+  "version": "0.27.9",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/llvm/tco.test.ts
+++ b/test/compiler/llvm/tco.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it } from "../../util/test_shim.ts";
 import { compileTripAndRun } from "./nativeHarness.ts";
 
 describe("LLVM Tail Call Optimization", () => {


### PR DESCRIPTION
Bun runs the in-process test suite directly from TypeScript source with no build step, ~10x faster than the node+tsgo path (which must emit all of bin+lib+scripts+test to ts_out/ before running). test/util/test_shim.ts already bridges node:test and bun:test; this makes `bun test` work end to end.

- lib/shared/workspaceRoot.ts: resolve the repo root by walking up to the nearest package.json instead of a fixed three-hop that assumed the compiled ts_out/ depth (it overshot one level above the repo when run from source). TYPED_SKI_PROJECT_ROOT stays authoritative; this also hardens the node-compiled fallback when the env var is unset.
- bunfig.toml: scope `bun test` discovery to test/ so a path filter does not also match the compiled ts_out/test mirror and double-run stale .js.
- test/compiler/llvm/tco.test.ts: import describe/it from the shim (the last node:test holdout) so the whole suite is runner-agnostic.
- package.json: add `test:bun` for the in-process dirs.

tsgo remains the typecheck authority (bun strips types); native LLVM and dist/CLI tests still run via Node + Bazel (they need clang and built artifacts). Bun reads pnpm's node_modules, so no installer change is needed locally.