### PR TITLE
fix(bootstrap): module-scope the export ambiguity check in ModuleEnv

### DIFF
--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -44,6 +44,8 @@ import Prelude if
 
 import Prelude or
 
+import Prelude and
+
 import Prelude not
 
 import Prelude U8
@@ -980,6 +982,45 @@ poly exportStatus =
               | otherwise => "EXPORT_UNDEFINED"
             }
 
+poly rec countModuleExportOrigins =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \exports : List ExportInfo =>
+        \acc : U8 =>
+          matchList
+            [ExportInfo]
+            [U8]
+            exports
+            acc
+            (
+              \h : ExportInfo =>
+                \t : List ExportInfo =>
+                  do [U8] {
+                    MkExportInfo hModule hSymbol = h
+                    return
+                    if [U8] (and (eqListU8 hModule moduleName) (eqListU8 hSymbol symbolName))
+                      (
+                        \u : U8 => countModuleExportOrigins moduleName symbolName t (inc acc)
+                      )
+                      (
+                        \u : U8 => countModuleExportOrigins moduleName symbolName t acc
+                      )
+                  }
+            )
+
+poly compileExportStatus =
+  \moduleName : List U8 =>
+    \symbolName : List U8 =>
+      \exports : List ExportInfo =>
+        \defs : List DefinitionInfo =>
+          \ctors : List ConstructorMeta =>
+            let origins = countModuleExportOrigins moduleName symbolName exports #u8(0) in
+            cond [List U8] {
+              | (ltU8 #u8(1) origins) => "AMBIGUOUS"
+              | (or (isDefined moduleName symbolName defs) (isConstructorDefined moduleName symbolName ctors)) => "OK"
+              | otherwise => "EXPORT_UNDEFINED"
+            }
+
 poly rec emitModuleImportsAcc =
   \moduleName : List U8 =>
     \imports : List ImportInfo =>
@@ -1600,7 +1641,7 @@ poly rec validateExports =
               \t : List ExportInfo =>
                 do [Result (List U8) Bool] {
                   MkExportInfo hModule hSymbol = h
-                  status = exportStatus hModule hSymbol exps defs ctors
+                  status = compileExportStatus hModule hSymbol exps defs ctors
                   return
                   if [Result (List U8) Bool] (eqListU8 status "OK")
                     (\u : U8 => validateExports t defs ctors)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.27.16",
+  "version": "0.27.17",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/bootstrapExportValidation.test.ts
+++ b/test/compiler/bootstrapExportValidation.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Exercises the bootstrap (.trip) front-half export validation
+ * (`ModuleEnv.buildModuleEnv` + `ModuleEnv.validateExports`) through the host
+ * MiniCore evaluator (no clang, runs under bun).
+ *
+ * Regression for the "global flat export namespace" bug: the compile-gate
+ * ambiguity check used to count export origins by symbol NAME across all
+ * modules, so a bundle in which two modules each `export main` (which the whole
+ * bootstrap corpus does) was rejected as AMBIGUOUS — blocking the compiler from
+ * ever ingesting its own source. The check is now module-scoped: an export is
+ * ambiguous only if the SAME module exports the SAME symbol more than once.
+ *
+ * A small `Verify` module builds tiny in-memory bundles from source text,
+ * runs the real `buildModuleEnv` + `validateExports`, and renders the outcome.
+ */
+
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { compilerTripModuleSourcePath } from "../../lib/compiler/bootstrapModules.ts";
+import { compileMiniCoreModules } from "../../lib/minicore/fromTrip.ts";
+import { evaluateMiniCore } from "../../lib/minicore/evaluator.ts";
+import type { Value } from "../../lib/minicore/ast.ts";
+
+const MODULE_NAMES = [
+  "Prelude",
+  "Nat",
+  "Bin",
+  "Lexer",
+  "Parser",
+  "BundleSummary",
+  "ModuleEnv",
+] as const;
+
+const VERIFY_SOURCE = `module Verify
+
+import Prelude List
+import Prelude U8
+import Prelude append
+import Prelude Result
+import Prelude Ok
+import Prelude Err
+import Prelude Bool
+import Prelude nil
+import Prelude cons
+import BundleSummary ModuleRecord
+import BundleSummary MkModuleRecord
+import ModuleEnv ModuleEnv
+import ModuleEnv MkModuleEnv
+import ModuleEnv buildModuleEnv
+import ModuleEnv validateExports
+
+export main
+
+poly nl = cons [U8] #u8(10) (nil [U8])
+
+poly mkRec = \\name : List U8 => \\src : List U8 => MkModuleRecord name "" src
+
+poly renderExports = \\mEnv : ModuleEnv =>
+  do [List U8] {
+    MkModuleEnv mods imps exps defs dataTypes ctors aliases opaques natives primitives = mEnv
+    return
+    match (validateExports exps defs ctors) [List U8] {
+      | Err e => append [U8] "ERR:" e
+      | Ok b => "OK"
+    }
+  }
+
+poly checkBundle = \\mods : List ModuleRecord =>
+  match (buildModuleEnv mods) [List U8] {
+    | Err e => append [U8] "BUILDERR:" e
+    | Ok mEnv => renderExports mEnv
+  }
+
+poly twoMains =
+  checkBundle
+    (cons [ModuleRecord] (mkRec "A" "module A\\nexport main\\npoly main : U8 = #u8(7)\\n")
+    (cons [ModuleRecord] (mkRec "B" "module B\\nexport main\\npoly main : U8 = #u8(9)\\n")
+    (nil [ModuleRecord])))
+
+poly undefinedExport =
+  checkBundle
+    (cons [ModuleRecord] (mkRec "C" "module C\\nexport ghost\\npoly main : U8 = #u8(1)\\n")
+    (nil [ModuleRecord]))
+
+poly dupExport =
+  checkBundle
+    (cons [ModuleRecord] (mkRec "D" "module D\\nexport main\\nexport main\\npoly main : U8 = #u8(2)\\n")
+    (nil [ModuleRecord]))
+
+poly main =
+  append [U8] twoMains
+    (append [U8] nl
+      (append [U8] undefinedExport
+        (append [U8] nl dupExport)))
+`;
+
+/** Decodes a Scott/ADT-encoded `List U8` MiniCore value to a byte array. */
+function valueToBytes(value: Value): number[] {
+  const bytes: number[] = [];
+  let cur: Value = value;
+  while (cur.kind === "con" && cur.fields.length === 2) {
+    const head = cur.fields[0];
+    const tail = cur.fields[1];
+    if (head === undefined || tail === undefined || head.kind !== "lit") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    const literal = head.value;
+    if (literal.kind !== "u8") {
+      throw new Error(`expected u8 list head, got ${JSON.stringify(head)}`);
+    }
+    bytes.push(literal.value);
+    cur = tail;
+  }
+  if (cur.kind !== "con" || cur.fields.length !== 0) {
+    throw new Error(`expected nil terminator, got ${JSON.stringify(cur)}`);
+  }
+  return bytes;
+}
+
+describe("bootstrap front-half export validation", () => {
+  it("accepts multiple modules each exporting `main`, still rejects undefined and same-module duplicate exports", async () => {
+    const modules: Array<{ name: string; source: string }> = await Promise.all(
+      MODULE_NAMES.map(async (name) => ({
+        name,
+        source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+      })),
+    );
+    modules.push({ name: "Verify", source: VERIFY_SOURCE });
+
+    const program = compileMiniCoreModules(modules, "Verify");
+    const result = evaluateMiniCore(program);
+    const text = Buffer.from(valueToBytes(result.value)).toString("utf8");
+    const [twoMains, undefinedExport, dupExport] = text.split("\n");
+
+    // The fix: two modules each exporting `main` is no longer ambiguous.
+    assert.equal(twoMains, "OK");
+
+    // Guard against over-loosening: a symbol exported but not defined in its
+    // module is still rejected.
+    assert.match(undefinedExport ?? "", /EXPORT_UNDEFINED/);
+    assert.match(undefinedExport ?? "", /module C, export ghost/);
+
+    // The ambiguity check is preserved in its correct, module-scoped form: a
+    // single module exporting the same symbol twice is still AMBIGUOUS.
+    assert.match(dupExport ?? "", /AMBIGUOUS/);
+    assert.match(dupExport ?? "", /module D, export main/);
+  });
+});


### PR DESCRIPTION
## What

The self-hosted compile gate `ModuleEnv.validateExports` rejected any symbol exported by more than one module as `AMBIGUOUS`. The bootstrap corpus has ≥5 modules that each `export main` (`BundleSummary`, `BundleParseSummary`, `BundleInventory`, `ModuleEnv`, `Compiler`), so the self-hosted compiler could not ingest its own source as a bundle — it failed with `Export error: in module BundleInventory, export main is AMBIGUOUS` before reaching elaboration.

## Root cause

`validateExports` (the compile gate) reused `exportStatus` / `countExportOrigins`, which were written for the **BundleInventory diagnostic**: they count export origins by symbol *name* across all modules (a faithful port of the host inventory tool, [`lib/compiler/bundleV1.ts:391`](../blob/main/lib/compiler/bundleV1.ts)). As an inventory report, "this name is exported by N modules" is legitimate information. As a *compile gate* it is wrong — `BundleInventory.main` and `Compiler.main` are distinct, unambiguous exports.

The host's actual compile path, `lib/minicore/fromTrip.ts:sortModulesAndValidate`, has **no** by-name ambiguity gate at all; it only checks that each import resolves to a symbol its target module exports. That is why the host compiles the multi-`main` corpus fine, while the self-hosted gate did not.

## Fix

Give the compile gate its own module-scoped check, leaving the inventory logic untouched:

- `countModuleExportOrigins` — counts origins matching both module **and** symbol
- `compileExportStatus` — `AMBIGUOUS` only if the **same module** exports the **same symbol** more than once

`validateExports` now calls `compileExportStatus`. The inventory emitter's `exportStatus` / `countExportOrigins` are unchanged, so `bundle-inventory-v1` output is identical.

## Payoff

Feeding the full compiler corpus to the stage-0 native compiler, the self-compile error advances several stages deeper into the pipeline:

```
before:  ERR:Export error: in module BundleInventory, export main is AMBIGUOUS
after:   ERR:Could not identify ADT for match     # now in Bridge elaboration
```

This unblocks the front-half export gate. The remaining self-host walls (elaboration ADT resolution → MiniCore escaping-lambda → AnfLlvm closures) are out of scope for this PR.

## Testing

New `test/compiler/bootstrapExportValidation.test.ts` drives the real `buildModuleEnv` + `validateExports` chain through the host MiniCore evaluator (no clang; runs under both `node --test` and `bun test`):

- two modules each exporting `main` → `OK` (the fix)
- a symbol exported but not defined in its module → still `EXPORT_UNDEFINED`
- a module exporting the same symbol twice → still `AMBIGUOUS`

The test was verified to fail (red) against the pre-fix code, so it genuinely guards the regression. No regressions elsewhere: the happy-path stage-1 self-host test still passes (clang), and the front-half bun/node tests are green.
