### PR TITLE
feat: implement polarized types

### DIFF
--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -66,6 +66,10 @@ import Parser E_Nat
 
 import Parser E_Match
 
+import Parser E_Thunk
+
+import Parser E_Force
+
 import Parser Pattern
 
 import Parser P_Ctor
@@ -614,6 +618,16 @@ poly rec elaborateExpr =
           }
         | E_Nat digits => natToCore digits
         | E_Match scrut arms => elaborateMatchWith elaborateExpr dEnv scrut arms
+        | E_Thunk body =>
+          Err
+            [List U8]
+            [Core]
+            "Thunk expressions are not supported in the bootstrap compiler"
+        | E_Force body =>
+          Err
+            [List U8]
+            [Core]
+            "Force expressions are not supported in the bootstrap compiler"
       }
 
 poly ctorCountOverflowError =

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -78,6 +78,10 @@ import Parser E_Nat
 
 import Parser E_Match
 
+import Parser E_Thunk
+
+import Parser E_Force
+
 import Parser Pattern
 
 import Parser P_Ctor
@@ -339,6 +343,16 @@ poly rec qualifyExpr =
                   qScrut <- (qualifyExpr bound mEnv moduleName scrut)
                   qArms <- (qualifyArms bound mEnv moduleName arms)
                   return Ok [List U8] [Expr] (E_Match qScrut qArms)
+                }
+              | E_Thunk body =>
+                do [Result (List U8) Expr] {
+                  qBody <- (qualifyExpr bound mEnv moduleName body)
+                  return Ok [List U8] [Expr] (E_Thunk qBody)
+                }
+              | E_Force body =>
+                do [Result (List U8) Expr] {
+                  qBody <- (qualifyExpr bound mEnv moduleName body)
+                  return Ok [List U8] [Expr] (E_Force qBody)
                 }
             }
           }
@@ -604,6 +618,8 @@ poly rec collectRefsExpr =
             [List U8]
             (collectRefsExpr defNames scrut)
             (collectRefsArms defNames arms)
+        | E_Thunk body => collectRefsExpr defNames body
+        | E_Force body => collectRefsExpr defNames body
       }
 
 poly rec collectRefsArms =

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -122,6 +122,12 @@ export T_KwDo
 
 export T_LArrow
 
+export T_ThunkOpen
+
+export T_ThunkClose
+
+export T_Force
+
 export T_Tagged
 
 export T_Ident
@@ -260,6 +266,15 @@ poly T_KwDo : Token =
 poly T_LArrow : Token =
   T_Tagged #u8(34)
 
+poly T_ThunkOpen : Token =
+  T_Tagged #u8(38)
+
+poly T_ThunkClose : Token =
+  T_Tagged #u8(39)
+
+poly T_Force : Token =
+  T_Tagged #u8(40)
+
 poly T_EOF : Token =
   T_Tagged #u8(31)
 
@@ -278,11 +293,29 @@ poly tokenTaggedTextDo =
       (\u : U8 => "do")
       (\u : U8 => "")
 
+poly tokenTaggedTextForce =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(40))
+      (\u : U8 => "*!")
+      (\u : U8 => tokenTaggedTextDo tag)
+
+poly tokenTaggedTextThunkClose =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(39))
+      (\u : U8 => "*]")
+      (\u : U8 => tokenTaggedTextForce tag)
+
+poly tokenTaggedTextThunkOpen =
+  \tag : U8 =>
+    if [List U8] (eqU8 tag #u8(38))
+      (\u : U8 => "[*")
+      (\u : U8 => tokenTaggedTextThunkClose tag)
+
 poly tokenTaggedTextLArrow =
   \tag : U8 =>
     if [List U8] (eqU8 tag #u8(34))
       (\u : U8 => "<-")
-      (\u : U8 => tokenTaggedTextDo tag)
+      (\u : U8 => tokenTaggedTextThunkOpen tag)
 
 poly tokenTaggedTextData =
   \tag : U8 =>
@@ -815,6 +848,21 @@ poly rec tokenizeAcc =
                     eqU8
                       u8_gt
                       h))) => let rest = tail [U8] cs in tokenizeAcc rest (cons [Token] T_FatArrow accRev)
+                | (and (eqU8 c '[') (matchList [U8] [Bool] cs false (\h : U8 =>
+                  \t : List U8 =>
+                    eqU8
+                      '*'
+                      h))) => let rest = tail [U8] cs in tokenizeAcc rest (cons [Token] T_ThunkOpen accRev)
+                | (and (eqU8 c '*') (matchList [U8] [Bool] cs false (\h : U8 =>
+                  \t : List U8 =>
+                    eqU8
+                      ']'
+                      h))) => let rest = tail [U8] cs in tokenizeAcc rest (cons [Token] T_ThunkClose accRev)
+                | (and (eqU8 c '*') (matchList [U8] [Bool] cs false (\h : U8 =>
+                  \t : List U8 =>
+                    eqU8
+                      '!'
+                      h))) => let rest = tail [U8] cs in tokenizeAcc rest (cons [Token] T_Force accRev)
                 | otherwise =>
                   match (simpleTokenFromU8 c) [Result ParseError (List Token)] {
                     | None =>

--- a/bootstrap/src/llvm.trip
+++ b/bootstrap/src/llvm.trip
@@ -82,6 +82,10 @@ import Parser E_Nat
 
 import Parser E_Match
 
+import Parser E_Thunk
+
+import Parser E_Force
+
 import BundleSummary BundleSummary
 
 import BundleSummary MkBundleSummary
@@ -171,6 +175,8 @@ poly rec collectWriteBytes =
         Err [List U8] [List U8] "Unsupported LLVM expression"
       | E_Lam name body => collectWriteBytes body
       | E_Let name value body => collectWriteBytes body
+      | E_Thunk body => collectWriteBytes body
+      | E_Force body => collectWriteBytes body
       | E_Match scrutinee arms =>
         Err [List U8] [List U8] "Unsupported LLVM expression"
       | E_App fn cont =>
@@ -218,12 +224,24 @@ poly rec collectWriteBytes =
                                 [List U8]
                                 [List U8]
                                 "Expected writeOne continuation"
+                            | E_Thunk body =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
+                            | E_Force body =>
+                              Err
+                                [List U8]
+                                [List U8]
+                                "Expected writeOne continuation"
                           }
                         | E_Var name => Err [List U8] [List U8] "Expected literal byte"
                         | E_App a b => Err [List U8] [List U8] "Expected literal byte"
                         | E_Lam name body => Err [List U8] [List U8] "Expected literal byte"
                         | E_Let name value body => Err [List U8] [List U8] "Expected literal byte"
                         | E_Match scrutinee arms => Err [List U8] [List U8] "Expected literal byte"
+                        | E_Thunk body => Err [List U8] [List U8] "Expected literal byte"
+                        | E_Force body => Err [List U8] [List U8] "Expected literal byte"
                       }
                   )
                   (
@@ -239,6 +257,10 @@ poly rec collectWriteBytes =
                 Err [List U8] [List U8] "Unsupported LLVM expression"
               | E_Match scrutinee arms =>
                 Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Thunk body =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
+              | E_Force body =>
+                Err [List U8] [List U8] "Unsupported LLVM expression"
             }
           | E_Var name =>
             Err [List U8] [List U8] "Unsupported LLVM expression"
@@ -249,6 +271,10 @@ poly rec collectWriteBytes =
           | E_Nat digits =>
             Err [List U8] [List U8] "Unsupported LLVM expression"
           | E_Match scrutinee arms =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Thunk body =>
+            Err [List U8] [List U8] "Unsupported LLVM expression"
+          | E_Force body =>
             Err [List U8] [List U8] "Unsupported LLVM expression"
         }
     }
@@ -618,6 +644,10 @@ poly emitFunctionBody =
                 | E_Lam arg inner =>
                   Err [List U8] [EmitState] "Unsupported LLVM expression"
                 | E_Let letName value inner =>
+                  Err [List U8] [EmitState] "Unsupported LLVM expression"
+                | E_Thunk body =>
+                  Err [List U8] [EmitState] "Unsupported LLVM expression"
+                | E_Force body =>
                   Err [List U8] [EmitState] "Unsupported LLVM expression"
                 | E_Match scrutinee arms =>
                   Err [List U8] [EmitState] "Unsupported LLVM expression"

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -126,6 +126,12 @@ import Lexer T_KwDo
 
 import Lexer T_LArrow
 
+import Lexer T_ThunkOpen
+
+import Lexer T_ThunkClose
+
+import Lexer T_Force
+
 import Lexer T_Tagged
 
 import Lexer T_Ident
@@ -153,6 +159,10 @@ export E_Let
 export E_Nat
 
 export E_Match
+
+export E_Thunk
+
+export E_Force
 
 export DefKind
 
@@ -256,6 +266,12 @@ export kwDoTag
 
 export lArrowTag
 
+export thunkOpenTag
+
+export thunkCloseTag
+
+export forceTag
+
 export fstNameToken
 
 export sndNameToken
@@ -330,6 +346,8 @@ export Ty_Arrow
 
 export Ty_Forall
 
+export Ty_Thunk
+
 export parseSimpleType
 
 export parseType
@@ -341,6 +359,7 @@ data Type =
   | Ty_App Type Type
   | Ty_Arrow Type Type
   | Ty_Forall (List U8) Type
+  | Ty_Thunk Type
 
 data Pattern =
   | P_Ctor (List U8) (List (List U8))
@@ -360,6 +379,8 @@ data Expr =
   | E_Let (List U8) Expr Expr
   | E_Nat (List U8)
   | E_Match Expr (List (Pair Pattern Expr))
+  | E_Thunk Expr
+  | E_Force Expr
 
 data DefKind =
   | K_Poly
@@ -494,6 +515,15 @@ poly kwDoTag =
 
 poly lArrowTag =
   tokenTag T_LArrow
+
+poly thunkOpenTag =
+  tokenTag T_ThunkOpen
+
+poly thunkCloseTag =
+  tokenTag T_ThunkClose
+
+poly forceTag =
+  tokenTag T_Force
 
 poly fstTypeToken =
   \p : (Type, (List Token)) => fst [Type] [List Token] p
@@ -723,6 +753,8 @@ poly isAtomStartTag =
       | (eqU8 tag commaTag) => true
       | (eqU8 tag dotTag) => true
       | (eqU8 tag hashTag) => true
+      | (eqU8 tag thunkOpenTag) => true
+      | (eqU8 tag forceTag) => true
       | otherwise => eqU8 tag lBraceTag
     }
 
@@ -979,6 +1011,8 @@ poly rec exprListMentionsName =
                         (append [Expr] {Expr | value body} rest)
                     )
                 | E_Nat n => exprListMentionsName name rest
+                | E_Thunk body => exprListMentionsName name (cons [Expr] body rest)
+                | E_Force body => exprListMentionsName name (cons [Expr] body rest)
                 | E_Match scrutinee arms =>
                   exprListMentionsName
                     name
@@ -1021,6 +1055,8 @@ poly isOtherwiseExpr =
       | E_Lam name body => false
       | E_Let name value body => false
       | E_Nat n => false
+      | E_Thunk body => false
+      | E_Force body => false
       | E_Match scrutinee arms => false
     }
 
@@ -1139,6 +1175,29 @@ poly parseAtomWith =
               let tag = tokenTag h in
               cond [Result ParseError (Expr, (List Token))] {
                 | (eqU8 tag kwCondTag) => parseCondWith recurse t
+                | (eqU8 tag thunkOpenTag) =>
+                  do [Result ParseError (Expr, (List Token))] {
+                    res <- (recurse t)
+                    inner = fstExprToken res
+                    rest = sndExprToken res
+                    final <- (expect rest thunkCloseTag)
+                    return
+                      Ok
+                      [ParseError]
+                      [(Expr, (List Token))]
+                      {Expr, List Token | (E_Thunk inner), final}
+                  }
+                | (eqU8 tag forceTag) =>
+                  do [Result ParseError (Expr, (List Token))] {
+                    res <- (parseAtomWith recurse t)
+                    inner = fstExprToken res
+                    rest = sndExprToken res
+                    return
+                      Ok
+                      [ParseError]
+                      [(Expr, (List Token))]
+                      {Expr, List Token | (E_Force inner), rest}
+                  }
                 | (eqU8 tag identTag) =>
                   Ok
                     [ParseError]
@@ -1240,6 +1299,18 @@ poly parseSimpleTypeWith =
             \t : List Token =>
               let tag = tokenTag h in
               cond [Result ParseError (Type, (List Token))] {
+                | (eqU8 tag thunkOpenTag) =>
+                  do [Result ParseError (Type, (List Token))] {
+                    res <- (recurse t)
+                    inner = fstTypeToken res
+                    afterInner = sndTypeToken res
+                    final <- (expect afterInner thunkCloseTag)
+                    return
+                      Ok
+                      [ParseError]
+                      [(Type, (List Token))]
+                      {Type, List Token | (Ty_Thunk inner), final}
+                  }
                 | (eqU8 tag lParenTag) =>
                   do [Result ParseError (Type, (List Token))] {
                     res <- (recurse t)
@@ -1295,7 +1366,8 @@ poly parseSimpleTypeWith =
         )
 
 poly isTypeAtomStartTag =
-  \tag : U8 => or (eqU8 tag identTag) (eqU8 tag lParenTag)
+  \tag : U8 =>
+    or (eqU8 tag identTag) (or (eqU8 tag lParenTag) (eqU8 tag thunkOpenTag))
 
 poly rec parseTypeAppLoopWith =
   \recurse : (List Token -> Result ParseError (Type, (List Token))) =>

--- a/lib/conversion/converter.ts
+++ b/lib/conversion/converter.ts
@@ -125,6 +125,7 @@ const toCore = (term: DeBruijnTerm): CoreTerm => {
       throw new ConversionError(`free variable detected: ${term.name}`);
     case "DbFreeTypeVar":
       throw new ConversionError(`free type variable detected: ${term.name}`);
+    case "DbThunkType":
     case "DbTyAbs":
     case "DbForall":
     case "DbTyApp":
@@ -135,6 +136,14 @@ const toCore = (term: DeBruijnTerm): CoreTerm => {
     case "DbMatch":
       throw new ConversionError(
         "match expressions are not supported in SKI conversion",
+      );
+    case "DbThunk":
+      throw new ConversionError(
+        "thunk expressions are not supported in SKI conversion",
+      );
+    case "DbForce":
+      throw new ConversionError(
+        "force expressions are not supported in SKI conversion",
       );
   }
 };

--- a/lib/improvize/index.ts
+++ b/lib/improvize/index.ts
@@ -180,6 +180,9 @@ function isOperatorLike(token: Token): boolean {
 
 function needsInlineSpace(prev: Token | undefined, current: Token): boolean {
   if (!prev) return false;
+  if (prev.text === "[" && current.text === "*") return false;
+  if (prev.text === "*" && current.text === "]") return false;
+  if (prev.text === "*" && current.text === "!") return false;
   if (prev.text === "<" && current.text === "-") return false;
   if (prev.text === "#") return false;
   if (current.text === "(" && prev.text === "u8") return false;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -94,6 +94,12 @@ export {
 // ─── Type utilities ─────────────────────────────────────────────────────
 export { unparseType } from "./parser/type.ts";
 export { inferType } from "./types/inference.ts";
+export {
+  getTypePolarity,
+  mkThunkType,
+  type Polarity,
+  type BaseType,
+} from "./types/types.ts";
 
 // ─── Constants ──────────────────────────────────────────────────────────
 export { TEST_TIMEOUT_MS } from "./constants.ts";

--- a/lib/meta/frontend/deBruijn.ts
+++ b/lib/meta/frontend/deBruijn.ts
@@ -152,6 +152,21 @@ interface DeBruijnU8Literal {
 /**
  * A De Bruijn term represents a TripLang value in name-independent form.
  */
+interface DeBruijnThunkType {
+  kind: "DbThunkType";
+  body: DeBruijnTerm;
+}
+
+interface DeBruijnThunk {
+  kind: "DbThunk";
+  body: DeBruijnTerm;
+}
+
+interface DeBruijnForce {
+  kind: "DbForce";
+  body: DeBruijnTerm;
+}
+
 export type DeBruijnTerm =
   | DeBruijnVar
   | DeBruijnFreeVar
@@ -167,7 +182,10 @@ export type DeBruijnTerm =
   | DeBruijnMatch
   | DeBruijnLet
   | DeBruijnTerminal
-  | DeBruijnU8Literal;
+  | DeBruijnU8Literal
+  | DeBruijnThunkType
+  | DeBruijnThunk
+  | DeBruijnForce;
 
 /**
  * Recursively converts a TripLangValueType AST into a De Bruijn representation.
@@ -296,6 +314,21 @@ function toDeBruijnInternal(
       return { kind: "DbTerminal", sym: term.sym };
     case "u8":
       return { kind: "DbU8Literal", value: term.value };
+    case "thunk":
+      return {
+        kind: "DbThunkType",
+        body: toDeBruijnInternal(term.body, termCtx, typeCtx),
+      };
+    case "systemF-thunk":
+      return {
+        kind: "DbThunk",
+        body: toDeBruijnInternal(term.body, termCtx, typeCtx),
+      };
+    case "systemF-force":
+      return {
+        kind: "DbForce",
+        body: toDeBruijnInternal(term.body, termCtx, typeCtx),
+      };
   }
 }
 

--- a/lib/meta/frontend/elaboration.ts
+++ b/lib/meta/frontend/elaboration.ts
@@ -95,6 +95,16 @@ export function elaborateSystemF(
         value: elaborateSystemF(systemF.value, syms),
         body: elaborateSystemF(systemF.body, syms),
       };
+    case "systemF-thunk":
+      return {
+        kind: "systemF-thunk",
+        body: elaborateSystemF(systemF.body, syms),
+      };
+    case "systemF-force":
+      return {
+        kind: "systemF-force",
+        body: elaborateSystemF(systemF.body, syms),
+      };
     case "non-terminal": {
       const elaboratedLft = elaborateSystemF(systemF.lft, syms);
       const elaboratedRgt = elaborateSystemF(systemF.rgt, syms);

--- a/lib/meta/frontend/substitution.ts
+++ b/lib/meta/frontend/substitution.ts
@@ -168,6 +168,12 @@ export function freeTermVars(t: TripLangValueType): Set<string> {
         case "type-var":
         case "terminal":
           break;
+        case "thunk":
+        case "systemF-thunk":
+        case "systemF-force": {
+          term = term.body;
+          continue;
+        }
       }
       // If we didn't 'continue', we are done with this node.
       break;
@@ -233,6 +239,11 @@ function usesSystemFNatLiteral(term: TripLangValueType): boolean {
       case "lambda-var":
       case "type-var":
       case "terminal":
+        break;
+      case "thunk":
+      case "systemF-thunk":
+      case "systemF-force":
+        stack.push(current.body);
         break;
     }
   }
@@ -322,6 +333,11 @@ export function freeTypeVars(t: TripLangValueType): Set<string> {
         }
         break;
       case "terminal":
+        break;
+      case "thunk":
+      case "systemF-thunk":
+      case "systemF-force":
+        collectFree(t.body, bound);
         break;
     }
   }
@@ -471,6 +487,21 @@ export function alphaRenameTermBinder<T extends TripLangValueType>(
     case "systemF-var":
       return term.name === oldName ? ({ ...term, name: newName } as T) : term;
     // Type binders/vars are separate namespace — don't touch here.
+    case "thunk":
+      return {
+        ...term,
+        body: alphaRenameTermBinder(term.body, oldName, newName),
+      } as T;
+    case "systemF-thunk":
+      return {
+        ...term,
+        body: alphaRenameTermBinder(term.body, oldName, newName),
+      } as T;
+    case "systemF-force":
+      return {
+        ...term,
+        body: alphaRenameTermBinder(term.body, oldName, newName),
+      } as T;
     default:
       return term;
   }
@@ -572,6 +603,21 @@ export function alphaRenameTypeBinder<T extends TripLangValueType>(
       return term.typeName === oldName
         ? ({ ...term, typeName: newName } as T)
         : term;
+    case "thunk":
+      return {
+        ...term,
+        body: alphaRenameTypeBinder(term.body, oldName, newName),
+      } as T;
+    case "systemF-thunk":
+      return {
+        ...term,
+        body: alphaRenameTypeBinder(term.body, oldName, newName),
+      } as T;
+    case "systemF-force":
+      return {
+        ...term,
+        body: alphaRenameTypeBinder(term.body, oldName, newName),
+      } as T;
     default:
       return term;
   }
@@ -1004,6 +1050,36 @@ export function substituteTermHygienicBatch(
     case "terminal":
     case "u8":
       return term;
+    case "thunk": {
+      const body = substituteTermHygienicBatch(
+        term.body,
+        substitutions,
+        replacementFVs,
+        bound,
+      );
+      if (body === term.body) return term;
+      return { ...term, body: body as BaseType } as TripLangValueType;
+    }
+    case "systemF-thunk": {
+      const body = substituteTermHygienicBatch(
+        term.body,
+        substitutions,
+        replacementFVs,
+        bound,
+      );
+      if (body === term.body) return term;
+      return { ...term, body: body as SystemFTerm } as TripLangValueType;
+    }
+    case "systemF-force": {
+      const body = substituteTermHygienicBatch(
+        term.body,
+        substitutions,
+        replacementFVs,
+        bound,
+      );
+      if (body === term.body) return term;
+      return { ...term, body: body as SystemFTerm } as TripLangValueType;
+    }
   }
 }
 
@@ -1196,6 +1272,36 @@ export function substituteHygienic<T extends TripLangValueType>(
     case "terminal":
     case "u8":
       return term;
+    case "thunk":
+      return {
+        ...term,
+        body: substituteHygienic(
+          (term as any).body,
+          termName,
+          replacement,
+          bound,
+        ),
+      } as T;
+    case "systemF-thunk":
+      return {
+        ...term,
+        body: substituteHygienic(
+          (term as any).body,
+          termName,
+          replacement,
+          bound,
+        ),
+      } as T;
+    case "systemF-force":
+      return {
+        ...term,
+        body: substituteHygienic(
+          (term as any).body,
+          termName,
+          replacement,
+          bound,
+        ),
+      } as T;
   }
 }
 
@@ -1320,6 +1426,36 @@ export function substituteTypeHygienic<T extends TripLangValueType>(
       return term.typeName === typeName && !bound.has(typeName)
         ? (replacement as T)
         : term;
+    case "thunk":
+      return {
+        ...term,
+        body: substituteTypeHygienic(
+          (term as any).body,
+          typeName,
+          replacement,
+          bound,
+        ),
+      } as T;
+    case "systemF-thunk":
+      return {
+        ...term,
+        body: substituteTypeHygienic(
+          (term as any).body,
+          typeName,
+          replacement,
+          bound,
+        ),
+      } as T;
+    case "systemF-force":
+      return {
+        ...term,
+        body: substituteTypeHygienic(
+          (term as any).body,
+          typeName,
+          replacement,
+          bound,
+        ),
+      } as T;
     default:
       return term;
   }

--- a/lib/meta/frontend/symbolTable.ts
+++ b/lib/meta/frontend/symbolTable.ts
@@ -52,6 +52,11 @@ function cloneType(type: BaseType): BaseType {
         lft: cloneType(type.lft),
         rgt: cloneType(type.rgt),
       };
+    case "thunk":
+      return {
+        kind: "thunk",
+        body: cloneType(type.body),
+      };
   }
 }
 

--- a/lib/minicore/fromTrip.ts
+++ b/lib/minicore/fromTrip.ts
@@ -1386,6 +1386,14 @@ class MiniCoreBuilder {
         throw new MiniCoreCompileError(
           "MiniCore does not support lambda values in expression position",
         );
+      case "systemF-thunk":
+        throw new MiniCoreCompileError(
+          "MiniCore does not support thunk values in expression position",
+        );
+      case "systemF-force":
+        throw new MiniCoreCompileError(
+          "MiniCore does not support force expressions in expression position",
+        );
     }
   }
 

--- a/lib/minicore/metadata.ts
+++ b/lib/minicore/metadata.ts
@@ -1,4 +1,4 @@
-import type { BaseType } from "../types/types.ts";
+import type { BaseType, Polarity } from "../types/types.ts";
 import type { Literal, LocalId, SymbolId } from "./ast.ts";
 
 export type TypeId = number;
@@ -103,6 +103,22 @@ export function cloneMiniCoreMetadata(
   };
 }
 
+export function getMiniTypePolarity(type: MiniType): Polarity {
+  switch (type.kind) {
+    case "nat":
+    case "u8":
+    case "bool":
+    case "unit":
+    case "data":
+    case "var":
+    case "unknown":
+      return "positive";
+    case "fn":
+    case "forall":
+      return "negative";
+  }
+}
+
 export function typeOfLiteral(literal: Literal): MiniType {
   return literal.kind === "u8" ? { kind: "u8" } : { kind: "nat" };
 }
@@ -112,6 +128,8 @@ export function miniTypeFromBaseType(
   resolveDataType?: (name: string) => MiniType | TypeId | undefined,
 ): MiniType {
   switch (type.kind) {
+    case "thunk":
+      return { kind: "unknown" };
     case "type-var": {
       switch (type.typeName) {
         case "Nat":

--- a/lib/parser/parserState.ts
+++ b/lib/parser/parserState.ts
@@ -336,3 +336,51 @@ export function isAtDefinitionKeywordLine(state: ParserState): boolean {
     return firstLine.startsWith(keyword) && /\s/.test(nextChar ?? "");
   });
 }
+
+export function peekThunkOpen(state: ParserState): [boolean, ParserState] {
+  const newState = skipWhitespace(state);
+  return [
+    newState.buf.slice(newState.idx, newState.idx + 2) === "[*",
+    newState,
+  ];
+}
+
+export function matchThunkOpen(state: ParserState): ParserState {
+  const [isOpen, newState] = peekThunkOpen(state);
+  if (!isOpen) {
+    throw new ParseError(withParserState(newState, "expected '[*'"));
+  }
+  return { buf: newState.buf, idx: newState.idx + 2 };
+}
+
+export function peekThunkClose(state: ParserState): [boolean, ParserState] {
+  const newState = skipWhitespace(state);
+  return [
+    newState.buf.slice(newState.idx, newState.idx + 2) === "*]",
+    newState,
+  ];
+}
+
+export function matchThunkClose(state: ParserState): ParserState {
+  const [isClose, newState] = peekThunkClose(state);
+  if (!isClose) {
+    throw new ParseError(withParserState(newState, "expected '*]'"));
+  }
+  return { buf: newState.buf, idx: newState.idx + 2 };
+}
+
+export function peekForce(state: ParserState): [boolean, ParserState] {
+  const newState = skipWhitespace(state);
+  return [
+    newState.buf.slice(newState.idx, newState.idx + 2) === "*!",
+    newState,
+  ];
+}
+
+export function matchForce(state: ParserState): ParserState {
+  const [isForce, newState] = peekForce(state);
+  if (!isForce) {
+    throw new ParseError(withParserState(newState, "expected '*!'"));
+  }
+  return { buf: newState.buf, idx: newState.idx + 2 };
+}

--- a/lib/parser/systemFTerm.ts
+++ b/lib/parser/systemFTerm.ts
@@ -29,6 +29,12 @@ import {
   matchBindArrow,
   skipWhitespace,
   withParserState,
+  peekThunkOpen,
+  matchThunkOpen,
+  peekThunkClose,
+  matchThunkClose,
+  peekForce,
+  matchForce,
 } from "./parserState.ts";
 import type { ParserState } from "./parserState.ts";
 import type { BaseType } from "../types/types.ts";
@@ -42,6 +48,8 @@ import {
   mkSystemFVar,
   type SystemFMatchArm,
   type SystemFTerm,
+  mkSystemFThunk,
+  mkSystemFForce,
 } from "../terms/systemF.ts";
 import {
   createSystemFApplication,
@@ -124,6 +132,9 @@ function isStartOfDoStep(state: ParserState): boolean {
 }
 
 function isTerminator(state: ParserState): boolean {
+  const [isClose] = peekThunkClose(state);
+  if (isClose) return true;
+
   const [isFatArrow] = peekFatArrow(state);
   if (isFatArrow) return true;
 
@@ -1127,6 +1138,22 @@ const parseStringLiteralTerm = (
 function parseAtomicSystemFTerm(
   state: ParserState,
 ): [string, SystemFTerm, ParserState] {
+  const [isThunk, stateThunkOpen] = peekThunkOpen(state);
+  if (isThunk) {
+    const stateOpen = matchThunkOpen(state);
+    const [bodyLit, bodyTerm, stateAfterBody] = parseSystemFTerm(stateOpen);
+    const stateClose = matchThunkClose(stateAfterBody);
+    return [`[* ${bodyLit} *]`, mkSystemFThunk(bodyTerm), stateClose];
+  }
+
+  const [isForce, stateForceCheck] = peekForce(state);
+  if (isForce) {
+    const stateForce = matchForce(state);
+    const [bodyLit, bodyTerm, stateAfterBody] =
+      parseAtomicSystemFTerm(stateForce);
+    return [`*! ${bodyLit}`, mkSystemFForce(bodyTerm), stateAfterBody];
+  }
+
   const [ch, currentState] = peek(state);
 
   // 1. Term Abstraction: \x:T => body
@@ -1363,17 +1390,20 @@ export function parseSystemFTerm(
 
     // Case A: Type Application [T]
     if (ch === "[") {
-      const stateAfterLBracket = matchCh(peekState, "[");
-      const stateBeforeType = skipWhitespace(stateAfterLBracket);
-      const [typeLit, typeArg, stateAfterType] =
-        parseSystemFType(stateBeforeType);
-      const stateBeforeRBracket = skipWhitespace(stateAfterType);
-      const stateAfterRBracket = matchCh(stateBeforeRBracket, "]");
+      const [isThunk] = peekThunkOpen(currentState);
+      if (!isThunk) {
+        const stateAfterLBracket = matchCh(peekState, "[");
+        const stateBeforeType = skipWhitespace(stateAfterLBracket);
+        const [typeLit, typeArg, stateAfterType] =
+          parseSystemFType(stateBeforeType);
+        const stateBeforeRBracket = skipWhitespace(stateAfterType);
+        const stateAfterRBracket = matchCh(stateBeforeRBracket, "]");
 
-      literals.push(`[${typeLit}]`);
-      resultTerm = mkSystemFTypeApp(resultTerm, typeArg);
-      currentState = stateAfterRBracket;
-      continue;
+        literals.push(`[${typeLit}]`);
+        resultTerm = mkSystemFTypeApp(resultTerm, typeArg);
+        currentState = stateAfterRBracket;
+        continue;
+      }
     }
 
     // Case B: Term Application (Next Atom)
@@ -1451,5 +1481,9 @@ export function unparseSystemF(term: SystemFTerm): string {
         term.body,
       )}`;
     }
+    case "systemF-thunk":
+      return `[* ${unparseSystemF(term.body)} *]`;
+    case "systemF-force":
+      return `*! ${unparseSystemF(term.body)}`;
   }
 }

--- a/lib/parser/systemFType.ts
+++ b/lib/parser/systemFType.ts
@@ -12,6 +12,7 @@ import {
   type BaseType,
   mkTypeVariable,
   typeApp,
+  mkThunkType,
 } from "../types/types.ts";
 import { ParseError } from "./parseError.ts";
 import {
@@ -25,6 +26,9 @@ import {
   peekArrow,
   skipWhitespace,
   withParserState,
+  peekThunkOpen,
+  matchThunkOpen,
+  matchThunkClose,
 } from "./parserState.ts";
 import {
   ARROW,
@@ -82,7 +86,11 @@ export function parseSystemFType(
   }
 }
 
-function isTypeAtomStart(ch: string | null): boolean {
+function isTypeAtomStart(ch: string | null, state: ParserState): boolean {
+  if (ch === "[") {
+    const [isThunk] = peekThunkOpen(state);
+    return isThunk;
+  }
   return ch === LEFT_PAREN || (ch !== null && IDENTIFIER_CHAR_REGEX.test(ch));
 }
 
@@ -98,7 +106,7 @@ function parseTypeApplication(
     const [nextCh, peekState] = peek(currentState);
     const skipped = currentState.buf.slice(currentState.idx, peekState.idx);
     if (skipped.includes("\n") || skipped.includes("\r")) break;
-    if (!isTypeAtomStart(nextCh)) break;
+    if (!isTypeAtomStart(nextCh, currentState)) break;
     const [argLit, argType, stateAfterArg] = parseSimpleSystemFType(peekState);
     literal = `${literal} ${argLit}`;
     resultType = typeApp(resultType, argType);
@@ -118,6 +126,14 @@ function parseTypeApplication(
 function parseSimpleSystemFType(
   state: ParserState,
 ): [string, BaseType, ParserState] {
+  const [isThunk, stateThunkOpen] = peekThunkOpen(state);
+  if (isThunk) {
+    const stateOpen = matchThunkOpen(state);
+    const [innerLit, innerType, stateAfterInner] = parseSystemFType(stateOpen);
+    const stateClose = matchThunkClose(stateAfterInner);
+    return [`[* ${innerLit} *]`, mkThunkType(innerType), stateClose];
+  }
+
   const [ch, s] = peek(state);
   if (ch === "(") {
     const stateAfterLP = matchLP(s);
@@ -170,6 +186,9 @@ function parseSimpleSystemFType(
 export function unparseSystemFType(ty: BaseType): string {
   if (ty.kind === "type-var") {
     return ty.typeName;
+  }
+  if (ty.kind === "thunk") {
+    return `[* ${unparseSystemFType(ty.body)} *]`;
   }
   if (ty.kind === "type-app") {
     const fn =

--- a/lib/parser/type.ts
+++ b/lib/parser/type.ts
@@ -17,6 +17,9 @@ import {
   peekArrow,
   skipWhitespace,
   withParserState,
+  peekThunkOpen,
+  matchThunkOpen,
+  matchThunkClose,
 } from "./parserState.ts";
 import { ParseError } from "./parseError.ts";
 import {
@@ -24,6 +27,7 @@ import {
   type BaseType,
   mkTypeVariable,
   typeApp,
+  mkThunkType,
 } from "../types/types.ts";
 import { parseWithEOF } from "./eof.ts";
 import {
@@ -41,6 +45,14 @@ import {
  * Returns a triple: [literal, BaseType, updatedState]
  */
 function parseSimpleType(state: ParserState): [string, BaseType, ParserState] {
+  const [isThunk, sThunk] = peekThunkOpen(state);
+  if (isThunk) {
+    const sOpen = matchThunkOpen(state);
+    const [innerLit, innerType, stateAfterInner] = parseArrowType(sOpen);
+    const stateAfterClose = matchThunkClose(stateAfterInner);
+    return [`[* ${innerLit} *]`, mkThunkType(innerType), stateAfterClose];
+  }
+
   const [ch, s] = peek(state);
   if (ch === "(") {
     // Parenthesized type.
@@ -87,7 +99,11 @@ function parseSimpleType(state: ParserState): [string, BaseType, ParserState] {
   }
 }
 
-function isTypeAtomStart(ch: string | null): boolean {
+function isTypeAtomStart(ch: string | null, state: ParserState): boolean {
+  if (ch === "[") {
+    const [isThunk] = peekThunkOpen(state);
+    return isThunk;
+  }
   return ch === LEFT_PAREN || (ch !== null && IDENTIFIER_CHAR_REGEX.test(ch));
 }
 
@@ -109,7 +125,7 @@ function parseTypeApplication(
     const [nextCh, peekState] = peek(currentState);
     const skipped = currentState.buf.slice(currentState.idx, peekState.idx);
     if (skipped.includes("\n") || skipped.includes("\r")) break;
-    if (!isTypeAtomStart(nextCh)) break;
+    if (!isTypeAtomStart(nextCh, currentState)) break;
     const [argLit, argType, stateAfterArg] = parseSimpleType(peekState);
     literal = `${literal} ${argLit}`;
     resultType = typeApp(resultType, argType);
@@ -181,6 +197,9 @@ export function parseType(input: string): [string, BaseType] {
  * @returns a human-readable string representation
  */
 export function unparseType(ty: BaseType): string {
+  if (ty.kind === "thunk") {
+    return `[* ${unparseType(ty.body)} *]`;
+  }
   // Formats either a type variable, a forall, or an arrow type using ASCII.
   if (ty.kind === "type-var") {
     return ty.typeName;

--- a/lib/prelude.trip
+++ b/lib/prelude.trip
@@ -98,6 +98,16 @@ export modU8
 
 export U8
 
+export LazyVal
+
+export Stream
+
+export enumFrom
+
+export streamHead
+
+export streamTail
+
 export eqListU8
 
 export ltListU8
@@ -133,6 +143,10 @@ native writeOne : U8 -> #R -> (U8 -> R) -> R
 type Bool = #B -> B -> B -> B
 
 type List = #A -> #R -> R -> (A -> R -> R) -> R
+
+type LazyVal A = [* U8 -> A *]
+
+type Stream A = Pair A [* U8 -> Stream A *]
 
 type Parser = #A -> List Bin -> Result ParseError ((A, (List Bin)))
 
@@ -442,3 +456,25 @@ poly u8ToDigits =
           (digitToAscii hundreds)
           (cons [U8] (digitToAscii tens) (singletonU8 (digitToAscii ones)))
     }
+
+poly rec enumFrom =
+  \n : U8 =>
+    MkPair
+      [U8]
+      [[* U8 -> Stream U8 *]]
+      n
+      [* \u : U8 => enumFrom (addU8 n #u8(1)) *]
+
+poly streamHead =
+  #A =>
+    \s : Stream A =>
+      match s [A] {
+        | MkPair h t => h
+      }
+
+poly streamTail =
+  #A =>
+    \s : Stream A =>
+      match s [Stream A] {
+        | MkPair h t => (*! t) #u8(0)
+      }

--- a/lib/terms/systemF.ts
+++ b/lib/terms/systemF.ts
@@ -156,6 +156,16 @@ interface SystemFApplication {
  * - a term application t u (SystemFApplication),
  * - a let binding let x = v in b (SystemFLet)
  */
+interface SystemFThunk {
+  kind: "systemF-thunk";
+  body: SystemFTerm;
+}
+
+interface SystemFForce {
+  kind: "systemF-force";
+  body: SystemFTerm;
+}
+
 export type SystemFTerm =
   | SystemFVar
   | SystemFAbs
@@ -163,7 +173,19 @@ export type SystemFTerm =
   | SystemFTypeApp
   | SystemFApplication
   | SystemFMatch
-  | SystemFLet;
+  | SystemFLet
+  | SystemFThunk
+  | SystemFForce;
+
+export const mkSystemFThunk = (body: SystemFTerm): SystemFThunk => ({
+  kind: "systemF-thunk",
+  body,
+});
+
+export const mkSystemFForce = (body: SystemFTerm): SystemFForce => ({
+  kind: "systemF-force",
+  body,
+});
 
 /**
  * Creates an application of one System F term to another.

--- a/lib/types/inference.ts
+++ b/lib/types/inference.ts
@@ -44,6 +44,8 @@ const occursIn = (tv: TypeVariable, ty: BaseType): boolean => {
     return ty.typeName === tv.typeName;
   } else if (ty.kind === "type-app") {
     return occursIn(tv, ty.fn) || occursIn(tv, ty.arg);
+  } else if (ty.kind === "thunk") {
+    return occursIn(tv, ty.body);
   } else if (ty.kind === "non-terminal") {
     return occursIn(tv, ty.lft) || occursIn(tv, ty.rgt);
   } else {
@@ -80,6 +82,11 @@ export const substituteType = (
         kind: "type-app",
         fn: substituteType(original.fn, lft, rgt),
         arg: substituteType(original.arg, lft, rgt),
+      };
+    case "thunk":
+      return {
+        kind: "thunk",
+        body: substituteType(original.body, lft, rgt),
       };
     case "non-terminal":
       return arrow(
@@ -223,6 +230,11 @@ export const unify = (
     }
     newContext.set(t2.typeName, t1);
     return newContext;
+  }
+
+  // Thunk type unification.
+  if (t1.kind === "thunk" && t2.kind === "thunk") {
+    return unify(t1.body, t2.body, context);
   }
 
   // Type application unification.

--- a/lib/types/normalization.ts
+++ b/lib/types/normalization.ts
@@ -19,6 +19,10 @@ export const normalizeTy = (
   vars: () => ReturnType<typeof mkTypeVariable>,
 ): [BaseType, Map<string, string>] => {
   switch (ty.kind) {
+    case "thunk": {
+      const [bodyType, bodyMapping] = normalizeTy(ty.body, mapping, vars);
+      return [{ kind: "thunk", body: bodyType }, bodyMapping];
+    }
     case "type-var": {
       const mapped = mapping.get(ty.typeName);
       if (mapped === undefined) {

--- a/lib/types/systemF.ts
+++ b/lib/types/systemF.ts
@@ -7,7 +7,13 @@
  *
  * @module
  */
-import { arrow, type BaseType, type ForallType, typesLitEq } from "./types.ts";
+import {
+  arrow,
+  type BaseType,
+  type ForallType,
+  typesLitEq,
+  getTypePolarity,
+} from "./types.ts";
 import { unparseType } from "../parser/type.ts";
 import {
   makeNatType,
@@ -44,6 +50,11 @@ const substituteSystemFType = (
         kind: "type-app",
         fn: substituteSystemFType(original.fn, targetVarName, replacement),
         arg: substituteSystemFType(original.arg, targetVarName, replacement),
+      };
+    case "thunk":
+      return {
+        kind: "thunk",
+        body: substituteSystemFType(original.body, targetVarName, replacement),
       };
     case "non-terminal":
       return arrow(
@@ -167,6 +178,16 @@ export function reduceLets(
           ...arm,
           body: reduceLets(ctx, arm.body),
         })),
+      };
+    case "systemF-thunk":
+      return {
+        kind: "systemF-thunk",
+        body: reduceLets(ctx, term.body),
+      };
+    case "systemF-force":
+      return {
+        kind: "systemF-force",
+        body: reduceLets(ctx, term.body),
       };
   }
 }
@@ -318,6 +339,25 @@ export const typecheckSystemF = (
       );
       return [bodyTy, ctx];
     }
+    case "systemF-thunk": {
+      const [bodyTy, updatedCtx] = typecheckSystemF(ctx, term.body);
+      if (getTypePolarity(bodyTy) !== "negative") {
+        throw new TypeError(
+          `expected negative computation type inside thunk, got: ${unparseType(bodyTy)}`,
+        );
+      }
+      return [{ kind: "thunk", body: bodyTy }, updatedCtx];
+    }
+    case "systemF-force": {
+      const [bodyTy, updatedCtx] = typecheckSystemF(ctx, term.body);
+      const resolvedBodyTy = resolveTypeAlias(bodyTy, updatedCtx.typeAliases);
+      if (resolvedBodyTy.kind !== "thunk") {
+        throw new TypeError(
+          `expected thunk type to force, got: ${unparseType(bodyTy)}`,
+        );
+      }
+      return [resolvedBodyTy.body, updatedCtx];
+    }
   }
 };
 
@@ -359,6 +399,10 @@ export const eraseSystemF = (term: SystemFTerm): UntypedLambda => {
         untypedAbs(term.name, eraseSystemF(term.body)),
         eraseSystemF(term.value),
       );
+    case "systemF-thunk":
+      return eraseSystemF(term.body);
+    case "systemF-force":
+      return eraseSystemF(term.body);
     default:
       return untypedApp(eraseSystemF(term.lft), eraseSystemF(term.rgt));
   }

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -31,11 +31,51 @@ interface TypeApplication {
   arg: BaseType;
 }
 
-export type BaseType = TypeVariable | ArrowType | ForallType | TypeApplication;
+interface ThunkType {
+  kind: "thunk";
+  body: BaseType;
+}
+
+export type BaseType =
+  | TypeVariable
+  | ArrowType
+  | ForallType
+  | TypeApplication
+  | ThunkType;
+
+export type Polarity = "positive" | "negative";
+
+export const getTypePolarity = (type: BaseType): Polarity => {
+  switch (type.kind) {
+    case "non-terminal":
+      return "negative";
+    case "forall":
+      return "negative";
+    case "thunk":
+      return "positive";
+    case "type-var":
+      return "positive";
+    case "type-app": {
+      let current = type.fn;
+      while (current.kind === "type-app") {
+        current = current.fn;
+      }
+      if (current.kind === "type-var") {
+        return "positive";
+      }
+      return getTypePolarity(current);
+    }
+  }
+};
 
 export const mkTypeVariable = (name: string): TypeVariable => ({
   kind: "type-var",
   typeName: name,
+});
+
+export const mkThunkType = (body: BaseType): ThunkType => ({
+  kind: "thunk",
+  body,
 });
 
 export const arrow = (a: BaseType, b: BaseType): ArrowType => ({
@@ -60,6 +100,8 @@ export const typesLitEq = (a: BaseType, b: BaseType): boolean => {
     return typesLitEq(a.fn, b.fn) && typesLitEq(a.arg, b.arg);
   } else if (a.kind === "forall" && b.kind === "forall") {
     return a.typeVar === b.typeVar && typesLitEq(a.body, b.body);
+  } else if (a.kind === "thunk" && b.kind === "thunk") {
+    return typesLitEq(a.body, b.body);
   } else if ("lft" in a && "rgt" in a && "lft" in b && "rgt" in b) {
     return typesLitEq(a.lft, b.lft) && typesLitEq(a.rgt, b.rgt);
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/test/compiler/llvm/bundleV1.test.ts
+++ b/test/compiler/llvm/bundleV1.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -95,7 +95,7 @@ import Prelude eqU8
 import Prelude ltU8
 import Prelude eqListU8
 import Prelude u8ToDigits
-exports 52
+exports 55
 export ParseError
 export MkParseError
 export Token
@@ -130,6 +130,9 @@ export T_KwData
 export T_KwCond
 export T_KwDo
 export T_LArrow
+export T_ThunkOpen
+export T_ThunkClose
+export T_Force
 export T_Tagged
 export T_Ident
 export T_Nat
@@ -159,7 +162,7 @@ ctor T_Str 1
 type 0
 opaque 0
 native 0
-poly 100
+poly 106
 poly T_LParen
 poly T_RParen
 poly T_LBrace
@@ -191,9 +194,15 @@ poly T_KwData
 poly T_KwCond
 poly T_KwDo
 poly T_LArrow
+poly T_ThunkOpen
+poly T_ThunkClose
+poly T_Force
 poly T_EOF
 poly tokenTag
 poly tokenTaggedTextDo
+poly tokenTaggedTextForce
+poly tokenTaggedTextThunkClose
+poly tokenTaggedTextThunkOpen
 poly tokenTaggedTextLArrow
 poly tokenTaggedTextData
 poly tokenTaggedTextType
@@ -263,7 +272,7 @@ poly tokenize
 combinator 0
 module Parser
 declared Parser
-imports 68
+imports 71
 import Prelude eqListU8
 import Prelude List
 import Prelude nil
@@ -327,12 +336,15 @@ import Lexer T_KwData
 import Lexer T_KwCond
 import Lexer T_KwDo
 import Lexer T_LArrow
+import Lexer T_ThunkOpen
+import Lexer T_ThunkClose
+import Lexer T_Force
 import Lexer T_Tagged
 import Lexer T_Ident
 import Lexer T_Nat
 import Lexer T_Str
 import Lexer T_EOF
-exports 100
+exports 106
 export Pattern
 export P_Ctor
 export Expr
@@ -342,6 +354,8 @@ export E_Lam
 export E_Let
 export E_Nat
 export E_Match
+export E_Thunk
+export E_Force
 export DefKind
 export K_Poly
 export K_Combinator
@@ -393,6 +407,9 @@ export kwDataTag
 export kwCondTag
 export kwDoTag
 export lArrowTag
+export thunkOpenTag
+export thunkCloseTag
+export forceTag
 export fstNameToken
 export sndNameToken
 export fstExprToken
@@ -430,6 +447,7 @@ export Ty_Var
 export Ty_App
 export Ty_Arrow
 export Ty_Forall
+export Ty_Thunk
 export parseSimpleType
 export parseType
 export arrowTag
@@ -439,6 +457,7 @@ ctor Ty_Var 1
 ctor Ty_App 2
 ctor Ty_Arrow 2
 ctor Ty_Forall 2
+ctor Ty_Thunk 1
 data Pattern
 ctor P_Ctor 2
 data DoStep
@@ -455,6 +474,8 @@ ctor E_Lam 2
 ctor E_Let 3
 ctor E_Nat 1
 ctor E_Match 2
+ctor E_Thunk 1
+ctor E_Force 1
 data DefKind
 ctor K_Poly 0
 ctor K_Combinator 0
@@ -470,7 +491,7 @@ ctor D_Def 4
 type 0
 opaque 0
 native 0
-poly 119
+poly 122
 poly parseError
 poly checkedIncrementU8
 poly identTag
@@ -508,6 +529,9 @@ poly kwDataTag
 poly kwCondTag
 poly kwDoTag
 poly lArrowTag
+poly thunkOpenTag
+poly thunkCloseTag
+poly forceTag
 poly fstTypeToken
 poly sndTypeToken
 poly fstNameToken
@@ -594,7 +618,7 @@ combinator 0
 module Prelude
 declared Prelude
 imports 0
-exports 55
+exports 60
 export Bool
 export id
 export true
@@ -644,6 +668,11 @@ export subU8
 export divU8
 export modU8
 export U8
+export LazyVal
+export Stream
+export enumFrom
+export streamHead
+export streamTail
 export eqListU8
 export ltListU8
 export lteListU8
@@ -665,9 +694,11 @@ ctor MkParseError 1
 data Maybe
 ctor None 0
 ctor Some 1
-type 3
+type 5
 type Bool
 type List
+type LazyVal
+type Stream
 type Parser
 opaque 1
 opaque U8
@@ -680,7 +711,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 34
+poly 37
 poly id
 poly true
 poly false
@@ -715,4 +746,7 @@ poly lteListU8
 poly digitToAscii
 poly singletonU8
 poly u8ToDigits
+poly enumFrom
+poly streamHead
+poly streamTail
 combinator 0

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
@@ -95,7 +95,7 @@ import Prelude eqU8
 import Prelude ltU8
 import Prelude eqListU8
 import Prelude u8ToDigits
-exports 52
+exports 55
 export ParseError
 export MkParseError
 export Token
@@ -130,6 +130,9 @@ export T_KwData
 export T_KwCond
 export T_KwDo
 export T_LArrow
+export T_ThunkOpen
+export T_ThunkClose
+export T_Force
 export T_Tagged
 export T_Ident
 export T_Nat
@@ -159,7 +162,7 @@ ctor T_Str 1
 type 0
 opaque 0
 native 0
-poly 100
+poly 106
 poly T_LParen
 poly T_RParen
 poly T_LBrace
@@ -191,9 +194,15 @@ poly T_KwData
 poly T_KwCond
 poly T_KwDo
 poly T_LArrow
+poly T_ThunkOpen
+poly T_ThunkClose
+poly T_Force
 poly T_EOF
 poly tokenTag
 poly tokenTaggedTextDo
+poly tokenTaggedTextForce
+poly tokenTaggedTextThunkClose
+poly tokenTaggedTextThunkOpen
 poly tokenTaggedTextLArrow
 poly tokenTaggedTextData
 poly tokenTaggedTextType
@@ -264,7 +273,7 @@ combinator 0
 module Prelude
 declared Prelude
 imports 0
-exports 55
+exports 60
 export Bool
 export id
 export true
@@ -314,6 +323,11 @@ export subU8
 export divU8
 export modU8
 export U8
+export LazyVal
+export Stream
+export enumFrom
+export streamHead
+export streamTail
 export eqListU8
 export ltListU8
 export lteListU8
@@ -335,9 +349,11 @@ ctor MkParseError 1
 data Maybe
 ctor None 0
 ctor Some 1
-type 3
+type 5
 type Bool
 type List
+type LazyVal
+type Stream
 type Parser
 opaque 1
 opaque U8
@@ -350,7 +366,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 34
+poly 37
 poly id
 poly true
 poly false
@@ -385,4 +401,7 @@ poly lteListU8
 poly digitToAscii
 poly singletonU8
 poly u8ToDigits
+poly enumFrom
+poly streamHead
+poly streamTail
 combinator 0

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude.txt
@@ -7,7 +7,7 @@ modules 1
 module Prelude
 declared Prelude
 imports 0
-exports 55
+exports 60
 export Bool
 export id
 export true
@@ -57,6 +57,11 @@ export subU8
 export divU8
 export modU8
 export U8
+export LazyVal
+export Stream
+export enumFrom
+export streamHead
+export streamTail
 export eqListU8
 export ltListU8
 export lteListU8
@@ -78,9 +83,11 @@ ctor MkParseError 1
 data Maybe
 ctor None 0
 ctor Some 1
-type 3
+type 5
 type Bool
 type List
+type LazyVal
+type Stream
 type Parser
 opaque 1
 opaque U8
@@ -93,7 +100,7 @@ native divU8
 native modU8
 native readOne
 native writeOne
-poly 34
+poly 37
 poly id
 poly true
 poly false
@@ -128,4 +135,7 @@ poly lteListU8
 poly digitToAscii
 poly singletonU8
 poly u8ToDigits
+poly enumFrom
+poly streamHead
+poly streamTail
 combinator 0

--- a/test/types/polarity.test.ts
+++ b/test/types/polarity.test.ts
@@ -1,0 +1,218 @@
+import { describe, it } from "../util/test_shim.ts";
+import assert from "node:assert/strict";
+
+import {
+  arrow,
+  arrows,
+  getTypePolarity,
+  mkTypeVariable,
+  typeApp,
+} from "../../lib/types/types.ts";
+import { getMiniTypePolarity } from "../../lib/minicore/metadata.ts";
+import { parseType, unparseType } from "../../lib/parser/type.ts";
+import { parseSystemF, unparseSystemF } from "../../lib/parser/systemFTerm.ts";
+import {
+  typecheck,
+  typecheckSystemF,
+  emptySystemFContext,
+} from "../../lib/types/systemF.ts";
+
+describe("type polarity checks", () => {
+  describe("BaseType Polarity", () => {
+    it("classifies primitive types and type variables as positive", () => {
+      const natTy = mkTypeVariable("Nat");
+      const u8Ty = mkTypeVariable("U8");
+      const aTy = mkTypeVariable("a");
+
+      assert.strictEqual(getTypePolarity(natTy), "positive");
+      assert.strictEqual(getTypePolarity(u8Ty), "positive");
+      assert.strictEqual(getTypePolarity(aTy), "positive");
+    });
+
+    it("classifies arrow types as negative", () => {
+      const natTy = mkTypeVariable("Nat");
+      const fnTy = arrow(natTy, natTy);
+      const complexFnTy = arrows(natTy, natTy, natTy);
+
+      assert.strictEqual(getTypePolarity(fnTy), "negative");
+      assert.strictEqual(getTypePolarity(complexFnTy), "negative");
+    });
+
+    it("classifies universal (forall) types as negative", () => {
+      const forallTy: any = {
+        kind: "forall",
+        typeVar: "a",
+        body: mkTypeVariable("a"),
+      };
+
+      assert.strictEqual(getTypePolarity(forallTy), "negative");
+    });
+
+    it("classifies type applications as positive", () => {
+      const listTy = mkTypeVariable("List");
+      const u8Ty = mkTypeVariable("U8");
+      const listU8Ty = typeApp(listTy, u8Ty);
+
+      assert.strictEqual(getTypePolarity(listU8Ty), "positive");
+    });
+  });
+
+  describe("MiniType Polarity", () => {
+    it("classifies values and data types as positive", () => {
+      assert.strictEqual(getMiniTypePolarity({ kind: "nat" }), "positive");
+      assert.strictEqual(getMiniTypePolarity({ kind: "u8" }), "positive");
+      assert.strictEqual(getMiniTypePolarity({ kind: "bool" }), "positive");
+      assert.strictEqual(getMiniTypePolarity({ kind: "unit" }), "positive");
+      assert.strictEqual(
+        getMiniTypePolarity({ kind: "data", id: 42, args: [] }),
+        "positive",
+      );
+      assert.strictEqual(
+        getMiniTypePolarity({ kind: "var", name: "a" }),
+        "positive",
+      );
+    });
+
+    it("classifies functions and universally quantified types as negative", () => {
+      assert.strictEqual(
+        getMiniTypePolarity({
+          kind: "fn",
+          params: [{ kind: "u8" }],
+          result: { kind: "u8" },
+        }),
+        "negative",
+      );
+      assert.strictEqual(
+        getMiniTypePolarity({
+          kind: "forall",
+          params: ["a"],
+          body: { kind: "var", name: "a" },
+        }),
+        "negative",
+      );
+    });
+  });
+
+  describe("Thunk and Force parsing & typechecking", () => {
+    it("parses and unparses thunk types", () => {
+      const [lit, ty] = parseType("[* U8 -> U8 *]");
+      assert.strictEqual(lit, "[* U8->U8 *]");
+      assert.strictEqual(ty.kind, "thunk");
+      assert.strictEqual(unparseType(ty), "[* (U8->U8) *]");
+    });
+
+    it("parses and unparses thunk and force terms", () => {
+      const [lit, term] = parseSystemF("[* \\x : U8 => x *]");
+      assert.strictEqual(lit, "[* \\x:U8=>x *]");
+      assert.strictEqual(term.kind, "systemF-thunk");
+      assert.strictEqual(unparseSystemF(term), "[* \\x:U8=>x *]");
+
+      const [forceLit, forceTerm] = parseSystemF("*! x");
+      assert.strictEqual(forceLit, "*! x");
+      assert.strictEqual(forceTerm.kind, "systemF-force");
+      assert.strictEqual(unparseSystemF(forceTerm), "*! x");
+    });
+
+    it("typechecks thunk and force terms correctly", () => {
+      // 1. Thunking a function type (negative) is positive.
+      const [, term] = parseSystemF("[* \\x : U8 => x *]");
+      const ty = typecheck(term);
+      assert.strictEqual(ty.kind, "thunk");
+      assert.strictEqual(unparseType(ty), "[* (U8->U8) *]");
+
+      // 2. Forcing a thunk type returns the inner negative type.
+      const [, forceTerm] = parseSystemF("*! [* \\x : U8 => x *]");
+      const innerTy = typecheck(forceTerm);
+      assert.strictEqual(innerTy.kind, "non-terminal");
+      assert.strictEqual(unparseType(innerTy), "(U8->U8)");
+    });
+
+    it("fails typechecking for polarity mismatch", () => {
+      // Thunking a positive type (Nat is positive, not negative/computation)
+      const [, badThunk] = parseSystemF("[* x *]");
+      const ctx = emptySystemFContext();
+      ctx.termCtx.set("x", mkTypeVariable("Nat"));
+      assert.throws(
+        () => typecheckSystemF(ctx, badThunk),
+        /expected negative computation type inside thunk/,
+      );
+
+      // Forcing a non-thunk type
+      const [, badForce] = parseSystemF("*! x");
+      const ctx2 = emptySystemFContext();
+      ctx2.termCtx.set("x", mkTypeVariable("Nat"));
+      assert.throws(
+        () => typecheckSystemF(ctx2, badForce),
+        /expected thunk type to force/,
+      );
+    });
+  });
+
+  describe("Lazy Streams", () => {
+    it("typechecks a lazy stream tail force expression", () => {
+      // Stream U8 = Pair U8 [* U8 -> Stream U8 *]
+      // We typecheck forcing the tail t : [* U8 -> Stream U8 *] and applying a dummy argument
+      const ctx = emptySystemFContext();
+      const streamU8Ty = typeApp(
+        mkTypeVariable("Stream"),
+        mkTypeVariable("U8"),
+      );
+      ctx.termCtx.set("t", {
+        kind: "thunk",
+        body: arrow(mkTypeVariable("U8"), streamU8Ty),
+      });
+
+      const [, forceTerm] = parseSystemF("(*! t) #u8(0)");
+      const [ty] = typecheckSystemF(ctx, forceTerm);
+      assert.strictEqual(unparseType(ty), "Stream U8");
+    });
+  });
+
+  describe("Advanced Motivating Examples", () => {
+    it("typechecks a lazy conditional selector (lazyChoose)", () => {
+      // lazyChoose : Bool -> [* U8 -> U8 *] -> [* U8 -> U8 *] -> U8
+      // lazyChoose = \c : Bool => \thenThunk : [* U8 -> U8 *] => \elseThunk : [* U8 -> U8 *] =>
+      //   (c [U8 -> U8] (*! thenThunk) (*! elseThunk)) #u8(0)
+      const ctx = emptySystemFContext();
+      ctx.termCtx.set("c", {
+        kind: "forall",
+        typeVar: "B",
+        body: arrow(
+          mkTypeVariable("B"),
+          arrow(mkTypeVariable("B"), mkTypeVariable("B")),
+        ),
+      }); // Church-encoded Bool
+      ctx.termCtx.set("thenThunk", {
+        kind: "thunk",
+        body: arrow(mkTypeVariable("U8"), mkTypeVariable("U8")),
+      });
+      ctx.termCtx.set("elseThunk", {
+        kind: "thunk",
+        body: arrow(mkTypeVariable("U8"), mkTypeVariable("U8")),
+      });
+
+      const [, term] = parseSystemF(
+        "(c [U8 -> U8] (*! thenThunk) (*! elseThunk)) #u8(0)",
+      );
+      const [ty] = typecheckSystemF(ctx, term);
+      assert.strictEqual(unparseType(ty), "U8");
+    });
+
+    it("typechecks nested thunks and multiple forces", () => {
+      // t : [* U8 -> [* U8 -> U8 *] *]
+      // Term: *! ((*! t) #u8(0))
+      const ctx = emptySystemFContext();
+      ctx.termCtx.set("t", {
+        kind: "thunk",
+        body: arrow(mkTypeVariable("U8"), {
+          kind: "thunk",
+          body: arrow(mkTypeVariable("U8"), mkTypeVariable("U8")),
+        }),
+      });
+
+      const [, term] = parseSystemF("*! ((*! t) #u8(0))");
+      const [ty] = typecheckSystemF(ctx, term);
+      assert.strictEqual(unparseType(ty), "(U8->U8)");
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR implements **Direction B (Polarized Types)** in TripLang, introducing first-class support for **Thunks** and **Forces** across both the TypeScript host compiler and the self-hosting `.trip` bootstrap compiler.

To maintain theoretical consistency, the implementation aligns strictly with standard Call-by-Push-Value (CBPV) type theory (`Thunk`, `Force`, `Polarity`), avoiding any internal naming slang.

---

## Language Extensions & Syntax

1. **Thunk Types**: `[* T *]` (represented as `Thunk T` in AST)
2. **Thunk Expressions**: `[* e *]` (represented as `thunk e` in AST)
3. **Force Expressions**: `*! e` (represented as `force e` in AST)

---

## Detailed Changes

### 1. Lexer & Parsing
- **TypeScript parser**:
  - Registered the new token sequences in `lib/parser/tripLang.ts`.
  - Added type parser support in `lib/parser/type.ts` and term/force parsing in `lib/parser/systemFTerm.ts`.
  - Fixed a token conflict where type application loops inside terms (`t [Type]`) would mistakenly consume the `[*` thunk open sequence. Added a `peekThunkOpen` guard to the type-app parse branch.
- **Self-Hosted compiler (`bootstrap/src/lexer.trip` & `bootstrap/src/parser.trip`)**:
  - Added `T_ThunkOpen`, `T_ThunkClose`, and `T_Force` constructors.
  - **Tag Collision Resolution**: Assigned tag numbers `38`, `39`, and `40` to these constructors respectively, avoiding a critical collision with the string literal tag `T_Str` (`35`) which previously broke self-hosted builds.
  - Extended the recursive `parseSimpleTypeWith` and `parseAtomWith` logic.

### 2. Formatter
- **Improvize Formatter (`lib/improvize/index.ts`)**:
  - Updated `needsInlineSpace` to prevent the formatter from reflowing or inserting spaces inside thunk/force operators (e.g. formatting `*! t` as `* ! t`). This guarantees that formatted code remains parse-equivalent and round-trips correctly.

### 3. Typechecker & Backend Passes
- **TypeScript Typechecker**:
  - Implemented polarity classification for positive/negative types (`getTypePolarity`).
  - Added inference and validation rules in `lib/types/inference.ts` to ensure thunks wrap negative computation types and forces operate on positive thunked values.
- **Bootstrap Compiler Passes**:
  - Updated all traversals, reference collectors (`collectRefsExpr`), and qualifications (`qualifyExpr`) in `bootstrap/src/index.trip` to handle `E_Thunk` and `E_Force` expressions.
  - Ensured backend/bridge components (`bridge.trip`, `llvm.trip`, `coreToMini.trip`) are exhaustive to keep build checks green.

---

## Verification Results

### 1. Automated Tests
All local test targets have been verified and pass successfully.
- **Bazel GHA local run**:
  - `bazel build //consumers/thanatos:thanatos //consumers/thanatos:performance_test //:trip_hello_world` (**PASSED**)
  - `bazel test //:native_tests` (**PASSED**)
  - `bazel build //:fmt_check //:typecheck` (**PASSED**)
  - `bazel test //:node_tests --test_output=errors` (**PASSED**)
- **Bun test suite**:
  - `pnpm run test:bun` (**PASSED** - 723 tests, 0 failures)

### 2. Unit Coverage
Added comprehensive test cases in [polarity.test.ts](file:///C:/Users/me/src/typed-ski/test/types/polarity.test.ts) exercising:
- Correct polarity classification of all types.
- Parsing, unparsing, and typechecking thunked/forced terms.
- Type errors under polarity mismatches.
- Lazy evaluation patterns (e.g., Church-boolean selector thunks and nested force executions).
- Added `LazyVal`, `Stream`, `enumFrom`, `streamHead`, and `streamTail` utilizing thunks to [prelude.trip](file:///C:/Users/me/src/typed-ski/lib/prelude.trip).

### 3. Version Bump
- Bumped the minor version to `0.29.0` in both `package.json` and `jsr.json`.
- Generated and synchronized `lib/shared/version.generated.ts`.
- Rebuilt distribution packages (`pnpm run dist`).
