### PR TITLE
feat: resolve local clang path from Bazel cache for tests

### DIFF
--- a/lib/shared/clangPath.ts
+++ b/lib/shared/clangPath.ts
@@ -36,7 +36,9 @@ export function findLocalClangPath(): string | null {
   }
 
   if (!outputBase) {
-    console.warn("findLocalClangPath: failed to run bazelisk/bazel info output_base");
+    console.warn(
+      "findLocalClangPath: failed to run bazelisk/bazel info output_base",
+    );
     return null;
   }
 

--- a/lib/shared/clangPath.ts
+++ b/lib/shared/clangPath.ts
@@ -1,0 +1,77 @@
+import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { workspaceRoot } from "./workspaceRoot.ts";
+
+/**
+ * Dynamically resolves the path to the Clang executable fetched by Bazel.
+ * If the environment variable TYPED_SKI_CLANG is set, that takes priority.
+ * Otherwise, queries Bazel for the output base, searches the external directory
+ * for the platform-appropriate LLVM/Clang archive, and returns the path to the
+ * executable if found.
+ */
+export function findLocalClangPath(): string | null {
+  if (process.env["TYPED_SKI_CLANG"]) {
+    return process.env["TYPED_SKI_CLANG"];
+  }
+
+  let outputBase = "";
+  const suffix = process.platform === "win32" ? ".exe" : "";
+  const candidates = [`bazelisk${suffix}`, `bazel${suffix}`];
+
+  for (const bin of candidates) {
+    try {
+      outputBase = execSync(`${bin} info output_base`, {
+        cwd: workspaceRoot,
+        stdio: ["ignore", "pipe", "ignore"],
+        encoding: "utf8",
+        timeout: 5000,
+      }).trim();
+      if (outputBase) {
+        break;
+      }
+    } catch {
+      // Try next binary candidate
+    }
+  }
+
+  if (!outputBase) {
+    console.warn("findLocalClangPath: failed to run bazelisk/bazel info output_base");
+    return null;
+  }
+
+  const externalDir = path.join(outputBase, "external");
+  if (!fs.existsSync(externalDir)) {
+    return null;
+  }
+
+  let targetPattern = "";
+  let binaryName = "";
+  if (process.platform === "win32") {
+    targetPattern = "typed_ski_llvm_windows_x64";
+    binaryName = "clang.exe";
+  } else if (process.platform === "darwin") {
+    targetPattern = "typed_ski_llvm_macos_arm64";
+    binaryName = "clang";
+  } else {
+    targetPattern = "typed_ski_llvm_linux_x64";
+    binaryName = "clang";
+  }
+
+  try {
+    const entries = fs.readdirSync(externalDir);
+    for (const entry of entries) {
+      if (entry.includes(targetPattern)) {
+        const candidateDir = path.join(externalDir, entry);
+        const clangPath = path.join(candidateDir, "bin", binaryName);
+        if (fs.existsSync(clangPath)) {
+          return clangPath;
+        }
+      }
+    }
+  } catch (e) {
+    console.warn("findLocalClangPath: error reading external dir", e);
+  }
+
+  return null;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.9",
+  "version": "0.27.10",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/scripts/bazel.ts
+++ b/scripts/bazel.ts
@@ -8,6 +8,7 @@ import * as fsp from "node:fs/promises";
 import * as process from "node:process";
 import { spawn, spawnSync } from "node:child_process";
 import { availableParallelism } from "node:os";
+import { findLocalClangPath } from "../lib/shared/clangPath.ts";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // JS_ROOT: directory containing compiled .js outputs (one level up from scripts/)
@@ -650,6 +651,11 @@ async function prepareTestExecution(
     // count directory levels relative to their own compiled location.
     TYPED_SKI_PROJECT_ROOT: PROJECT_ROOT,
   };
+
+  const clangPath = findLocalClangPath();
+  if (clangPath) {
+    env.TYPED_SKI_CLANG = clangPath;
+  }
 
   if (process.env["TEST_SRCDIR"] && process.env["TEST_WORKSPACE"]) {
     const nodeOptions = [

--- a/test/compiler/anfLlvmEmit.test.ts
+++ b/test/compiler/anfLlvmEmit.test.ts
@@ -16,11 +16,12 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { compilerTripModuleSourcePath } from "../../lib/compiler/bootstrapModules.ts";
+import { findLocalClangPath } from "../../lib/shared/clangPath.ts";
 import { compileMiniCoreModules } from "../../lib/minicore/fromTrip.ts";
 import { evaluateMiniCore } from "../../lib/minicore/evaluator.ts";
 import type { Value } from "../../lib/minicore/ast.ts";
 
-const CLANG = process.env["TYPED_SKI_CLANG"];
+const CLANG = process.env["TYPED_SKI_CLANG"] ?? findLocalClangPath();
 
 /**
  * Assembles `llvm` with clang (`-x ir -c`) and asserts it is structurally

--- a/test/compiler/llvm/nativeHarness.ts
+++ b/test/compiler/llvm/nativeHarness.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { workspaceRoot } from "../../../lib/shared/workspaceRoot.ts";
+import { findLocalClangPath } from "../../../lib/shared/clangPath.ts";
 import {
   compilerTripModuleSourcePath,
   isKnownCompilerTripModule,
@@ -27,7 +28,7 @@ export interface HarnessOptions extends CompileTripSourceToLlvmOptions {
   stdin?: string | Uint8Array;
 }
 
-const CLANG = process.env["TYPED_SKI_CLANG"];
+const CLANG = process.env["TYPED_SKI_CLANG"] ?? findLocalClangPath();
 
 function macosSdkArgs(): string[] {
   if (process.platform !== "darwin") {


### PR DESCRIPTION
Resolves local test failures on Windows, macOS, and Linux when \TYPED_SKI_CLANG\ is unset in the environment but Bazel fetches are complete (making the downloaded compiler toolchain archives available in the output base).

### Changes
- **New helper utility**: Added \lib/shared/clangPath.ts\ which:
  - Queries Bazel's \output_base\ using \azelisk\ / \azel\.
  - Searches the \external\ cache directory for the platform-appropriate LLVM package (\	yped_ski_llvm_windows_x64\, \	yped_ski_llvm_macos_arm64\, or \	yped_ski_llvm_linux_x64\).
  - Scans for the exact \clang\ or \clang.exe\ executable inside the Bazel directory.
  - Safe and non-intrusive: gracefully returns \
ull\ via catch blocks if Bazel is not present or LLVM is not downloaded yet.
- **CLI Test Wrapper integration**: Updated \scripts/bazel.ts\ to automatically detect the path and inject it as \TYPED_SKI_CLANG\ when setting up local test executions.
- **Harness Fallbacks**: Updated \	est/compiler/llvm/nativeHarness.ts\ and \	est/compiler/anfLlvmEmit.test.ts\ to fall back to \indLocalClangPath()\ when \process.env.TYPED_SKI_CLANG\ is unset.