### PR TITLE
fix: rename bootstrap script to bootstrap:normalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ are an in-progress re-implementation of the compiler in TripLang itself.
 They are not currently part of the main build. The active acceptance path
 is the LLVM self-hosting test: TypeScript compiles the Trip compiler to a
 native executable, then that executable reads `bundle-v1` and emits LLVM IR
-for a stage-1 Trip program.
+for a stage-1 Trip program. The native compiler does not yet recompile its
+own bundle, so there is no stage-2 / IR-fixpoint self-reproduction check.
 
 This is targeting LLVM IR self-hosting, not in-language object emission or
 linking. Parser bootstrap progress is measured through the `bundle-v1`
@@ -271,7 +272,7 @@ To lint, format, or prune the bootstrap corpus files under `bootstrap/src/`, the
 - `pnpm run bootstrap:format` — Format all `.trip` files in `bootstrap/src/`
 - `pnpm run bootstrap:lint` — Lint all `.trip` files in `bootstrap/src/` and apply safe automatic fixes
 - `pnpm run bootstrap:prune` — Prune unreachable definitions and imports in `bootstrap/src/`, keeping only the transitively referenced code starting from the entry points of the test suite (e.g., `Compiler.main`, `MiniVerify.verifyToAnfText`, etc.)
-- `pnpm run bootstrap` — Run prune → lint → format (in that order) followed by verification that the corpus is clean (equivalent to the three commands above plus `format --check` + `lint`)
+- `pnpm run bootstrap:normalize` — Run prune → lint → format (in that order) followed by verification that the corpus is clean (equivalent to the three commands above plus `format --check` + `lint`)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "license": "MIT",
   "type": "module",
   "exports": {
@@ -45,7 +45,7 @@
     "bootstrap:format": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js format --write bootstrap/src",
     "bootstrap:lint": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js lint --fix bootstrap/src",
     "bootstrap:prune": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/bin/improvize.js prune bootstrap/src Compiler.main,MiniVerify.verifyToAnfText,BundleSummary.main,BundleParseSummary.main,BundleInventory.main,ModuleEnv.main,Llvm.compileSourceToLlvm,AnfLlvm.compileSourceToLlvmText,Llvm.compileBundleSummaryToLlvm",
-    "bootstrap": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/bootstrap.js",
+    "bootstrap:normalize": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/bootstrapNormalize.js",
     "update:goldens": "pnpm run build:ts && node --disable-warning=ExperimentalWarning ts_out/scripts/update_goldens.js"
   },
   "dependencies": {

--- a/scripts/bootstrapNormalize.ts
+++ b/scripts/bootstrapNormalize.ts
@@ -20,7 +20,7 @@
  * and do not cause the script to fail or modify anything further).
  *
  * Run via:
- *   pnpm run bootstrap
+ *   pnpm run bootstrap:normalize
  *
  * (The pnpm wrapper does a fresh build:ts first.)
  *
@@ -33,7 +33,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-// When executed from ts_out/scripts/bootstrap.js, __dirname is .../ts_out/scripts
+// When executed from ts_out/scripts/bootstrapNormalize.js, __dirname is .../ts_out/scripts
 // Project root is two levels up.
 const PROJECT_ROOT = join(__dirname, "..", "..");
 
@@ -124,7 +124,7 @@ function verifyClean(): void {
 
 function main(): void {
   console.log(
-    "Running improvize bootstrap maintenance (prune → lint → fmt) + verification...",
+    "Running bootstrap-corpus normalization (prune → lint → fmt) + verification...",
   );
 
   runImprovize(["prune", BOOTSTRAP_SRC, PRUNE_ENTRY_POINTS]);


### PR DESCRIPTION
The bootstrap npm script is a source-normalization pass over bootstrap/src/ (prune -> lint -> format + format-check), not the self-hosting/fixpoint bootstrap it shared a name with. Rename it to bootstrap:normalize so it joins the bootstrap:format / :lint / :prune family and no longer collides with the self-host milestone. Drop the now-redundant disambiguation comments, and note in README section 4 that the self-host test does not yet recompile the compiler's own bundle (no stage-2 / IR fixpoint check).

Patch bump 0.28.0 -> 0.28.1.