### PR TITLE
4-phase fixpoint verification

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,7 +9,7 @@ common --experimental_repository_downloader_retries=3
 common --http_timeout_scaling=2.0
 
 build --action_env=PATH
-test --test_timeout=80
+test --test_timeout=240
 test --test_env=PATH
 test:linux --test_env=HOME
 test:macos --test_env=HOME

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ package-lock.json
 pnpm-lock.yaml
 ts_out/
 dist/
+scratch/
+

--- a/README.md
+++ b/README.md
@@ -255,17 +255,22 @@ transform them as first-order AST data.
 
 `.trip` files under [`bootstrap/src/`](bootstrap/src/) (lexer.trip,
 parser.trip, core.trip, lowering.trip, llvm.trip, moduleEnv.trip, etc.)
-are an in-progress re-implementation of the compiler in TripLang itself.
-They are not currently part of the main build. The active acceptance path
-is the LLVM self-hosting test: TypeScript compiles the Trip compiler to a
-native executable, then that executable reads `bundle-v1` and emits LLVM IR
-for a stage-1 Trip program. The native compiler does not yet recompile its
-own bundle, so there is no stage-2 / IR-fixpoint self-reproduction check.
+are a re-implementation of the compiler in TripLang itself.
 
-This is targeting LLVM IR self-hosting, not in-language object emission or
-linking. Parser bootstrap progress is measured through the `bundle-v1`
-contract above; legacy SKI parser bootstrap tests are not acceptance criteria
-for this milestone.
+The acceptance path is the LLVM self-hosting test (`bootstrapLlvmSelfHost.test.ts`):
+
+1. **Stage 1**: TypeScript compiler compiles the compiler source bundle to a native compiler executable (`stage1.exe`).
+2. **Stage 2**: `stage1.exe` compiles the compiler source bundle to LLVM IR (`stage2.ll`), which is assembled to `stage2.exe`.
+3. **Stage 3**: `stage2.exe` compiles the compiler source bundle to LLVM IR (`stage3.ll`), which is assembled to `stage3.exe`.
+4. **Stage 4**: `stage3.exe` compiles the compiler source bundle to LLVM IR (`stage4.ll`).
+
+The test suite asserts and verifies a byte-identical LLVM IR fixpoint (`stage2.ll === stage3.ll === stage4.ll`), alongside running correctness checks (Hello World and multi-module program compilation) using the generated `stage3.exe` executable to ensure compiler correctness.
+
+### Load-Bearing Design Decisions & Tech Debt
+
+- **Determinism Contract**: The fixpoint check matches generated LLVM IR byte-for-byte. This strictly requires deterministic traversal/iteration orders for all collections, environments, and symbol tables (such as `ModuleEnv`).
+- **Boolean Pointer Representation**: In the LLVM-v0 backend, `false` is represented as the pointer value `1` and `true` as the pointer value `2` in uniform/unboxed positions. This leaves `0` (NULL) and other small pointers free to trigger explicit aborts in `trip_obj_tag`, avoiding the masking of null-dereference bugs.
+- **Church Prelude Closures (Performance Tech Debt)**: The lack of monomorphization/specialization in the bootstrap compiler means all occurrences of prelude helpers (`if`, `and`, `or`, `matchList`) lower to heap-allocated closures and indirect function calls, leading to a performance penalty (Stage 3 compilation takes ~30s). Full specialization/monomorphization remains on the roadmap to improve compiler performance.
 
 To lint, format, or prune the bootstrap corpus files under `bootstrap/src/`, the following npm scripts are provided:
 

--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -838,7 +838,8 @@ poly liftFuncs =
     \funcs : List AnfFunc =>
       do [(Bin, (List AnfFunc))] {
         MkPair finalCounter finalFuncs = (liftFuncsAcc counter {AnfFunc |} funcs)
-        return {Bin, List AnfFunc | finalCounter, (reverse [AnfFunc] finalFuncs)}
+        return
+          {Bin, List AnfFunc | finalCounter, (reverse [AnfFunc] finalFuncs)}
       }
 
 poly liftProgram =
@@ -869,13 +870,22 @@ poly rec normalizeFuncsAcc =
             \t : List MiniFunc =>
               do [List AnfFunc] {
                 MkMiniFunc name params body = h
-                return (normalizeFuncsAcc (cons [AnfFunc] (MkAnfFunc name params (normalize body)) acc) t)
+                return
+                  (
+                    normalizeFuncsAcc
+                      (
+                        cons
+                          [AnfFunc]
+                          (MkAnfFunc name params (normalize body))
+                          acc
+                      )
+                      t
+                  )
               }
         )
 
 poly normalizeFuncs =
-  \funcs : List MiniFunc =>
-    (reverse [AnfFunc] (normalizeFuncsAcc {AnfFunc |} funcs))
+  \funcs : List MiniFunc => (reverse [AnfFunc] (normalizeFuncsAcc {AnfFunc |} funcs))
 
 poly normalizeProgram =
   \prog : MiniProgram =>

--- a/bootstrap/src/anf.trip
+++ b/bootstrap/src/anf.trip
@@ -190,113 +190,109 @@ poly trivialAt =
     \atom : AnfExpr => \pos : Pos => MkNormResult state {Binding |} atom
 
 poly rec atomizeArgs =
-  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
-    \state : Bin =>
-      \args : List MiniExpr =>
-        \accBinds : List Binding =>
-          matchList
-            [MiniExpr]
-            [AtomList]
-            args
-            (MkAtomList state accBinds {AnfExpr |})
-            (
-              \h : MiniExpr =>
-                \t : List MiniExpr =>
-                  do [AtomList] {
-                    MkNormResult s1 hBinds hAtom = (normFn state h PAtom)
-                    combined = append [Binding] hBinds accBinds
-                    MkAtomList s2 finalBinds restAtoms = (atomizeArgs normFn s1 t combined)
-                    return
-                      MkAtomList
-                      s2
-                      finalBinds
-                      (cons [AnfExpr] hAtom restAtoms)
-                  }
-            )
+  \state : Bin =>
+    \args : List MiniExpr =>
+      \accBinds : List Binding =>
+        matchList
+          [MiniExpr]
+          [AtomList]
+          args
+          (MkAtomList state accBinds {AnfExpr |})
+          (
+            \h : MiniExpr =>
+              \t : List MiniExpr =>
+                do [AtomList] {
+                  MkNormResult s1 hBinds hAtom = (norm state h PAtom)
+                  combined = append [Binding] hBinds accBinds
+                  MkAtomList s2 finalBinds restAtoms = (atomizeArgs s1 t combined)
+                  return
+                    MkAtomList
+                    s2
+                    finalBinds
+                    (cons [AnfExpr] hAtom restAtoms)
+                }
+          )
 
 poly rec normArms =
-  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
-    \state : Bin =>
-      \arms : List MiniExpr =>
-        \acc : List AnfExpr =>
-          matchList
-            [MiniExpr]
-            [ArmsRes]
-            arms
-            (MkArmsRes state {AnfExpr |})
-            (
-              \h : MiniExpr =>
-                \t : List MiniExpr =>
-                  do [ArmsRes] {
-                    MkNormResult s1 _ hExpr = (normFn state h PTail)
-                    MkArmsRes s2 restArms = (normArms normFn s1 t acc)
-                    return MkArmsRes s2 (cons [AnfExpr] hExpr restArms)
-                  }
-            )
+  \state : Bin =>
+    \arms : List MiniExpr =>
+      \acc : List AnfExpr =>
+        matchList
+          [MiniExpr]
+          [ArmsRes]
+          arms
+          (MkArmsRes state {AnfExpr |})
+          (
+            \h : MiniExpr =>
+              \t : List MiniExpr =>
+                do [ArmsRes] {
+                  MkNormResult s1 _ hExpr = (norm state h PTail)
+                  MkArmsRes s2 restArms = (normArms s1 t acc)
+                  return MkArmsRes s2 (cons [AnfExpr] hExpr restArms)
+                }
+          )
 
 poly normWriteOneCall =
-  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
-    \state : Bin =>
-      \args : List MiniExpr =>
-        \pos : Pos =>
-          matchList
-            [MiniExpr]
-            [NormResult]
-            args
-            (MkNormResult state {Binding |} (AE_Call "writeOne" {AnfExpr |}))
-            (
-              \byte : MiniExpr =>
-                \r1 : List MiniExpr =>
-                  matchList
-                    [MiniExpr]
-                    [NormResult]
-                    r1
-                    (
-                      MkNormResult
-                        state
-                        {Binding |}
-                        (AE_Call "writeOne" {AnfExpr |})
-                    )
-                    (
-                      \cont : MiniExpr =>
-                        \r2 : List MiniExpr =>
-                          do [NormResult] {
-                            MkNormResult s1 byteBinds byteAtom = (normFn state byte PAtom)
-                            MkNormResult s2 contBinds contExpr = (normFn s1 cont PVal)
-                            combined = append [Binding] contBinds byteBinds
-                            return
-                              wrapValue
-                              s2
-                              combined
-                              (AE_Call "writeOne" {AnfExpr | byteAtom contExpr})
-                              pos
-                          }
-                    )
-            )
+  \state : Bin =>
+    \args : List MiniExpr =>
+      \pos : Pos =>
+        matchList
+          [MiniExpr]
+          [NormResult]
+          args
+          (MkNormResult state {Binding |} (AE_Call "writeOne" {AnfExpr |}))
+          (
+            \byte : MiniExpr =>
+              \r1 : List MiniExpr =>
+                matchList
+                  [MiniExpr]
+                  [NormResult]
+                  r1
+                  (
+                    MkNormResult
+                      state
+                      {Binding |}
+                      (AE_Call "writeOne" {AnfExpr |})
+                  )
+                  (
+                    \cont : MiniExpr =>
+                      \r2 : List MiniExpr =>
+                        do [NormResult] {
+                          MkNormResult s1 byteBinds byteAtom = (norm state byte PAtom)
+                          MkNormResult s2 contBinds contExpr = (norm s1 cont PVal)
+                          combined = append [Binding] contBinds byteBinds
+                          return
+                            wrapValue
+                            s2
+                            combined
+                            (AE_Call "writeOne" {AnfExpr | byteAtom contExpr})
+                            pos
+                        }
+                  )
+          )
 
 poly normReadOneCall =
-  \normFn : Bin -> MiniExpr -> Pos -> NormResult =>
-    \state : Bin =>
-      \args : List MiniExpr =>
-        \pos : Pos =>
-          matchList
-            [MiniExpr]
-            [NormResult]
-            args
-            (MkNormResult state {Binding |} (AE_Call "readOne" {AnfExpr |}))
-            (
-              \cont : MiniExpr =>
-                \r1 : List MiniExpr =>
-                  do [NormResult] {
-                    MkNormResult s1 contBinds contExpr = (normFn state cont PVal)
-                    return
-                      wrapValue
-                      s1
-                      contBinds
-                      (AE_Call "readOne" {AnfExpr | contExpr})
-                      pos
-                  }
-            )
+  \state : Bin =>
+    \args : List MiniExpr =>
+      \pos : Pos =>
+        matchList
+          [MiniExpr]
+          [NormResult]
+          args
+          (MkNormResult state {Binding |} (AE_Call "readOne" {AnfExpr |}))
+          (
+            \cont : MiniExpr =>
+              \r1 : List MiniExpr =>
+                do [NormResult] {
+                  MkNormResult s1 contBinds contExpr = (norm state cont PVal)
+                  return
+                    wrapValue
+                    s1
+                    contBinds
+                    (AE_Call "readOne" {AnfExpr | contExpr})
+                    pos
+                }
+          )
 
 poly rec norm =
   \state : Bin =>
@@ -312,22 +308,22 @@ poly rec norm =
             }
           | ME_Call f args =>
             if [NormResult] (or (eqListU8 f "writeOne") (eqListU8 f "Prelude.writeOne"))
-              (\u : U8 => normWriteOneCall norm state args pos)
+              (\u : U8 => normWriteOneCall state args pos)
               (
                 \u : U8 =>
                   if [NormResult] (or (eqListU8 f "readOne") (eqListU8 f "Prelude.readOne"))
-                    (\u2 : U8 => normReadOneCall norm state args pos)
+                    (\u2 : U8 => normReadOneCall state args pos)
                     (
                       \u2 : U8 =>
                         do [NormResult] {
-                          MkAtomList s1 binds atoms = (atomizeArgs norm state args {Binding |})
+                          MkAtomList s1 binds atoms = (atomizeArgs state args {Binding |})
                           return wrapValue s1 binds (AE_Call f atoms) pos
                         }
                     )
               )
           | ME_Con tag total arity fields =>
             do [NormResult] {
-              MkAtomList s1 binds atoms = (atomizeArgs norm state fields {Binding |})
+              MkAtomList s1 binds atoms = (atomizeArgs state fields {Binding |})
               return wrapValue s1 binds (AE_Con tag total arity atoms) pos
             }
           | ME_Let name val body =>
@@ -352,7 +348,7 @@ poly rec norm =
           | ME_Match scrut arms =>
             do [NormResult] {
               MkNormResult s1 scrBinds scrAtom = (norm state scrut PAtom)
-              MkArmsRes s2 normedArms = (normArms norm s1 arms {AnfExpr |})
+              MkArmsRes s2 normedArms = (normArms s1 arms {AnfExpr |})
               return wrapValue s2 scrBinds (AE_Case scrAtom normedArms) pos
             }
         }

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -307,9 +307,10 @@ poly rec emitCaseFieldBinds =
   \env : List ((List U8), (List U8)) =>
     \instrs : List (List U8) =>
       \scrutPtr : List U8 =>
-        \params : List (List U8) =>
-          \fieldIdx : U8 =>
-            matchList
+        \armIdx : U8 =>
+          \params : List (List U8) =>
+            \fieldIdx : U8 =>
+              matchList
               [List U8]
               [(List ((List U8), (List U8)), List (List U8))]
               params
@@ -317,7 +318,7 @@ poly rec emitCaseFieldBinds =
               (
                 \p : List U8 =>
                   \t : List (List U8) =>
-                    let fldVar = concat [U8] {List U8 | scrutPtr "_fld_" (u8ToDigits fieldIdx)} in
+                    let fldVar = concat [U8] {List U8 | scrutPtr "_arm_" (u8ToDigits armIdx) "_fld_" (u8ToDigits fieldIdx)} in
                     let line = concat [U8] {List U8 | "  " fldVar " = call i64 @trip_obj_field(ptr " scrutPtr ", i64 " (u8ToDigits fieldIdx) ")\n"} in
                     emitCaseFieldBinds
                       (
@@ -328,6 +329,7 @@ poly rec emitCaseFieldBinds =
                       )
                       (cons [List U8] line instrs)
                       scrutPtr
+                      armIdx
                       t
                       (addU8 fieldIdx #u8(1))
               )
@@ -1277,6 +1279,7 @@ poly rec emitExpr =
               do [Result (List U8) EmitRes] {
                 op_scrut <- (atomOperand env scrut)
                 caseId = binToDigits counter
+                counter1 = incBin counter
                 caseVar = append [U8]
                 "%__case_res_" caseId
                 scrutPtr = append [U8]
@@ -1316,7 +1319,7 @@ poly rec emitExpr =
                   "  ]\n"
                 }
                 initialInstrs = append [List U8] {List U8 | switchInstr tagLine castLine allocLine} instrs
-                return emitCaseArms env counter initialInstrs caseVar scrutPtr caseId arms #u8(0)
+                return emitCaseArms env counter1 initialInstrs caseVar scrutPtr caseId arms #u8(0)
               }
             | AE_Let name val body =>
               do [Result (List U8) EmitRes] {
@@ -1397,7 +1400,7 @@ poly rec emitCaseArms =
                           match (peelBinders arm {List U8 |}) [(List (List U8), AnfExpr)] {
                             | MkPair params body =>
                               let armLabel = concat [U8] {List U8 | "case_" caseId "_arm_" (u8ToDigits idx)} in
-                              match (emitCaseFieldBinds env {List U8 |} scrutPtr params #u8(0)) [(List ((List U8), (List U8)), List (List U8))] {
+                              match (emitCaseFieldBinds env {List U8 |} scrutPtr idx params #u8(0)) [(List ((List U8), (List U8)), List (List U8))] {
                                 | MkPair armEnv armInstrs =>
                                   let labelLine = append [U8] armLabel ":\n" in
                                   let combinedInstrs = append [List U8] (reverse [List U8] armInstrs) (cons [List U8] labelLine instrs) in
@@ -1498,7 +1501,7 @@ poly emitFunc =
                     (llvmSymbolName name)
                     "("
                     (paramDeclsString params true)
-                    ") {\nentry:\n"
+                    ") {\n__entry:\n"
                     instrText
                     "  ret i64 "
                     op

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -587,7 +587,10 @@ poly emitEqU8 =
                 dest
                 "_t2\n"
               }
-              ext = concat [U8] {List U8 | "  " dest " = zext i1 " dest "_cmp to i64\n"}
+              ext = concat [U8] {List U8 |
+                "  " dest "_zext = zext i1 " dest "_cmp to i64\n"
+                "  " dest " = add i64 " dest "_zext, 1\n"
+              }
               return
                 Ok
                 [List U8]
@@ -626,7 +629,10 @@ poly emitLtU8 =
                 dest
                 "_t2\n"
               }
-              ext = concat [U8] {List U8 | "  " dest " = zext i1 " dest "_cmp to i64\n"}
+              ext = concat [U8] {List U8 |
+                "  " dest "_zext = zext i1 " dest "_cmp to i64\n"
+                "  " dest " = add i64 " dest "_zext, 1\n"
+              }
               return
                 Ok
                 [List U8]

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -771,6 +771,38 @@ poly llvmSymbolName =
       (\u : U8 => append [U8] "trip_fn_" (replaceDot name))
       (\u : U8 => name)
 
+poly startsWithLambda =
+  \name : List U8 =>
+    match name [Bool] {
+      | nil => false
+      | cons h1 t1 =>
+        if [Bool] (eqU8 h1 #u8(95))
+          (\u : U8 =>
+            match t1 [Bool] {
+              | nil => false
+              | cons h2 t2 =>
+                if [Bool] (eqU8 h2 #u8(95))
+                  (\u : U8 =>
+                    match t2 [Bool] {
+                      | nil => false
+                      | cons h3 t3 =>
+                        if [Bool] (eqU8 h3 #u8(108))
+                          (\u : U8 =>
+                            match t3 [Bool] {
+                              | nil => false
+                              | cons h4 t4 =>
+                                eqU8 h4 #u8(97)
+                            }
+                          )
+                          (\u : U8 => false)
+                    }
+                  )
+                  (\u : U8 => false)
+            }
+          )
+          (\u : U8 => false)
+    }
+
 poly rec bindGlobalArgs =
   \env : List ((List U8), (List U8)) =>
     \counter : Bin =>
@@ -796,20 +828,44 @@ poly rec bindGlobalArgs =
                                   Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env1 c1 instrs1 (cons [AnfExpr] h restArgs))
                               }
                           }
-                        | None =>
-                          let dest = append [U8] "%__ll" (binToDigits counter) in
-                          let counter1 = incBin counter in
-                          let line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"} in
-                          let env1 = cons [((List U8), (List U8))] {List U8, List U8 | n, dest} env in
-                          let instrs1 = cons [List U8] line instrs in
-                          match (bindGlobalArgs env1 counter1 instrs1 t) [Result (List U8) BindGlobalArgsRes] {
-                            | Err e => Err [List U8] [BindGlobalArgsRes] e
-                            | Ok res =>
-                              match res [Result (List U8) BindGlobalArgsRes] {
-                                | MkBindGlobalArgsRes env2 c2 instrs2 restArgs =>
-                                  Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env2 c2 instrs2 (cons [AnfExpr] (AE_Var n) restArgs))
-                              }
-                          }
+                         | None =>
+                          if [Result (List U8) BindGlobalArgsRes] (startsWithLambda n)
+                            (
+                              \u : U8 =>
+                                let dest = append [U8] "%__ll" (binToDigits counter) in
+                                let counter1 = incBin counter in
+                                let line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"} in
+                                let env1 = cons [((List U8), (List U8))] {List U8, List U8 | n, dest} env in
+                                let instrs1 = cons [List U8] line instrs in
+                                match (bindGlobalArgs env1 counter1 instrs1 t) [Result (List U8) BindGlobalArgsRes] {
+                                  | Err e => Err [List U8] [BindGlobalArgsRes] e
+                                  | Ok res =>
+                                    match res [Result (List U8) BindGlobalArgsRes] {
+                                      | MkBindGlobalArgsRes env2 c2 instrs2 restArgs =>
+                                        Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env2 c2 instrs2 (cons [AnfExpr] (AE_Var n) restArgs))
+                                    }
+                                }
+                            )
+                            (
+                              \u : U8 =>
+                                let dest = append [U8] "%__ll" (binToDigits counter) in
+                                let counter1 = incBin counter in
+                                let counter2 = incBin counter1 in
+                                let fnPtrLine = concat [U8] {List U8 | "  " dest "_fn_val = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"} in
+                                let allocLine = concat [U8] {List U8 | "  " dest "_p = call ptr @trip_alloc_obj(i64 0, i64 1)\n"} in
+                                let setLine = concat [U8] {List U8 | "  call void @trip_obj_set_field(ptr " dest "_p, i64 0, i64 " dest "_fn_val)\n"} in
+                                let castLine = concat [U8] {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"} in
+                                let env1 = cons [((List U8), (List U8))] {List U8, List U8 | n, dest} env in
+                                let instrs1 = cons [List U8] castLine (cons [List U8] setLine (cons [List U8] allocLine (cons [List U8] fnPtrLine instrs))) in
+                                match (bindGlobalArgs env1 counter2 instrs1 t) [Result (List U8) BindGlobalArgsRes] {
+                                  | Err e => Err [List U8] [BindGlobalArgsRes] e
+                                  | Ok res =>
+                                    match res [Result (List U8) BindGlobalArgsRes] {
+                                      | MkBindGlobalArgsRes env2 c2 instrs2 restArgs =>
+                                        Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env2 c2 instrs2 (cons [AnfExpr] (AE_Var n) restArgs))
+                                    }
+                                }
+                            )
                       }
                     | AE_Native term =>
                       match (bindGlobalArgs env counter instrs t) [Result (List U8) BindGlobalArgsRes] {
@@ -841,18 +897,29 @@ poly rec emitExpr =
           match e [Result (List U8) EmitRes] {
             | AE_Var n =>
               match (lookupEnv env n) [Result (List U8) EmitRes] {
-                | None =>
-                  do [Result (List U8) EmitRes] {
-                    dest = append [U8]
-                    "%__ll" (binToDigits counter)
-                    counter1 = incBin counter
-                    line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
-                    return
-                      Ok
-                      [List U8]
-                      [EmitRes]
-                      (MkEmitRes counter1 (cons [List U8] line instrs) dest)
-                  }
+                 | None =>
+                  if [Result (List U8) EmitRes] (startsWithLambda n)
+                    (\u : U8 =>
+                      do [Result (List U8) EmitRes] {
+                        dest = append [U8] "%__ll" (binToDigits counter)
+                        counter1 = incBin counter
+                        line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
+                        return Ok [List U8] [EmitRes] (MkEmitRes counter1 (cons [List U8] line instrs) dest)
+                      }
+                    )
+                    (\u : U8 =>
+                      do [Result (List U8) EmitRes] {
+                        dest = append [U8] "%__ll" (binToDigits counter)
+                        counter1 = incBin counter
+                        counter2 = incBin counter1
+                        fnPtrLine = concat [U8] {List U8 | "  " dest "_fn_val = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
+                        allocLine = concat [U8] {List U8 | "  " dest "_p = call ptr @trip_alloc_obj(i64 0, i64 1)\n"}
+                        setLine = concat [U8] {List U8 | "  call void @trip_obj_set_field(ptr " dest "_p, i64 0, i64 " dest "_fn_val)\n"}
+                        castLine = concat [U8] {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"}
+                        lines = append [List U8] {List U8 | castLine setLine allocLine fnPtrLine} instrs
+                        return Ok [List U8] [EmitRes] (MkEmitRes counter2 lines dest)
+                      }
+                    )
                 | Some op =>
                   Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
               }
@@ -1203,53 +1270,81 @@ poly rec emitExpr =
                                                                         | Ok res =>
                                                                           match res [Result (List U8) EmitRes] {
                                                                             | MkBindGlobalArgsRes env1 counter1 instrs1 args1 =>
-                                                                              match (lookupEnv env1 f) [Result (List U8) EmitRes] {
-                                                                                | Some closureOp =>
-                                                                                  emitIndirectCallChain
-                                                                                    env1
-                                                                                    counter1
-                                                                                    instrs1
-                                                                                    closureOp
-                                                                                    args1
-                                                                                | None =>
-                                                                                  if [Result (List U8) EmitRes] (eqListU8 f "_")
-                                                                                    (
-                                                                                      \u10 : U8 =>
-                                                                                        Err
-                                                                                          [List U8]
-                                                                                          [EmitRes]
-                                                                                          "Indirect call to _ not supported without closure variable"
-                                                                                    )
-                                                                                    (
-                                                                                      \u10 : U8 =>
-                                                                                        do [Result (List U8) EmitRes] {
-                                                                                          argStr <- (emitArgsString env1 args1 true)
-                                                                                          dest = append [U8]
-                                                                                          "%__ll"
+                                                                              if [Result (List U8) EmitRes] (startsWithLambda f)
+                                                                                (
+                                                                                  \u10 : U8 =>
+                                                                                    do [Result (List U8) EmitRes] {
+                                                                                      argStr <- (emitArgsString env1 args1 true)
+                                                                                      dest = append [U8] "%__ll" (binToDigits counter1)
+                                                                                      counter2 = incBin counter1
+                                                                                      line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(" argStr ")\n"}
+                                                                                      return
+                                                                                        Ok
+                                                                                        [List U8]
+                                                                                        [EmitRes]
+                                                                                        (
+                                                                                          MkEmitRes
+                                                                                            counter2
                                                                                             (
-                                                                                              binToDigits
-                                                                                                counter1
+                                                                                              cons
+                                                                                                [List U8]
+                                                                                                line
+                                                                                                instrs1
                                                                                             )
-                                                                                          counter2 = incBin counter1
-                                                                                          line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(" argStr ")\n"}
-                                                                                          return
-                                                                                            Ok
-                                                                                            [List U8]
-                                                                                            [EmitRes]
-                                                                                            (
-                                                                                              MkEmitRes
-                                                                                                counter2
-                                                                                                (
-                                                                                                  cons
-                                                                                                    [List U8]
-                                                                                                    line
-                                                                                                    instrs1
-                                                                                                )
-                                                                                                dest
-                                                                                            )
-                                                                                        }
-                                                                                    )
-                                                                              }
+                                                                                            dest
+                                                                                        )
+                                                                                    }
+                                                                                )
+                                                                                (
+                                                                                  \u10 : U8 =>
+                                                                                    match (lookupEnv env1 f) [Result (List U8) EmitRes] {
+                                                                                      | Some closureOp =>
+                                                                                        emitIndirectCallChain
+                                                                                          env1
+                                                                                          counter1
+                                                                                          instrs1
+                                                                                          closureOp
+                                                                                          args1
+                                                                                      | None =>
+                                                                                        if [Result (List U8) EmitRes] (eqListU8 f "_")
+                                                                                          (
+                                                                                            \u11 : U8 =>
+                                                                                              Err
+                                                                                                [List U8]
+                                                                                                [EmitRes]
+                                                                                                "Indirect call to _ not supported without closure variable"
+                                                                                          )
+                                                                                          (
+                                                                                            \u11 : U8 =>
+                                                                                              do [Result (List U8) EmitRes] {
+                                                                                                argStr <- (emitArgsString env1 args1 false)
+                                                                                                dest = append [U8]
+                                                                                                  "%__ll"
+                                                                                                  (
+                                                                                                    binToDigits
+                                                                                                      counter1
+                                                                                                  )
+                                                                                                counter2 = incBin counter1
+                                                                                                line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(i64 0" argStr ")\n"}
+                                                                                                return
+                                                                                                  Ok
+                                                                                                  [List U8]
+                                                                                                  [EmitRes]
+                                                                                                  (
+                                                                                                    MkEmitRes
+                                                                                                      counter2
+                                                                                                      (
+                                                                                                        cons
+                                                                                                          [List U8]
+                                                                                                          line
+                                                                                                          instrs1
+                                                                                                      )
+                                                                                                      dest
+                                                                                                  )
+                                                                                              }
+                                                                                          )
+                                                                                    }
+                                                                                )
                                                                           }
                                                                       }
                                                                 )
@@ -1482,8 +1577,12 @@ poly emitFunc =
   \fn : AnfFunc =>
     do [Result (List U8) (List U8)] {
       MkAnfFunc name params body = fn
+      paramsWithEnv =
+        if [List (List U8)] (startsWithLambda name)
+          (\u : U8 => params)
+          (\u : U8 => cons [List U8] "dummy_env" params)
       return
-      match (emitExpr (paramEnv params) BZ {List U8 |} body) [Result (List U8) (List U8)] {
+        match (emitExpr (paramEnv paramsWithEnv) BZ {List U8 |} body) [Result (List U8) (List U8)] {
         | Err e => Err [List U8] [List U8] (concat [U8] {List U8 | "[fn " name "] " e})
         | Ok res =>
           do [Result (List U8) (List U8)] {
@@ -1500,7 +1599,7 @@ poly emitFunc =
                     "define i64 @"
                     (llvmSymbolName name)
                     "("
-                    (paramDeclsString params true)
+                    (paramDeclsString paramsWithEnv true)
                     ") {\n__entry:\n"
                     instrText
                     "  ret i64 "

--- a/bootstrap/src/anfLlvm.trip
+++ b/bootstrap/src/anfLlvm.trip
@@ -311,28 +311,28 @@ poly rec emitCaseFieldBinds =
           \params : List (List U8) =>
             \fieldIdx : U8 =>
               matchList
-              [List U8]
-              [(List ((List U8), (List U8)), List (List U8))]
-              params
-              {List ((List U8), (List U8)), List (List U8) | env, instrs}
-              (
-                \p : List U8 =>
-                  \t : List (List U8) =>
-                    let fldVar = concat [U8] {List U8 | scrutPtr "_arm_" (u8ToDigits armIdx) "_fld_" (u8ToDigits fieldIdx)} in
-                    let line = concat [U8] {List U8 | "  " fldVar " = call i64 @trip_obj_field(ptr " scrutPtr ", i64 " (u8ToDigits fieldIdx) ")\n"} in
-                    emitCaseFieldBinds
-                      (
-                        cons
-                          [((List U8), (List U8))]
-                          {List U8, List U8 | p, fldVar}
-                          env
-                      )
-                      (cons [List U8] line instrs)
-                      scrutPtr
-                      armIdx
-                      t
-                      (addU8 fieldIdx #u8(1))
-              )
+                [List U8]
+                [(List ((List U8), (List U8)), List (List U8))]
+                params
+                {List ((List U8), (List U8)), List (List U8) | env, instrs}
+                (
+                  \p : List U8 =>
+                    \t : List (List U8) =>
+                      let fldVar = concat [U8] {List U8 | scrutPtr "_arm_" (u8ToDigits armIdx) "_fld_" (u8ToDigits fieldIdx)} in
+                      let line = concat [U8] {List U8 | "  " fldVar " = call i64 @trip_obj_field(ptr " scrutPtr ", i64 " (u8ToDigits fieldIdx) ")\n"} in
+                      emitCaseFieldBinds
+                        (
+                          cons
+                            [((List U8), (List U8))]
+                            {List U8, List U8 | p, fldVar}
+                            env
+                        )
+                        (cons [List U8] line instrs)
+                        scrutPtr
+                        armIdx
+                        t
+                        (addU8 fieldIdx #u8(1))
+                )
 
 poly rec emitCtorFields =
   \env : List ((List U8), (List U8)) =>
@@ -587,10 +587,7 @@ poly emitEqU8 =
                 dest
                 "_t2\n"
               }
-              ext = concat [U8] {List U8 |
-                "  " dest "_zext = zext i1 " dest "_cmp to i64\n"
-                "  " dest " = add i64 " dest "_zext, 1\n"
-              }
+              ext = concat [U8] {List U8 | "  " dest "_zext = zext i1 " dest "_cmp to i64\n" "  " dest " = add i64 " dest "_zext, 1\n"}
               return
                 Ok
                 [List U8]
@@ -629,10 +626,7 @@ poly emitLtU8 =
                 dest
                 "_t2\n"
               }
-              ext = concat [U8] {List U8 |
-                "  " dest "_zext = zext i1 " dest "_cmp to i64\n"
-                "  " dest " = add i64 " dest "_zext, 1\n"
-              }
+              ext = concat [U8] {List U8 | "  " dest "_zext = zext i1 " dest "_cmp to i64\n" "  " dest " = add i64 " dest "_zext, 1\n"}
               return
                 Ok
                 [List U8]
@@ -783,28 +777,30 @@ poly startsWithLambda =
       | nil => false
       | cons h1 t1 =>
         if [Bool] (eqU8 h1 #u8(95))
-          (\u : U8 =>
-            match t1 [Bool] {
-              | nil => false
-              | cons h2 t2 =>
-                if [Bool] (eqU8 h2 #u8(95))
-                  (\u : U8 =>
-                    match t2 [Bool] {
-                      | nil => false
-                      | cons h3 t3 =>
-                        if [Bool] (eqU8 h3 #u8(108))
-                          (\u : U8 =>
-                            match t3 [Bool] {
-                              | nil => false
-                              | cons h4 t4 =>
-                                eqU8 h4 #u8(97)
-                            }
-                          )
-                          (\u : U8 => false)
-                    }
-                  )
-                  (\u : U8 => false)
-            }
+          (
+            \u : U8 =>
+              match t1 [Bool] {
+                | nil => false
+                | cons h2 t2 =>
+                  if [Bool] (eqU8 h2 #u8(95))
+                    (
+                      \u : U8 =>
+                        match t2 [Bool] {
+                          | nil => false
+                          | cons h3 t3 =>
+                            if [Bool] (eqU8 h3 #u8(108))
+                              (
+                                \u : U8 =>
+                                  match t3 [Bool] {
+                                    | nil => false
+                                    | cons h4 t4 => eqU8 h4 #u8(97)
+                                  }
+                              )
+                              (\u : U8 => false)
+                        }
+                    )
+                    (\u : U8 => false)
+              }
           )
           (\u : U8 => false)
     }
@@ -818,7 +814,12 @@ poly rec bindGlobalArgs =
             [AnfExpr]
             [Result (List U8) BindGlobalArgsRes]
             args
-            (Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env counter instrs {AnfExpr |}))
+            (
+              Ok
+                [List U8]
+                [BindGlobalArgsRes]
+                (MkBindGlobalArgsRes env counter instrs {AnfExpr |})
+            )
             (
               \h : AnfExpr =>
                 \t : List AnfExpr =>
@@ -826,15 +827,22 @@ poly rec bindGlobalArgs =
                     | AE_Var n =>
                       match (lookupEnv env n) [Maybe (List U8)] {
                         | Some op =>
-                          match (bindGlobalArgs env counter instrs t) [Result (List U8) BindGlobalArgsRes] {
-                            | Err e => Err [List U8] [BindGlobalArgsRes] e
-                            | Ok res =>
-                              match res [Result (List U8) BindGlobalArgsRes] {
-                                | MkBindGlobalArgsRes env1 c1 instrs1 restArgs =>
-                                  Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env1 c1 instrs1 (cons [AnfExpr] h restArgs))
-                              }
+                          do [Result (List U8) BindGlobalArgsRes] {
+                            res <- (bindGlobalArgs env counter instrs t)
+                            MkBindGlobalArgsRes env1 c1 instrs1 restArgs = res
+                            return
+                              Ok
+                              [List U8]
+                              [BindGlobalArgsRes]
+                              (
+                                MkBindGlobalArgsRes
+                                  env1
+                                  c1
+                                  instrs1
+                                  (cons [AnfExpr] h restArgs)
+                              )
                           }
-                         | None =>
+                        | None =>
                           if [Result (List U8) BindGlobalArgsRes] (startsWithLambda n)
                             (
                               \u : U8 =>
@@ -843,13 +851,20 @@ poly rec bindGlobalArgs =
                                 let line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"} in
                                 let env1 = cons [((List U8), (List U8))] {List U8, List U8 | n, dest} env in
                                 let instrs1 = cons [List U8] line instrs in
-                                match (bindGlobalArgs env1 counter1 instrs1 t) [Result (List U8) BindGlobalArgsRes] {
-                                  | Err e => Err [List U8] [BindGlobalArgsRes] e
-                                  | Ok res =>
-                                    match res [Result (List U8) BindGlobalArgsRes] {
-                                      | MkBindGlobalArgsRes env2 c2 instrs2 restArgs =>
-                                        Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env2 c2 instrs2 (cons [AnfExpr] (AE_Var n) restArgs))
-                                    }
+                                do [Result (List U8) BindGlobalArgsRes] {
+                                  res <- (bindGlobalArgs env1 counter1 instrs1 t)
+                                  MkBindGlobalArgsRes env2 c2 instrs2 restArgs = res
+                                  return
+                                    Ok
+                                    [List U8]
+                                    [BindGlobalArgsRes]
+                                    (
+                                      MkBindGlobalArgsRes
+                                        env2
+                                        c2
+                                        instrs2
+                                        (cons [AnfExpr] (AE_Var n) restArgs)
+                                    )
                                 }
                             )
                             (
@@ -862,36 +877,65 @@ poly rec bindGlobalArgs =
                                 let setLine = concat [U8] {List U8 | "  call void @trip_obj_set_field(ptr " dest "_p, i64 0, i64 " dest "_fn_val)\n"} in
                                 let castLine = concat [U8] {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"} in
                                 let env1 = cons [((List U8), (List U8))] {List U8, List U8 | n, dest} env in
-                                let instrs1 = cons [List U8] castLine (cons [List U8] setLine (cons [List U8] allocLine (cons [List U8] fnPtrLine instrs))) in
-                                match (bindGlobalArgs env1 counter2 instrs1 t) [Result (List U8) BindGlobalArgsRes] {
-                                  | Err e => Err [List U8] [BindGlobalArgsRes] e
-                                  | Ok res =>
-                                    match res [Result (List U8) BindGlobalArgsRes] {
-                                      | MkBindGlobalArgsRes env2 c2 instrs2 restArgs =>
-                                        Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env2 c2 instrs2 (cons [AnfExpr] (AE_Var n) restArgs))
-                                    }
+                                let instrs1 = append [List U8] {List U8 | castLine setLine allocLine fnPtrLine} instrs in
+                                do [Result (List U8) BindGlobalArgsRes] {
+                                  res <- (bindGlobalArgs env1 counter2 instrs1 t)
+                                  MkBindGlobalArgsRes env2 c2 instrs2 restArgs = res
+                                  return
+                                    Ok
+                                    [List U8]
+                                    [BindGlobalArgsRes]
+                                    (
+                                      MkBindGlobalArgsRes
+                                        env2
+                                        c2
+                                        instrs2
+                                        (cons [AnfExpr] (AE_Var n) restArgs)
+                                    )
                                 }
                             )
                       }
                     | AE_Native term =>
-                      match (bindGlobalArgs env counter instrs t) [Result (List U8) BindGlobalArgsRes] {
-                        | Err e => Err [List U8] [BindGlobalArgsRes] e
-                        | Ok res =>
-                          match res [Result (List U8) BindGlobalArgsRes] {
-                            | MkBindGlobalArgsRes env1 c1 instrs1 restArgs =>
-                              Ok [List U8] [BindGlobalArgsRes] (MkBindGlobalArgsRes env1 c1 instrs1 (cons [AnfExpr] h restArgs))
-                          }
+                      do [Result (List U8) BindGlobalArgsRes] {
+                        res <- (bindGlobalArgs env counter instrs t)
+                        MkBindGlobalArgsRes env1 c1 instrs1 restArgs = res
+                        return
+                          Ok
+                          [List U8]
+                          [BindGlobalArgsRes]
+                          (
+                            MkBindGlobalArgsRes
+                              env1
+                              c1
+                              instrs1
+                              (cons [AnfExpr] h restArgs)
+                          )
                       }
                     | AE_Lam n b =>
-                      Err [List U8] [BindGlobalArgsRes] "Unsupported argument: lambda"
+                      Err
+                        [List U8]
+                        [BindGlobalArgsRes]
+                        "Unsupported argument: lambda"
                     | AE_Call f args1 =>
-                      Err [List U8] [BindGlobalArgsRes] "Unsupported argument: call"
+                      Err
+                        [List U8]
+                        [BindGlobalArgsRes]
+                        "Unsupported argument: call"
                     | AE_Con tag total arity args1 =>
-                      Err [List U8] [BindGlobalArgsRes] "Unsupported argument: constructor"
+                      Err
+                        [List U8]
+                        [BindGlobalArgsRes]
+                        "Unsupported argument: constructor"
                     | AE_Case scrut arms =>
-                      Err [List U8] [BindGlobalArgsRes] "Unsupported argument: case"
+                      Err
+                        [List U8]
+                        [BindGlobalArgsRes]
+                        "Unsupported argument: case"
                     | AE_Let name val body =>
-                      Err [List U8] [BindGlobalArgsRes] "Unsupported argument: let"
+                      Err
+                        [List U8]
+                        [BindGlobalArgsRes]
+                        "Unsupported argument: let"
                   }
             )
 
@@ -903,28 +947,71 @@ poly rec emitExpr =
           match e [Result (List U8) EmitRes] {
             | AE_Var n =>
               match (lookupEnv env n) [Result (List U8) EmitRes] {
-                 | None =>
+                | None =>
                   if [Result (List U8) EmitRes] (startsWithLambda n)
-                    (\u : U8 =>
-                      do [Result (List U8) EmitRes] {
-                        dest = append [U8] "%__ll" (binToDigits counter)
-                        counter1 = incBin counter
-                        line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
-                        return Ok [List U8] [EmitRes] (MkEmitRes counter1 (cons [List U8] line instrs) dest)
-                      }
+                    (
+                      \u : U8 =>
+                        do [Result (List U8) EmitRes] {
+                          dest = append [U8]
+                          "%__ll" (binToDigits counter)
+                          counter1 = incBin counter
+                          line = concat [U8] {List U8 | "  " dest " = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
+                          return
+                            Ok
+                            [List U8]
+                            [EmitRes]
+                            (
+                              MkEmitRes
+                                counter1
+                                (cons [List U8] line instrs)
+                                dest
+                            )
+                        }
                     )
-                    (\u : U8 =>
-                      do [Result (List U8) EmitRes] {
-                        dest = append [U8] "%__ll" (binToDigits counter)
-                        counter1 = incBin counter
-                        counter2 = incBin counter1
-                        fnPtrLine = concat [U8] {List U8 | "  " dest "_fn_val = ptrtoint ptr @" (llvmSymbolName n) " to i64\n"}
-                        allocLine = concat [U8] {List U8 | "  " dest "_p = call ptr @trip_alloc_obj(i64 0, i64 1)\n"}
-                        setLine = concat [U8] {List U8 | "  call void @trip_obj_set_field(ptr " dest "_p, i64 0, i64 " dest "_fn_val)\n"}
-                        castLine = concat [U8] {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"}
-                        lines = append [List U8] {List U8 | castLine setLine allocLine fnPtrLine} instrs
-                        return Ok [List U8] [EmitRes] (MkEmitRes counter2 lines dest)
-                      }
+                    (
+                      \u : U8 =>
+                        do [Result (List U8) EmitRes] {
+                          dest = append [U8]
+                          "%__ll" (binToDigits counter)
+                          counter1 = incBin counter
+                          counter2 = incBin counter1
+                          fnPtrLine = concat [U8]
+                          {List U8 |
+                            "  "
+                            dest
+                            "_fn_val = ptrtoint ptr @"
+                            (llvmSymbolName n)
+                            " to i64\n"
+                          }
+                          allocLine = concat [U8]
+                          {List U8 |
+                            "  "
+                            dest
+                            "_p = call ptr @trip_alloc_obj(i64 0, i64 1)\n"
+                          }
+                          setLine = concat [U8]
+                          {List U8 |
+                            "  call void @trip_obj_set_field(ptr "
+                            dest
+                            "_p, i64 0, i64 "
+                            dest
+                            "_fn_val)\n"
+                          }
+                          castLine = concat [U8]
+                          {List U8 |
+                            "  "
+                            dest
+                            " = ptrtoint ptr "
+                            dest
+                            "_p to i64\n"
+                          }
+                          lines = append [List U8] {List U8 | castLine setLine allocLine fnPtrLine} instrs
+                          return
+                            Ok
+                            [List U8]
+                            [EmitRes]
+                            (MkEmitRes counter2 lines dest)
+                        }
                     )
                 | Some op =>
                   Ok [List U8] [EmitRes] (MkEmitRes counter instrs op)
@@ -1271,88 +1358,91 @@ poly rec emitExpr =
                                                                 )
                                                                 (
                                                                   \u9 : U8 =>
-                                                                    match (bindGlobalArgs env counter instrs args) [Result (List U8) EmitRes] {
-                                                                        | Err e => Err [List U8] [EmitRes] e
-                                                                        | Ok res =>
-                                                                          match res [Result (List U8) EmitRes] {
-                                                                            | MkBindGlobalArgsRes env1 counter1 instrs1 args1 =>
-                                                                              if [Result (List U8) EmitRes] (startsWithLambda f)
+                                                                    do [Result (List U8) EmitRes] {
+                                                                      res <- (bindGlobalArgs env counter instrs args)
+                                                                      MkBindGlobalArgsRes env1 counter1 instrs1 args1 = res
+                                                                      return
+                                                                      if [Result (List U8) EmitRes] (startsWithLambda f)
+                                                                        (
+                                                                          \u10 : U8 =>
+                                                                            do [Result (List U8) EmitRes] {
+                                                                              argStr <- (emitArgsString env1 args1 true)
+                                                                              dest = append [U8]
+                                                                              "%__ll"
                                                                                 (
-                                                                                  \u10 : U8 =>
-                                                                                    do [Result (List U8) EmitRes] {
-                                                                                      argStr <- (emitArgsString env1 args1 true)
-                                                                                      dest = append [U8] "%__ll" (binToDigits counter1)
-                                                                                      counter2 = incBin counter1
-                                                                                      line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(" argStr ")\n"}
-                                                                                      return
-                                                                                        Ok
+                                                                                  binToDigits
+                                                                                    counter1
+                                                                                )
+                                                                              counter2 = incBin counter1
+                                                                              line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(" argStr ")\n"}
+                                                                              return
+                                                                                Ok
+                                                                                [List U8]
+                                                                                [EmitRes]
+                                                                                (
+                                                                                  MkEmitRes
+                                                                                    counter2
+                                                                                    (
+                                                                                      cons
+                                                                                        [List U8]
+                                                                                        line
+                                                                                        instrs1
+                                                                                    )
+                                                                                    dest
+                                                                                )
+                                                                            }
+                                                                        )
+                                                                        (
+                                                                          \u10 : U8 =>
+                                                                            match (lookupEnv env1 f) [Result (List U8) EmitRes] {
+                                                                              | Some closureOp =>
+                                                                                emitIndirectCallChain
+                                                                                  env1
+                                                                                  counter1
+                                                                                  instrs1
+                                                                                  closureOp
+                                                                                  args1
+                                                                              | None =>
+                                                                                if [Result (List U8) EmitRes] (eqListU8 f "_")
+                                                                                  (
+                                                                                    \u11 : U8 =>
+                                                                                      Err
                                                                                         [List U8]
                                                                                         [EmitRes]
-                                                                                        (
-                                                                                          MkEmitRes
-                                                                                            counter2
-                                                                                            (
-                                                                                              cons
-                                                                                                [List U8]
-                                                                                                line
-                                                                                                instrs1
-                                                                                            )
-                                                                                            dest
-                                                                                        )
-                                                                                    }
-                                                                                )
-                                                                                (
-                                                                                  \u10 : U8 =>
-                                                                                    match (lookupEnv env1 f) [Result (List U8) EmitRes] {
-                                                                                      | Some closureOp =>
-                                                                                        emitIndirectCallChain
-                                                                                          env1
-                                                                                          counter1
-                                                                                          instrs1
-                                                                                          closureOp
-                                                                                          args1
-                                                                                      | None =>
-                                                                                        if [Result (List U8) EmitRes] (eqListU8 f "_")
+                                                                                        "Indirect call to _ not supported without closure variable"
+                                                                                  )
+                                                                                  (
+                                                                                    \u11 : U8 =>
+                                                                                      do [Result (List U8) EmitRes] {
+                                                                                        argStr <- (emitArgsString env1 args1 false)
+                                                                                        dest = append [U8]
+                                                                                        "%__ll"
                                                                                           (
-                                                                                            \u11 : U8 =>
-                                                                                              Err
-                                                                                                [List U8]
-                                                                                                [EmitRes]
-                                                                                                "Indirect call to _ not supported without closure variable"
+                                                                                            binToDigits
+                                                                                              counter1
                                                                                           )
+                                                                                        counter2 = incBin counter1
+                                                                                        line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(i64 0" argStr ")\n"}
+                                                                                        return
+                                                                                          Ok
+                                                                                          [List U8]
+                                                                                          [EmitRes]
                                                                                           (
-                                                                                            \u11 : U8 =>
-                                                                                              do [Result (List U8) EmitRes] {
-                                                                                                argStr <- (emitArgsString env1 args1 false)
-                                                                                                dest = append [U8]
-                                                                                                  "%__ll"
-                                                                                                  (
-                                                                                                    binToDigits
-                                                                                                      counter1
-                                                                                                  )
-                                                                                                counter2 = incBin counter1
-                                                                                                line = concat [U8] {List U8 | "  " dest " = call i64 @" (llvmSymbolName f) "(i64 0" argStr ")\n"}
-                                                                                                return
-                                                                                                  Ok
+                                                                                            MkEmitRes
+                                                                                              counter2
+                                                                                              (
+                                                                                                cons
                                                                                                   [List U8]
-                                                                                                  [EmitRes]
-                                                                                                  (
-                                                                                                    MkEmitRes
-                                                                                                      counter2
-                                                                                                      (
-                                                                                                        cons
-                                                                                                          [List U8]
-                                                                                                          line
-                                                                                                          instrs1
-                                                                                                      )
-                                                                                                      dest
-                                                                                                  )
-                                                                                              }
+                                                                                                  line
+                                                                                                  instrs1
+                                                                                              )
+                                                                                              dest
                                                                                           )
-                                                                                    }
-                                                                                )
-                                                                          }
-                                                                      }
+                                                                                      }
+                                                                                  )
+                                                                            }
+                                                                        )
+                                                                    }
                                                                 )
                                                           )
                                                     )
@@ -1363,18 +1453,26 @@ poly rec emitExpr =
                       )
                 )
             | AE_Con tag total arity args =>
-              match (bindGlobalArgs env counter instrs args) [Result (List U8) EmitRes] {
-                | Err e => Err [List U8] [EmitRes] e
-                | Ok res =>
-                  match res [Result (List U8) EmitRes] {
-                    | MkBindGlobalArgsRes env1 counter1 instrs1 args1 =>
-                      let dest = append [U8] "%__ll" (binToDigits counter1) in
-                      let counter2 = incBin counter1 in
-                      let allocLine = concat [U8] {List U8 | "  " dest "_p = call ptr @trip_alloc_obj(i64 " (u8ToDigits tag) ", i64 " (u8ToDigits arity) ")\n"} in
-                      let castLine = concat [U8] {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"} in
-                      let initialInstrs = append [List U8] {List U8 | castLine allocLine} instrs1 in
-                      emitCtorFields env1 counter2 initialInstrs dest arity args1 #u8(0)
-                  }
+              do [Result (List U8) EmitRes] {
+                res <- (bindGlobalArgs env counter instrs args)
+                MkBindGlobalArgsRes env1 counter1 instrs1 args1 = res
+                dest = append [U8]
+                "%__ll" (binToDigits counter1)
+                counter2 = incBin counter1
+                allocLine = concat [U8]
+                {List U8 |
+                  "  "
+                  dest
+                  "_p = call ptr @trip_alloc_obj(i64 "
+                  (u8ToDigits tag)
+                  ", i64 "
+                  (u8ToDigits arity)
+                  ")\n"
+                }
+                castLine = concat [U8]
+                {List U8 | "  " dest " = ptrtoint ptr " dest "_p to i64\n"}
+                initialInstrs = append [List U8] {List U8 | castLine allocLine} instrs1
+                return emitCtorFields env1 counter2 initialInstrs dest arity args1 #u8(0)
               }
             | AE_Case scrut arms =>
               do [Result (List U8) EmitRes] {
@@ -1584,12 +1682,13 @@ poly emitFunc =
     do [Result (List U8) (List U8)] {
       MkAnfFunc name params body = fn
       paramsWithEnv =
-        if [List (List U8)] (startsWithLambda name)
-          (\u : U8 => params)
-          (\u : U8 => cons [List U8] "dummy_env" params)
+      if [List (List U8)] (startsWithLambda name)
+        (\u : U8 => params)
+        (\u : U8 => cons [List U8] "dummy_env" params)
       return
-        match (emitExpr (paramEnv paramsWithEnv) BZ {List U8 |} body) [Result (List U8) (List U8)] {
-        | Err e => Err [List U8] [List U8] (concat [U8] {List U8 | "[fn " name "] " e})
+      match (emitExpr (paramEnv paramsWithEnv) BZ {List U8 |} body) [Result (List U8) (List U8)] {
+        | Err e =>
+          Err [List U8] [List U8] (concat [U8] {List U8 | "[fn " name "] " e})
         | Ok res =>
           do [Result (List U8) (List U8)] {
             MkEmitRes c instrs op = res
@@ -1628,18 +1727,17 @@ poly rec emitFuncsAcc =
         (
           \h : AnfFunc =>
             \t : List AnfFunc =>
-              match (emitFunc h) [Result (List U8) (List (List U8))] {
-                | Err e => Err [List U8] [List (List U8)] e
-                | Ok block =>
-                  (emitFuncsAcc (cons [List U8] block acc) t)
+              do [Result (List U8) (List (List U8))] {
+                block <- (emitFunc h)
+                return emitFuncsAcc (cons [List U8] block acc) t
               }
         )
 
 poly emitFuncs =
   \fns : List AnfFunc =>
-    match (emitFuncsAcc {List U8 |} fns) [Result (List U8) (List U8)] {
-      | Err e => Err [List U8] [List U8] e
-      | Ok blocks => Ok [List U8] [List U8] (joinLines "" blocks)
+    do [Result (List U8) (List U8)] {
+      blocks <- (emitFuncsAcc {List U8 |} fns)
+      return Ok [List U8] [List U8] (joinLines "" blocks)
     }
 
 poly emitProgram =
@@ -1697,10 +1795,7 @@ poly rec funcsUseReadWrite =
         \h : AnfFunc =>
           \t : List AnfFunc =>
             match h [Bool] {
-              | MkAnfFunc name params body =>
-                if [Bool] (exprUsesReadWrite body)
-                  (\u : U8 => true)
-                  (\u : U8 => funcsUseReadWrite t)
+              | MkAnfFunc name params body => or (exprUsesReadWrite body) (funcsUseReadWrite t)
             }
       )
 
@@ -1739,10 +1834,7 @@ poly rec funcsUseBoxed =
         \h : AnfFunc =>
           \t : List AnfFunc =>
             match h [Bool] {
-              | MkAnfFunc name params body =>
-                if [Bool] (exprUsesBoxed body)
-                  (\u : U8 => true)
-                  (\u : U8 => funcsUseBoxed t)
+              | MkAnfFunc name params body => or (exprUsesBoxed body) (funcsUseBoxed t)
             }
       )
 

--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -46,11 +46,11 @@ import Prelude eqU8
 
 import Prelude ltU8
 
-import Avl empty
+import DataEnv BridgeAvl
 
-import Avl lookup
+import DataEnv Empty
 
-import Avl insert
+import DataEnv Node
 
 import Parser Expr
 
@@ -363,10 +363,192 @@ poly natToCore =
               (\u : U8 => Ok [List U8] [Core] (buildBinLiteralCore trimmed))
       )
 
+poly height =
+  #V =>
+    \t : BridgeAvl V =>
+      match t [U8] {
+        | Empty => #u8(0)
+        | Node _ _ _ h _ => h
+      }
+
+poly maxU8 =
+  \a : U8 =>
+    \b : U8 =>
+      if [U8] (ltU8 a b) (\u : Bin => b) (\u : Bin => a)
+
+poly gtU8 =
+  \a : U8 =>
+    \b : U8 =>
+      ltU8 b a
+
+poly lteU8 =
+  \a : U8 =>
+    \b : U8 =>
+      or (ltU8 a b) (eqU8 a b)
+
+poly mkNode =
+  #V =>
+    \l : BridgeAvl V =>
+      \k : List U8 =>
+        \v : V =>
+          \r : BridgeAvl V =>
+            Node
+              [V]
+              l
+              k
+              v
+              (addU8 (maxU8 (height [V] l) (height [V] r)) #u8(1))
+              r
+
+poly rotateLeft =
+  #V =>
+    \t : BridgeAvl V =>
+      match t [BridgeAvl V] {
+        | Empty => Empty [V]
+        | Node l k v _ r =>
+          match r [BridgeAvl V] {
+            | Empty => mkNode [V] l k v r
+            | Node rl rk rv _ rr => mkNode [V] (mkNode [V] l k v rl) rk rv rr
+          }
+      }
+
+poly rotateRight =
+  #V =>
+    \t : BridgeAvl V =>
+      match t [BridgeAvl V] {
+        | Empty => Empty [V]
+        | Node l k v _ r =>
+          match l [BridgeAvl V] {
+            | Empty => mkNode [V] l k v r
+            | Node ll lk lv _ lr => mkNode [V] ll lk lv (mkNode [V] lr k v r)
+          }
+      }
+
+poly balance =
+  #V =>
+    \t : BridgeAvl V =>
+      match t [BridgeAvl V] {
+        | Empty => Empty [V]
+        | Node l k v _ r =>
+          let hl = height [V] l in
+          let hr = height [V] r in
+          if [BridgeAvl V] (gtU8 hl (addU8 hr #u8(1)))
+            (
+              \u : Bin =>
+                match l [BridgeAvl V] {
+                  | Empty => mkNode [V] l k v r
+                  | Node ll _ _ _ lr =>
+                    if [BridgeAvl V] (lteU8 (height [V] lr) (height [V] ll))
+                      (
+                        \u : Bin => rotateRight [V] (mkNode [V] l k v r)
+                      )
+                      (
+                        \u : Bin =>
+                          rotateRight
+                            [V]
+                            (mkNode [V] (rotateLeft [V] l) k v r)
+                      )
+                }
+            )
+            (
+              \u : Bin =>
+                if [BridgeAvl V] (gtU8 hr (addU8 hl #u8(1)))
+                  (
+                    \u : Bin =>
+                      match r [BridgeAvl V] {
+                        | Empty => mkNode [V] l k v r
+                        | Node rl _ _ _ rr =>
+                          if [BridgeAvl V] (lteU8 (height [V] rl) (height [V] rr))
+                            (
+                              \u : Bin => rotateLeft [V] (mkNode [V] l k v r)
+                            )
+                            (
+                              \u : Bin =>
+                                rotateLeft
+                                  [V]
+                                  (
+                                    mkNode
+                                      [V]
+                                      l
+                                      k
+                                      v
+                                      (rotateRight [V] r)
+                                  )
+                            )
+                      }
+                  )
+                  (\u : Bin => mkNode [V] l k v r)
+            )
+      }
+
+poly rec bridgeAvlLookup =
+  #V =>
+    \key : List U8 =>
+      \t : BridgeAvl V =>
+        match t [Maybe V] {
+          | Empty => None [V]
+          | Node l nk nv _ r =>
+            let le = lteListU8 key nk in
+            let ge = lteListU8 nk key in
+            if [Maybe V] (and le ge)
+              (\u : Bin => Some [V] nv)
+              (
+                \u : Bin =>
+                  if [Maybe V] le
+                    (\u : Bin => bridgeAvlLookup [V] key l)
+                    (\u : Bin => bridgeAvlLookup [V] key r)
+              )
+        }
+
+poly rec bridgeAvlInsert =
+  #V =>
+    \key : List U8 =>
+      \value : V =>
+        \t : BridgeAvl V =>
+          match t [BridgeAvl V] {
+            | Empty =>
+              mkNode [V] (Empty [V]) key value (Empty [V])
+            | Node l nk nv _ r =>
+              let le = lteListU8 key nk in
+              let ge = lteListU8 nk key in
+              if [BridgeAvl V] (and le ge)
+                (\u : Bin => mkNode [V] l nk value r)
+                (
+                  \u : Bin =>
+                    if [BridgeAvl V] le
+                      (
+                        \u : Bin =>
+                          balance
+                            [V]
+                            (
+                              mkNode
+                                [V]
+                                (bridgeAvlInsert [V] key value l)
+                                nk
+                                nv
+                                r
+                            )
+                      )
+                      (
+                        \u : Bin =>
+                          balance
+                            [V]
+                            (
+                              mkNode
+                                [V]
+                                l
+                                nk
+                                nv
+                                (bridgeAvlInsert [V] key value r)
+                            )
+                      )
+                )
+          }
+
 poly resolveCoreName =
   \dEnv : DataEnv =>
     \name : List U8 =>
-      match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Core] {
+      match (bridgeAvlLookup [CtorInfo] name (datEnvCtors dEnv)) [Core] {
         | Some info =>
           Cr_Ctor (ctorTag info) (ctorTotal info) (ctorArity info)
         | None => Cr_Var name
@@ -386,7 +568,7 @@ poly rec findCtorInfoInArms =
               do [Maybe CtorInfo] {
                 P_Ctor name args = (fst [Pattern] [Expr] h)
                 return
-                match (lookup [List U8] [CtorInfo] lteListU8 name (datEnvCtors dEnv)) [Maybe CtorInfo] {
+                match (bridgeAvlLookup [CtorInfo] name (datEnvCtors dEnv)) [Maybe CtorInfo] {
                   | Some info => Some [CtorInfo] info
                   | None => findCtorInfoInArms dEnv t
                 }
@@ -438,26 +620,25 @@ poly rec wrapInLambdas =
         (\h : List U8 => \t : List (List U8) => Cr_Lam h (wrapInLambdas t body))
 
 poly rec elaborateArms =
-  \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
-    \dEnv : DataEnv =>
-      \arms : List (Pattern, Expr) =>
-        matchList
-          [(Pattern, Expr)]
-          [Result (List U8) (List Core)]
-          arms
-          (Ok [List U8] [List Core] {Core |})
-          (
-            \h : (Pattern, Expr) =>
-              \t : List (Pattern, Expr) =>
-                do [Result (List U8) (List Core)] {
-                  MkPair pat body = h
-                  P_Ctor name args = pat
-                  coreBody <- (elaborate dEnv body)
-                  wrapped = wrapInLambdas args coreBody
-                  rest <- (elaborateArms elaborate dEnv t)
-                  return Ok [List U8] [List Core] (cons [Core] wrapped rest)
-                }
-          )
+  \dEnv : DataEnv =>
+    \arms : List (Pattern, Expr) =>
+      matchList
+        [(Pattern, Expr)]
+        [Result (List U8) (List Core)]
+        arms
+        (Ok [List U8] [List Core] {Core |})
+        (
+          \h : (Pattern, Expr) =>
+            \t : List (Pattern, Expr) =>
+              do [Result (List U8) (List Core)] {
+                MkPair pat body = h
+                P_Ctor name args = pat
+                coreBody <- (elaborateExpr dEnv body)
+                wrapped = wrapInLambdas args coreBody
+                rest <- (elaborateArms dEnv t)
+                return Ok [List U8] [List Core] (cons [Core] wrapped rest)
+              }
+        )
 
 poly rec lengthList =
   #A =>
@@ -510,7 +691,7 @@ poly rec validateEachArm =
                   )
                   (
                     \u : U8 =>
-                      match (lookup [List U8] [CtorInfo] lteListU8 cName (datEnvCtors dEnv)) [Result (List U8) Bool] {
+                      match (bridgeAvlLookup [CtorInfo] cName (datEnvCtors dEnv)) [Result (List U8) Bool] {
                         | None =>
                           Err [List U8] [Bool] "Constructor metadata not found"
                         | Some info =>
@@ -552,43 +733,42 @@ poly rec validateExhaustiveness =
         )
 
 poly elaborateMatchWith =
-  \elaborate : DataEnv -> Expr -> Result (List U8) Core =>
-    \dEnv : DataEnv =>
-      \scrut : Expr =>
-        \arms : List (Pattern, Expr) =>
-          do [Result (List U8) Core] {
-            coreScrut <- (elaborate dEnv scrut)
-            return
-            match (findCtorInfoInArms dEnv arms) [Result (List U8) Core] {
-              | None =>
-                let firstCtorName = match (fst [Pattern] [Expr] (matchList [(Pattern, Expr)] [(Pattern, Expr)] arms {Pattern, Expr | (P_Ctor "NO_ARMS" {List U8 |}), (E_Var "dummy")} (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => h))) [List U8] { | P_Ctor cn args => cn} in
-                Err
-                  [List U8]
-                  [Core]
-                  (
-                    concat
-                      [U8]
-                      {List U8 |
-                        "Could not identify ADT for match: "
-                        firstCtorName
-                      }
-                  )
-              | Some info =>
-                let adtName = ctorAdtName info in
-                match (lookup [List U8] [ADTInfo] lteListU8 adtName (datEnvAdts dEnv)) [Result (List U8) Core] {
-                  | None => Err [List U8] [Core] "ADT metadata not found"
-                  | Some adtInfo =>
-                    let expectedNames = adtCtors adtInfo in
-                    do [Result (List U8) Core] {
-                      valEach <- (validateEachArm dEnv expectedNames arms)
-                      valExhaustive <- (validateExhaustiveness expectedNames arms)
-                      sortedArms = sortArms expectedNames arms
-                      coreArms <- (elaborateArms elaborate dEnv sortedArms)
-                      return Ok [List U8] [Core] (Cr_Match coreScrut coreArms)
+  \dEnv : DataEnv =>
+    \scrut : Expr =>
+      \arms : List (Pattern, Expr) =>
+        do [Result (List U8) Core] {
+          coreScrut <- (elaborateExpr dEnv scrut)
+          return
+          match (findCtorInfoInArms dEnv arms) [Result (List U8) Core] {
+            | None =>
+              let firstCtorName = match (fst [Pattern] [Expr] (matchList [(Pattern, Expr)] [(Pattern, Expr)] arms {Pattern, Expr | (P_Ctor "NO_ARMS" {List U8 |}), (E_Var "dummy")} (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => h))) [List U8] { | P_Ctor cn args => cn} in
+              Err
+                [List U8]
+                [Core]
+                (
+                  concat
+                    [U8]
+                    {List U8 |
+                      "Could not identify ADT for match: "
+                      firstCtorName
                     }
-                }
-            }
+                )
+            | Some info =>
+              let adtName = ctorAdtName info in
+              match (bridgeAvlLookup [ADTInfo] adtName (datEnvAdts dEnv)) [Result (List U8) Core] {
+                | None => Err [List U8] [Core] "ADT metadata not found"
+                | Some adtInfo =>
+                  let expectedNames = adtCtors adtInfo in
+                  do [Result (List U8) Core] {
+                    valEach <- (validateEachArm dEnv expectedNames arms)
+                    valExhaustive <- (validateExhaustiveness expectedNames arms)
+                    sortedArms = sortArms expectedNames arms
+                    coreArms <- (elaborateArms dEnv sortedArms)
+                    return Ok [List U8] [Core] (Cr_Match coreScrut coreArms)
+                  }
+              }
           }
+        }
 
 poly rec elaborateExpr =
   \dEnv : DataEnv =>
@@ -613,7 +793,7 @@ poly rec elaborateExpr =
             return Ok [List U8] [Core] (Cr_App (Cr_Lam name coreBody) coreVal)
           }
         | E_Nat digits => natToCore digits
-        | E_Match scrut arms => elaborateMatchWith elaborateExpr dEnv scrut arms
+        | E_Match scrut arms => elaborateMatchWith dEnv scrut arms
       }
 
 poly ctorCountOverflowError =
@@ -655,7 +835,7 @@ poly rec populateDataEnv =
                     let info = MkCtorInfo idx total arity adtName in
                     match datEnv [DataEnv] {
                       | MkDataEnv cEnv aEnv =>
-                        let nextDatEnv = MkDataEnv (insert [List U8] [CtorInfo] lteListU8 ctorName info cEnv) aEnv in
+                        let nextDatEnv = MkDataEnv (bridgeAvlInsert [CtorInfo] ctorName info cEnv) aEnv in
                         populateDataEnv
                           adtName
                           t
@@ -733,7 +913,7 @@ poly rec elaborateToCoreRec =
                     do [Result (List U8) (List ((List U8), Core))] {
                       MkDataEnv cEnv aEnv = (populateDataEnv name ctors total #u8(0) dEnv)
                       adtInfo =
-                      MkADTInfo (getCtorNames ctors) nextDEnv = MkDataEnv cEnv (insert [List U8] [ADTInfo] lteListU8 name adtInfo aEnv)
+                      MkADTInfo (getCtorNames ctors) nextDEnv = MkDataEnv cEnv (bridgeAvlInsert [ADTInfo] name adtInfo aEnv)
                       return elaborateToCoreRec nextDEnv t
                     }
                   }
@@ -747,14 +927,14 @@ poly rec elaborateToCoreRec =
         )
 
 poly seededDataEnv =
-  let c0 = empty [List U8] [CtorInfo] in
-  let c1 = insert [List U8] [CtorInfo] lteListU8 "Prelude.false" (MkCtorInfo #u8(0) #u8(2) #u8(0) "Prelude.Bool") c0 in
-  let c2 = insert [List U8] [CtorInfo] lteListU8 "Prelude.true" (MkCtorInfo #u8(1) #u8(2) #u8(0) "Prelude.Bool") c1 in
-  let c3 = insert [List U8] [CtorInfo] lteListU8 "Prelude.nil" (MkCtorInfo #u8(0) #u8(2) #u8(0) "Prelude.List") c2 in
-  let c4 = insert [List U8] [CtorInfo] lteListU8 "Prelude.cons" (MkCtorInfo #u8(1) #u8(2) #u8(2) "Prelude.List") c3 in
-  let a0 = empty [List U8] [ADTInfo] in
-  let a1 = insert [List U8] [ADTInfo] lteListU8 "Prelude.Bool" (MkADTInfo {List U8 | "Prelude.false" "Prelude.true"}) a0 in
-  let a2 = insert [List U8] [ADTInfo] lteListU8 "Prelude.List" (MkADTInfo {List U8 | "Prelude.nil" "Prelude.cons"}) a1 in
+  let c0 = Empty [CtorInfo] in
+  let c1 = bridgeAvlInsert [CtorInfo] "Prelude.false" (MkCtorInfo #u8(0) #u8(2) #u8(0) "Prelude.Bool") c0 in
+  let c2 = bridgeAvlInsert [CtorInfo] "Prelude.true" (MkCtorInfo #u8(1) #u8(2) #u8(0) "Prelude.Bool") c1 in
+  let c3 = bridgeAvlInsert [CtorInfo] "Prelude.nil" (MkCtorInfo #u8(0) #u8(2) #u8(0) "Prelude.List") c2 in
+  let c4 = bridgeAvlInsert [CtorInfo] "Prelude.cons" (MkCtorInfo #u8(1) #u8(2) #u8(2) "Prelude.List") c3 in
+  let a0 = Empty [ADTInfo] in
+  let a1 = bridgeAvlInsert [ADTInfo] "Prelude.Bool" (MkADTInfo {List U8 | "Prelude.false" "Prelude.true"}) a0 in
+  let a2 = bridgeAvlInsert [ADTInfo] "Prelude.List" (MkADTInfo {List U8 | "Prelude.nil" "Prelude.cons"}) a1 in
   MkDataEnv c4 a2
 
 poly elaborateProgramToCore =

--- a/bootstrap/src/bridge.trip
+++ b/bootstrap/src/bridge.trip
@@ -374,17 +374,15 @@ poly height =
 poly maxU8 =
   \a : U8 =>
     \b : U8 =>
-      if [U8] (ltU8 a b) (\u : Bin => b) (\u : Bin => a)
+      if [U8] (ltU8 a b)
+        (\u : Bin => b)
+        (\u : Bin => a)
 
 poly gtU8 =
-  \a : U8 =>
-    \b : U8 =>
-      ltU8 b a
+  \a : U8 => \b : U8 => ltU8 b a
 
 poly lteU8 =
-  \a : U8 =>
-    \b : U8 =>
-      or (ltU8 a b) (eqU8 a b)
+  \a : U8 => \b : U8 => or (ltU8 a b) (eqU8 a b)
 
 poly mkNode =
   #V =>
@@ -439,14 +437,9 @@ poly balance =
                   | Empty => mkNode [V] l k v r
                   | Node ll _ _ _ lr =>
                     if [BridgeAvl V] (lteU8 (height [V] lr) (height [V] ll))
+                      (\u : Bin => rotateRight [V] (mkNode [V] l k v r))
                       (
-                        \u : Bin => rotateRight [V] (mkNode [V] l k v r)
-                      )
-                      (
-                        \u : Bin =>
-                          rotateRight
-                            [V]
-                            (mkNode [V] (rotateLeft [V] l) k v r)
+                        \u : Bin => rotateRight [V] (mkNode [V] (rotateLeft [V] l) k v r)
                       )
                 }
             )
@@ -459,21 +452,9 @@ poly balance =
                         | Empty => mkNode [V] l k v r
                         | Node rl _ _ _ rr =>
                           if [BridgeAvl V] (lteU8 (height [V] rl) (height [V] rr))
+                            (\u : Bin => rotateLeft [V] (mkNode [V] l k v r))
                             (
-                              \u : Bin => rotateLeft [V] (mkNode [V] l k v r)
-                            )
-                            (
-                              \u : Bin =>
-                                rotateLeft
-                                  [V]
-                                  (
-                                    mkNode
-                                      [V]
-                                      l
-                                      k
-                                      v
-                                      (rotateRight [V] r)
-                                  )
+                              \u : Bin => rotateLeft [V] (mkNode [V] l k v (rotateRight [V] r))
                             )
                       }
                   )
@@ -506,8 +487,7 @@ poly rec bridgeAvlInsert =
       \value : V =>
         \t : BridgeAvl V =>
           match t [BridgeAvl V] {
-            | Empty =>
-              mkNode [V] (Empty [V]) key value (Empty [V])
+            | Empty => mkNode [V] (Empty [V]) key value (Empty [V])
             | Node l nk nv _ r =>
               let le = lteListU8 key nk in
               let ge = lteListU8 nk key in
@@ -664,7 +644,7 @@ poly rec isNameInList =
 poly rec countNameInArms =
   \name : List U8 =>
     \arms : List (Pattern, Expr) =>
-      matchList [(Pattern, Expr)] [U8] arms #u8(0) (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => let pat = fst [Pattern] [Expr] h in let cName = match pat [List U8] { | P_Ctor cn args => cn} in let restCount = countNameInArms name t in if [U8] (eqListU8 cName name) (\u : U8 => addU8 #u8(1) restCount) (\u : U8 => restCount))
+      matchList [(Pattern, Expr)] [U8] arms #u8(0) (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => let pat = fst [Pattern] [Expr] h in let cName = match pat [List U8] {| P_Ctor cn args => cn} in let restCount = countNameInArms name t in if [U8] (eqListU8 cName name) (\u : U8 => addU8 #u8(1) restCount) (\u : U8 => restCount))
 
 poly rec validateEachArm =
   \dEnv : DataEnv =>
@@ -679,8 +659,8 @@ poly rec validateEachArm =
             \h : (Pattern, Expr) =>
               \t : List (Pattern, Expr) =>
                 let pat = fst [Pattern] [Expr] h in
-                let cName = match pat [List U8] { | P_Ctor cn args => cn} in
-                let args = match pat [List (List U8)] { | P_Ctor cn args => args} in
+                let cName = match pat [List U8] {| P_Ctor cn args => cn} in
+                let args = match pat [List (List U8)] {| P_Ctor cn args => args} in
                 if [Result (List U8) Bool] (not (isNameInList cName expectedNames))
                   (
                     \u : U8 =>
@@ -741,7 +721,7 @@ poly elaborateMatchWith =
           return
           match (findCtorInfoInArms dEnv arms) [Result (List U8) Core] {
             | None =>
-              let firstCtorName = match (fst [Pattern] [Expr] (matchList [(Pattern, Expr)] [(Pattern, Expr)] arms {Pattern, Expr | (P_Ctor "NO_ARMS" {List U8 |}), (E_Var "dummy")} (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => h))) [List U8] { | P_Ctor cn args => cn} in
+              let firstCtorName = match (fst [Pattern] [Expr] (matchList [(Pattern, Expr)] [(Pattern, Expr)] arms {Pattern, Expr | (P_Ctor "NO_ARMS" {List U8 |}), (E_Var "dummy")} (\h : (Pattern, Expr) => \t : List (Pattern, Expr) => h))) [List U8] {| P_Ctor cn args => cn} in
               Err
                 [List U8]
                 [Core]
@@ -939,6 +919,4 @@ poly seededDataEnv =
 
 poly elaborateProgramToCore =
   \decls : List Decl =>
-    elaborateToCoreRec
-      seededDataEnv
-      (filterElaboratableDecls decls)
+    elaborateToCoreRec seededDataEnv (filterElaboratableDecls decls)

--- a/bootstrap/src/bundleSummary.trip
+++ b/bootstrap/src/bundleSummary.trip
@@ -541,7 +541,10 @@ poly parseBundleSummary =
     do [Result (List U8) BundleSummary] {
       magicRes <- readLine input
       MkLine magic afterMagic = magicRes
-      assert (eqListU8 magic "TRIP-BUNDLE-V1") else (append [U8] "bad magic: " magic)
+      assert
+        (eqListU8 magic "TRIP-BUNDLE-V1")
+        else
+        (append [U8] "bad magic: " magic)
       entryLineRes <- readLine afterMagic
       MkLine entryLine afterEntry = entryLineRes
       entry <- requireEntry entryLine

--- a/bootstrap/src/bundleSummary.trip
+++ b/bootstrap/src/bundleSummary.trip
@@ -541,7 +541,7 @@ poly parseBundleSummary =
     do [Result (List U8) BundleSummary] {
       magicRes <- readLine input
       MkLine magic afterMagic = magicRes
-      assert (eqListU8 magic "TRIP-BUNDLE-V1") else "bad magic"
+      assert (eqListU8 magic "TRIP-BUNDLE-V1") else (append [U8] "bad magic: " magic)
       entryLineRes <- readLine afterMagic
       MkLine entryLine afterEntry = entryLineRes
       entry <- requireEntry entryLine

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -130,7 +130,9 @@ poly rec applyAnon =
 
 poly nameIsMatchList =
   \n : List U8 =>
-    if [Bool] (eqListU8 n "Prelude.matchList") (\u : U8 => true) (\u : U8 => eqListU8 n "matchList")
+    if [Bool] (eqListU8 n "Prelude.matchList")
+      (\u : U8 => true)
+      (\u : U8 => eqListU8 n "matchList")
 
 -- matchList is a Prelude function over the Scott encoding, but the back end
 -- boxes List. Lower a saturated `matchList l onNil onCons` to a boxed case:
@@ -169,14 +171,18 @@ poly matchListIntrinsicOr =
                                 [MiniExpr]
                                 r2
                                 (ME_Match l {MiniExpr | onNil onCons})
-                                (\x : MiniExpr => \xs : List MiniExpr => fallback)
+                                (
+                                  \x : MiniExpr => \xs : List MiniExpr => fallback
+                                )
                         )
                 )
         )
 
 poly nameIsIf =
   \n : List U8 =>
-    if [Bool] (eqListU8 n "Prelude.if") (\u : U8 => true) (\u : U8 => eqListU8 n "if")
+    if [Bool] (eqListU8 n "Prelude.if")
+      (\u : U8 => true)
+      (\u : U8 => eqListU8 n "if")
 
 poly peelMiniIfBranch =
   \branch : MiniExpr =>
@@ -221,15 +227,26 @@ poly ifIntrinsicOr =
                                 [MiniExpr]
                                 [MiniExpr]
                                 r2
-                                (ME_Match c {MiniExpr | (peelMiniIfBranch elseBranch) (peelMiniIfBranch thenBranch)})
-                                (\x : MiniExpr => \xs : List MiniExpr => fallback)
+                                (
+                                  ME_Match
+                                    c
+                                    {MiniExpr |
+                                      (peelMiniIfBranch elseBranch)
+                                      (peelMiniIfBranch thenBranch)
+                                    }
+                                )
+                                (
+                                  \x : MiniExpr => \xs : List MiniExpr => fallback
+                                )
                         )
                 )
         )
 
 poly nameIsAnd =
   \n : List U8 =>
-    if [Bool] (eqListU8 n "Prelude.and") (\u : U8 => true) (\u : U8 => eqListU8 n "and")
+    if [Bool] (eqListU8 n "Prelude.and")
+      (\u : U8 => true)
+      (\u : U8 => eqListU8 n "and")
 
 poly andIntrinsicOr =
   \miniArgs : List MiniExpr =>
@@ -254,14 +271,23 @@ poly andIntrinsicOr =
                         [MiniExpr]
                         [MiniExpr]
                         r1
-                        (ME_Match a {MiniExpr | (ME_Con #u8(0) #u8(2) #u8(0) {MiniExpr |}) b})
+                        (
+                          ME_Match
+                            a
+                            {MiniExpr |
+                              (ME_Con #u8(0) #u8(2) #u8(0) {MiniExpr |})
+                              b
+                            }
+                        )
                         (\x : MiniExpr => \xs : List MiniExpr => fallback)
                 )
         )
 
 poly nameIsOr =
   \n : List U8 =>
-    if [Bool] (eqListU8 n "Prelude.or") (\u : U8 => true) (\u : U8 => eqListU8 n "or")
+    if [Bool] (eqListU8 n "Prelude.or")
+      (\u : U8 => true)
+      (\u : U8 => eqListU8 n "or")
 
 poly orIntrinsicOr =
   \miniArgs : List MiniExpr =>
@@ -286,7 +312,14 @@ poly orIntrinsicOr =
                         [MiniExpr]
                         [MiniExpr]
                         r1
-                        (ME_Match a {MiniExpr | b (ME_Con #u8(1) #u8(2) #u8(0) {MiniExpr |})})
+                        (
+                          ME_Match
+                            a
+                            {MiniExpr |
+                              b
+                              (ME_Con #u8(1) #u8(2) #u8(0) {MiniExpr |})
+                            }
+                        )
                         (\x : MiniExpr => \xs : List MiniExpr => fallback)
                 )
         )
@@ -310,19 +343,27 @@ poly rec coreToMini =
             match head [MiniExpr] {
               | Cr_Var name =>
                 if [MiniExpr] (nameIsMatchList name)
-                  (\u : U8 => matchListIntrinsicOr miniArgs (ME_Call name miniArgs))
+                  (
+                    \u : U8 => matchListIntrinsicOr miniArgs (ME_Call name miniArgs)
+                  )
                   (
                     \u : U8 =>
                       if [MiniExpr] (nameIsIf name)
-                        (\u2 : U8 => ifIntrinsicOr miniArgs (ME_Call name miniArgs))
+                        (
+                          \u2 : U8 => ifIntrinsicOr miniArgs (ME_Call name miniArgs)
+                        )
                         (
                           \u2 : U8 =>
                             if [MiniExpr] (nameIsAnd name)
-                              (\u3 : U8 => andIntrinsicOr miniArgs (ME_Call name miniArgs))
+                              (
+                                \u3 : U8 => andIntrinsicOr miniArgs (ME_Call name miniArgs)
+                              )
                               (
                                 \u3 : U8 =>
                                   if [MiniExpr] (nameIsOr name)
-                                    (\u4 : U8 => orIntrinsicOr miniArgs (ME_Call name miniArgs))
+                                    (
+                                      \u4 : U8 => orIntrinsicOr miniArgs (ME_Call name miniArgs)
+                                    )
                                     (\u4 : U8 => ME_Call name miniArgs)
                               )
                         )

--- a/bootstrap/src/coreToMini.trip
+++ b/bootstrap/src/coreToMini.trip
@@ -174,6 +174,123 @@ poly matchListIntrinsicOr =
                 )
         )
 
+poly nameIsIf =
+  \n : List U8 =>
+    if [Bool] (eqListU8 n "Prelude.if") (\u : U8 => true) (\u : U8 => eqListU8 n "if")
+
+poly peelMiniIfBranch =
+  \branch : MiniExpr =>
+    match branch [MiniExpr] {
+      | ME_Lam name body => body
+      | ME_Var name => branch
+      | ME_Call f args => branch
+      | ME_Con tag total arity fields => branch
+      | ME_Let name val body => branch
+      | ME_Native t => branch
+      | ME_Match scrut arms => branch
+    }
+
+poly ifIntrinsicOr =
+  \miniArgs : List MiniExpr =>
+    \fallback : MiniExpr =>
+      matchList
+        [MiniExpr]
+        [MiniExpr]
+        miniArgs
+        fallback
+        (
+          \c : MiniExpr =>
+            \r0 : List MiniExpr =>
+              matchList
+                [MiniExpr]
+                [MiniExpr]
+                r0
+                fallback
+                (
+                  \thenBranch : MiniExpr =>
+                    \r1 : List MiniExpr =>
+                      matchList
+                        [MiniExpr]
+                        [MiniExpr]
+                        r1
+                        fallback
+                        (
+                          \elseBranch : MiniExpr =>
+                            \r2 : List MiniExpr =>
+                              matchList
+                                [MiniExpr]
+                                [MiniExpr]
+                                r2
+                                (ME_Match c {MiniExpr | (peelMiniIfBranch elseBranch) (peelMiniIfBranch thenBranch)})
+                                (\x : MiniExpr => \xs : List MiniExpr => fallback)
+                        )
+                )
+        )
+
+poly nameIsAnd =
+  \n : List U8 =>
+    if [Bool] (eqListU8 n "Prelude.and") (\u : U8 => true) (\u : U8 => eqListU8 n "and")
+
+poly andIntrinsicOr =
+  \miniArgs : List MiniExpr =>
+    \fallback : MiniExpr =>
+      matchList
+        [MiniExpr]
+        [MiniExpr]
+        miniArgs
+        fallback
+        (
+          \a : MiniExpr =>
+            \r0 : List MiniExpr =>
+              matchList
+                [MiniExpr]
+                [MiniExpr]
+                r0
+                fallback
+                (
+                  \b : MiniExpr =>
+                    \r1 : List MiniExpr =>
+                      matchList
+                        [MiniExpr]
+                        [MiniExpr]
+                        r1
+                        (ME_Match a {MiniExpr | (ME_Con #u8(0) #u8(2) #u8(0) {MiniExpr |}) b})
+                        (\x : MiniExpr => \xs : List MiniExpr => fallback)
+                )
+        )
+
+poly nameIsOr =
+  \n : List U8 =>
+    if [Bool] (eqListU8 n "Prelude.or") (\u : U8 => true) (\u : U8 => eqListU8 n "or")
+
+poly orIntrinsicOr =
+  \miniArgs : List MiniExpr =>
+    \fallback : MiniExpr =>
+      matchList
+        [MiniExpr]
+        [MiniExpr]
+        miniArgs
+        fallback
+        (
+          \a : MiniExpr =>
+            \r0 : List MiniExpr =>
+              matchList
+                [MiniExpr]
+                [MiniExpr]
+                r0
+                fallback
+                (
+                  \b : MiniExpr =>
+                    \r1 : List MiniExpr =>
+                      matchList
+                        [MiniExpr]
+                        [MiniExpr]
+                        r1
+                        (ME_Match a {MiniExpr | b (ME_Con #u8(1) #u8(2) #u8(0) {MiniExpr |})})
+                        (\x : MiniExpr => \xs : List MiniExpr => fallback)
+                )
+        )
+
 poly rec coreToMini =
   \zeroArityNames : List (List U8) =>
     \expr : Core =>
@@ -194,7 +311,22 @@ poly rec coreToMini =
               | Cr_Var name =>
                 if [MiniExpr] (nameIsMatchList name)
                   (\u : U8 => matchListIntrinsicOr miniArgs (ME_Call name miniArgs))
-                  (\u : U8 => ME_Call name miniArgs)
+                  (
+                    \u : U8 =>
+                      if [MiniExpr] (nameIsIf name)
+                        (\u2 : U8 => ifIntrinsicOr miniArgs (ME_Call name miniArgs))
+                        (
+                          \u2 : U8 =>
+                            if [MiniExpr] (nameIsAnd name)
+                              (\u3 : U8 => andIntrinsicOr miniArgs (ME_Call name miniArgs))
+                              (
+                                \u3 : U8 =>
+                                  if [MiniExpr] (nameIsOr name)
+                                    (\u4 : U8 => orIntrinsicOr miniArgs (ME_Call name miniArgs))
+                                    (\u4 : U8 => ME_Call name miniArgs)
+                              )
+                        )
+                  )
               | Cr_Ctor tag total arity => ME_Con tag total arity miniArgs
               | Cr_Lam name body =>
                 matchList

--- a/bootstrap/src/dataEnv.trip
+++ b/bootstrap/src/dataEnv.trip
@@ -4,8 +4,6 @@ import Prelude List
 
 import Prelude U8
 
-import Avl Avl
-
 export CtorInfo
 
 export MkCtorInfo
@@ -23,6 +21,12 @@ export ADTInfo
 export MkADTInfo
 
 export adtCtors
+
+export BridgeAvl
+
+export Empty
+
+export Node
 
 export DataEnv
 
@@ -53,11 +57,15 @@ data ADTInfo =
 poly adtCtors =
   \i : ADTInfo => do [List (List U8)] {MkADTInfo cs = i return cs}
 
+data BridgeAvl V =
+  | Empty
+  | Node (BridgeAvl V) (List U8) V U8 (BridgeAvl V)
+
 data DataEnv =
-  | MkDataEnv (Avl (List U8) CtorInfo) (Avl (List U8) ADTInfo)
+  | MkDataEnv (BridgeAvl CtorInfo) (BridgeAvl ADTInfo)
 
 poly datEnvCtors =
-  \e : DataEnv => do [Avl (List U8) CtorInfo] {MkDataEnv c a = e return c}
+  \e : DataEnv => do [BridgeAvl CtorInfo] {MkDataEnv c a = e return c}
 
 poly datEnvAdts =
-  \e : DataEnv => do [Avl (List U8) ADTInfo] {MkDataEnv c a = e return a}
+  \e : DataEnv => do [BridgeAvl ADTInfo] {MkDataEnv c a = e return a}

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -124,6 +124,8 @@ import ModuleEnv validateImports
 
 import ModuleEnv validateExports
 
+import ModuleEnv lookupExportModule
+
 import ModuleEnv lookupConstructorAlias
 
 export compileBundleToLlvm
@@ -311,7 +313,20 @@ poly rec qualifyExpr =
                                               }
                                           )
                                     }
-                                  | None => Ok [List U8] [Expr] (E_Var name)
+                                  | None =>
+                                    match (lookupExportModule name exps) [Result (List U8) Expr] {
+                                      | None => Ok [List U8] [Expr] (E_Var name)
+                                      | Some m =>
+                                        let gName = qualify m name in
+                                        match (lookupConstructorAlias gName aliases) [Result (List U8) Expr] {
+                                          | Some res2 =>
+                                            match res2 [Result (List U8) Expr] {
+                                              | Some rc => Ok [List U8] [Expr] (E_Var rc)
+                                              | None => Err [List U8] [Expr] (concat [U8] {List U8 | "Ambiguous constructor alias: " name})
+                                            }
+                                          | None => Ok [List U8] [Expr] (E_Var gName)
+                                        }
+                                    }
                                 }
                             )
                       }

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -6,8 +6,6 @@ module Compiler
 -- must always execute in a stable, deterministic order. Any change to iteration order
 -- (e.g. from hash maps or unsorted collections) will break the byte-identical self-host
 -- LLVM IR fixpoint.
-
-
 import Prelude List
 
 import Prelude nil
@@ -330,7 +328,18 @@ poly rec qualifyExpr =
                                           | Some res2 =>
                                             match res2 [Result (List U8) Expr] {
                                               | Some rc => Ok [List U8] [Expr] (E_Var rc)
-                                              | None => Err [List U8] [Expr] (concat [U8] {List U8 | "Ambiguous constructor alias: " name})
+                                              | None =>
+                                                Err
+                                                  [List U8]
+                                                  [Expr]
+                                                  (
+                                                    concat
+                                                      [U8]
+                                                      {List U8 |
+                                                        "Ambiguous constructor alias: "
+                                                        name
+                                                      }
+                                                  )
                                             }
                                           | None => Ok [List U8] [Expr] (E_Var gName)
                                         }

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -1,5 +1,13 @@
 module Compiler
 
+-- DETERMINISM CONTRACT WARNING:
+-- The self-hosted compiler's fixpoint depends strictly on determinism of the output.
+-- The symbol table collection, module environment traversal, and file list iteration
+-- must always execute in a stable, deterministic order. Any change to iteration order
+-- (e.g. from hash maps or unsorted collections) will break the byte-identical self-host
+-- LLVM IR fixpoint.
+
+
 import Prelude List
 
 import Prelude nil

--- a/bootstrap/src/index.trip
+++ b/bootstrap/src/index.trip
@@ -774,17 +774,17 @@ poly compileBundleToLlvm =
         (
           if [List U8] (eqListU8 wrapper "enabled")
             (
-              \u : U8 =>
+              \u2 : U8 =>
                 let fullName = concat [U8] {List U8 | "trip_fn_" entryName "_main"} in
-                if [List U8] (entryHasParam funcs fullName)
+                if [List U8] (entryHasParam funcs (concat [U8] {List U8 | entryName ".main"}))
                   (
                     \u2 : U8 =>
-                      let mainWrapper = concat [U8] {List U8 | "declare ptr @trip_read_stdin_list_u8()\n\ndefine i32 @main() {\nentry:\n  %trip_source = call ptr @trip_read_stdin_list_u8()\n  %trip_source_cast = ptrtoint ptr %trip_source to i64\n  %trip_result = call i64 @" fullName "(i64 %trip_source_cast)\n  ret i32 0\n}\n"} in
+                      let mainWrapper = concat [U8] {List U8 | "declare ptr @trip_read_stdin_list_u8()\n\ndefine i32 @main() {\nentry:\n  %trip_source = call ptr @trip_read_stdin_list_u8()\n  %trip_source_cast = ptrtoint ptr %trip_source to i64\n  %trip_result = call i64 @" fullName "(i64 0, i64 %trip_source_cast)\n  ret i32 0\n}\n"} in
                       append [U8] withDecls mainWrapper
                   )
                   (
                     \u2 : U8 =>
-                      let mainWrapper = concat [U8] {List U8 | "define i32 @main() {\nentry:\n  %trip_result = call i64 @" fullName "()\n  ret i32 0\n}\n"} in
+                      let mainWrapper = concat [U8] {List U8 | "define i32 @main() {\nentry:\n  %trip_result = call i64 @" fullName "(i64 0)\n  ret i32 0\n}\n"} in
                       append [U8] withDecls mainWrapper
                   )
             )

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -667,25 +667,31 @@ poly rec consumeString =
             \t : List U8 =>
               cond [Result ParseError ((List U8), (List U8))] {
                 | (eqU8 h u8_quote) =>
-                    Ok
-                      [ParseError]
-                      [((List U8), (List U8))]
-                      {List U8, List U8 | (reverse [U8] acc), t}
+                  Ok
+                    [ParseError]
+                    [((List U8), (List U8))]
+                    {List U8, List U8 | (reverse [U8] acc), t}
                 | (eqU8 h u8_backslash) =>
-                    matchList
-                      [U8]
-                      [Result ParseError ((List U8), (List U8))]
-                      t
-                      (Err [ParseError] [((List U8), (List U8))] (MkParseError ""))
-                      (
-                        \escaped : U8 =>
-                          \afterEscaped : List U8 =>
-                            consumeString (cons [U8] (escapedCharValue escaped) acc) afterEscaped
-                      )
+                  matchList
+                    [U8]
+                    [Result ParseError ((List U8), (List U8))]
+                    t
+                    (
+                      Err
+                        [ParseError]
+                        [((List U8), (List U8))]
+                        (MkParseError "")
+                    )
+                    (
+                      \escaped : U8 =>
+                        \afterEscaped : List U8 =>
+                          consumeString
+                            (cons [U8] (escapedCharValue escaped) acc)
+                            afterEscaped
+                    )
                 | otherwise => consumeString (cons [U8] h acc) t
               }
         )
-
 
 poly charLiteralError =
   Err [ParseError] [(U8, (List U8))] (MkParseError "")

--- a/bootstrap/src/lexer.trip
+++ b/bootstrap/src/lexer.trip
@@ -643,6 +643,17 @@ poly rec consumeDigits =
                 (\u : U8 => {List U8, List U8 | (reverse [U8] acc), input})
         )
 
+poly escapedCharValue =
+  \c : U8 =>
+    cond [U8] {
+      | (eqU8 c u8_n) => u8_newline
+      | (eqU8 c u8_r) => u8_cr
+      | (eqU8 c 't') => u8_tab
+      | (eqU8 c u8_quote) => u8_quote
+      | (eqU8 c u8_squote) => u8_squote
+      | otherwise => c
+    }
+
 poly rec consumeString =
   \acc : List U8 =>
     \input : List U8 =>
@@ -654,27 +665,27 @@ poly rec consumeString =
         (
           \h : U8 =>
             \t : List U8 =>
-              if [Result ParseError ((List U8), (List U8))] (eqU8 h u8_quote)
-                (
-                  \u : U8 =>
+              cond [Result ParseError ((List U8), (List U8))] {
+                | (eqU8 h u8_quote) =>
                     Ok
                       [ParseError]
                       [((List U8), (List U8))]
                       {List U8, List U8 | (reverse [U8] acc), t}
-                )
-                (\u : U8 => consumeString (cons [U8] h acc) t)
+                | (eqU8 h u8_backslash) =>
+                    matchList
+                      [U8]
+                      [Result ParseError ((List U8), (List U8))]
+                      t
+                      (Err [ParseError] [((List U8), (List U8))] (MkParseError ""))
+                      (
+                        \escaped : U8 =>
+                          \afterEscaped : List U8 =>
+                            consumeString (cons [U8] (escapedCharValue escaped) acc) afterEscaped
+                      )
+                | otherwise => consumeString (cons [U8] h acc) t
+              }
         )
 
-poly escapedCharValue =
-  \c : U8 =>
-    cond [U8] {
-      | (eqU8 c u8_n) => u8_newline
-      | (eqU8 c u8_r) => u8_cr
-      | (eqU8 c 't') => u8_tab
-      | (eqU8 c u8_quote) => u8_quote
-      | (eqU8 c u8_squote) => u8_squote
-      | otherwise => c
-    }
 
 poly charLiteralError =
   Err [ParseError] [(U8, (List U8))] (MkParseError "")

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -158,6 +158,8 @@ export validateImports
 
 export validateExports
 
+export lookupExportModule
+
 export main
 
 data ModuleInfo =
@@ -890,6 +892,26 @@ poly rec lookupExport =
                     (\u : U8 => Some [ExportInfo] h)
                 }
           )
+
+poly rec lookupExportModule =
+  \symbolName : List U8 =>
+    \exports : List ExportInfo =>
+      matchList
+        [ExportInfo]
+        [Maybe (List U8)]
+        exports
+        (None [List U8])
+        (
+          \h : ExportInfo =>
+            \t : List ExportInfo =>
+              do [Maybe (List U8)] {
+                MkExportInfo hModule hSymbol = h
+                return
+                if [Maybe (List U8)] (eqListU8 hSymbol symbolName)
+                  (\u : U8 => Some [List U8] hModule)
+                  (\u : U8 => lookupExportModule symbolName t)
+              }
+        )
 
 poly rec lookupDefinition =
   \moduleName : List U8 =>

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -1,5 +1,13 @@
 module ModuleEnv
 
+-- DETERMINISM CONTRACT WARNING:
+-- The self-hosted compiler's fixpoint depends strictly on determinism of the output.
+-- Any traversal or iteration over ModuleEnv components (like definitions, modules,
+-- imports, exports, and constructors) must process elements in a stable, deterministic
+-- order (e.g. source file list order, or sorted alphabetically) to prevent compiler
+-- output divergence. Avoid relying on unstable sorting or iteration orders.
+
+
 import Prelude List
 
 import Prelude nil

--- a/bootstrap/src/moduleEnv.trip
+++ b/bootstrap/src/moduleEnv.trip
@@ -6,8 +6,6 @@ module ModuleEnv
 -- imports, exports, and constructors) must process elements in a stable, deterministic
 -- order (e.g. source file list order, or sorted alphabetically) to prevent compiler
 -- output divergence. Avoid relying on unstable sorting or iteration orders.
-
-
 import Prelude List
 
 import Prelude nil
@@ -539,16 +537,26 @@ poly rec parseModulesAcc =
             \t : List ModuleRecord =>
               do [Result (List U8) BuildState] {
                 MkModuleRecord name lengthDigits source = h
-                res <- match (parseModuleSource name source) [Result (List U8) BuildState] {
-                  | Err e => Err [List U8] [BuildState] (concat [U8] {List U8 | "Parse error in module " name ": " e})
+                res <-
+                match (parseModuleSource name source) [Result (List U8) BuildState] {
+                  | Err e =>
+                    Err
+                      [List U8]
+                      [BuildState]
+                      (
+                        concat
+                          [U8]
+                          {List U8 | "Parse error in module " name ": " e}
+                      )
                   | Ok modInfo =>
-                    match modInfo [Result (List U8) BuildState] {
-                      | MkModuleInfo modName decls =>
-                        match state [Result (List U8) BuildState] {
-                          | MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId =>
-                            let withMod = MkBuildState (append [ModuleInfo] mods {ModuleInfo | modInfo}) imps exps defs dataTypes opaques natives nextTypeId in
-                            parseModulesAcc t (collectDecls modName decls withMod)
-                        }
+                    do [Result (List U8) BuildState] {
+                      MkModuleInfo modName decls = modInfo
+                      MkBuildState mods imps exps defs dataTypes opaques natives nextTypeId = state
+                      withMod = MkBuildState (append [ModuleInfo] mods {ModuleInfo | modInfo}) imps exps defs dataTypes opaques natives nextTypeId
+                      return
+                        parseModulesAcc
+                        t
+                        (collectDecls modName decls withMod)
                     }
                 }
                 return (Ok [List U8] [BuildState] res)

--- a/bootstrap/src/parser.trip
+++ b/bootstrap/src/parser.trip
@@ -393,12 +393,6 @@ poly natTag =
 poly strTag =
   tokenTag (T_Str "")
 
-
-
-
-
-
-
 poly lParenTag =
   tokenTag T_LParen
 
@@ -1910,7 +1904,6 @@ poly parseDecl =
             }
       )
 
-
 poly rec parseProgramAcc =
   \toks : List Token =>
     \acc : List Decl =>
@@ -2283,12 +2276,12 @@ poly parseSingleStep =
   \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
     \toks : List Token =>
       matchList
-            [Token]
-            [Result ParseError DoStep]
-            toks
-            (Err [ParseError] [DoStep] parseError)
-            (
-              \h : Token =>
+        [Token]
+        [Result ParseError DoStep]
+        toks
+        (Err [ParseError] [DoStep] parseError)
+        (
+          \h : Token =>
             \t : List Token =>
               let tag = tokenTag h in
               cond [Result ParseError DoStep] {
@@ -2495,10 +2488,9 @@ poly parseSingleStep =
                                         }
                                   )
                             )
-                      )
+                    )
               }
         )
-
 
 poly rec parseDoStepsRec =
   \recurse : (List Token -> Result ParseError (Expr, (List Token))) =>
@@ -2563,11 +2555,3 @@ poly parseDoWith =
               }
           }
       }
-
-
-
-
-
-
-
-

--- a/lib/compiler/llvm/emitLlvm.ts
+++ b/lib/compiler/llvm/emitLlvm.ts
@@ -929,11 +929,20 @@ function wordFromValue(
     case "i64":
       return { lines: [], value: rendered };
     case "i8":
-    case "i1":
       return {
-        lines: [`${word} = zext ${type} ${rendered} to i64`],
+        lines: [`${word} = zext i8 ${rendered} to i64`],
         value: word,
       };
+    case "i1": {
+      const zext = `%${sanitizeLlvmIdentifier(`${prefix}_zext`)}`;
+      return {
+        lines: [
+          `${zext} = zext i1 ${rendered} to i64`,
+          `${word} = add i64 ${zext}, 1`,
+        ],
+        value: word,
+      };
+    }
     case "ptr":
       return {
         lines: [`${word} = ptrtoint ptr ${rendered} to i64`],
@@ -953,8 +962,13 @@ function valueFromWord(
       return [`${valueName} = add i64 ${rawName}, 0`];
     case "i8":
       return [`${valueName} = trunc i64 ${rawName} to i8`];
-    case "i1":
-      return [`${valueName} = trunc i64 ${rawName} to i1`];
+    case "i1": {
+      const sub = `%${sanitizeLlvmIdentifier(`${valueName}_sub`)}`;
+      return [
+        `${sub} = sub i64 ${rawName}, 1`,
+        `${valueName} = trunc i64 ${sub} to i1`,
+      ];
+    }
     case "ptr":
       return [`${valueName} = inttoptr i64 ${rawName} to ptr`];
   }

--- a/lib/prelude.trip
+++ b/lib/prelude.trip
@@ -184,13 +184,13 @@ poly snd =
         }
 
 poly not =
-  \b : Bool => b [Bool] false true
+  \b : Bool => if [Bool] b (\u : U8 => false) (\u : U8 => true)
 
 poly and =
-  \a : Bool => \b : Bool => a [Bool] b false
+  \a : Bool => \b : Bool => if [Bool] a (\u : U8 => b) (\u : U8 => false)
 
 poly or =
-  \a : Bool => \b : Bool => a [Bool] true b
+  \a : Bool => \b : Bool => if [Bool] a (\u : U8 => true) (\u : U8 => b)
 
 poly lteU8 =
   \a : U8 => \b : U8 => or (eqU8 a b) (ltU8 a b)
@@ -220,11 +220,11 @@ poly listIsEmpty =
 
 poly head =
   #A =>
-    \l : List A => l [A] (error [A]) (\h : A => \t : List A => h)
+    \l : List A => matchList [A] [A] l (error [A]) (\h : A => \t : List A => h)
 
 poly tail =
   #A =>
-    \l : List A => l [List A] ({A |}) (\h : A => \t : List A => t)
+    \l : List A => matchList [A] [List A] l ({A |}) (\h : A => \t : List A => t)
 
 poly rec appendAcc =
   #A =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxdeliso/typed-ski",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/runtime/trip/trip_runtime.c
+++ b/runtime/trip/trip_runtime.c
@@ -6,6 +6,7 @@
 #ifdef _WIN32
 #include <fcntl.h>
 #include <io.h>
+#include <windows.h>
 
 static void configure_binary_stdio(void) {
   _setmode(_fileno(stdin), _O_BINARY);
@@ -46,20 +47,42 @@ trip_obj_t *trip_alloc_obj(uint64_t tag, uint64_t arity) {
 
 void trip_obj_set_field(trip_obj_t *obj, uint64_t index, trip_word_t value) {
   if (obj == NULL || index >= obj->arity) {
+    fprintf(stderr, "CRITICAL: trip_obj_set_field with obj=%p index=%llu arity=%llu\n", (void*)obj, (unsigned long long)index, obj ? (unsigned long long)obj->arity : 0);
     abort();
   }
   obj->fields[index] = value;
 }
 
 uint64_t trip_obj_tag(const trip_obj_t *obj) {
+  if ((uintptr_t)obj < 256) {
+    return (uint64_t)(uintptr_t)obj;
+  }
+#ifdef _WIN32
+  if (IsBadReadPtr(obj, sizeof(trip_obj_t))) {
+    fprintf(stderr, "CRITICAL: IsBadReadPtr(%p) in trip_obj_tag\n", (void*)obj);
+    abort();
+  }
+#endif
   if (obj == NULL) {
+    fprintf(stderr, "CRITICAL: obj is NULL in trip_obj_tag\n");
     abort();
   }
   return obj->tag;
 }
 
 trip_word_t trip_obj_field(const trip_obj_t *obj, uint64_t index) {
+  if ((uintptr_t)obj < 256) {
+    fprintf(stderr, "CRITICAL: obj < 256 (%p) in trip_obj_field (index=%llu)\n", (void*)obj, (unsigned long long)index);
+    abort();
+  }
+#ifdef _WIN32
+  if (IsBadReadPtr(obj, sizeof(trip_obj_t))) {
+    fprintf(stderr, "CRITICAL: IsBadReadPtr(%p) in trip_obj_field (index=%llu)\n", (void*)obj, (unsigned long long)index);
+    abort();
+  }
+#endif
   if (obj == NULL || index >= obj->arity) {
+    fprintf(stderr, "CRITICAL: Null or index %llu >= arity %llu in trip_obj_field (obj=%p, tag=%llu)\n", (unsigned long long)index, obj ? (unsigned long long)obj->arity : 0, (void*)obj, obj ? (unsigned long long)obj->tag : 0);
     abort();
   }
   return obj->fields[index];
@@ -97,8 +120,6 @@ trip_obj_t *trip_read_stdin_list_u8(void) {
     bytes[length++] = (uint8_t)byte;
   }
 
-  /* Temporary ABI assumption: List U8 tags are hardcoded as 0 (nil) and 1 (cons). 
-   * This matches the order in which they are defined in Prelude.trip. */
   trip_obj_t *list = trip_alloc_obj(0, 0);
   while (length > 0) {
     trip_obj_t *cons = trip_alloc_obj(1, 2);

--- a/runtime/trip/trip_runtime.c
+++ b/runtime/trip/trip_runtime.c
@@ -54,8 +54,19 @@ void trip_obj_set_field(trip_obj_t *obj, uint64_t index, trip_word_t value) {
 }
 
 uint64_t trip_obj_tag(const trip_obj_t *obj) {
+  if (obj == NULL) {
+    fprintf(stderr, "CRITICAL: obj is NULL in trip_obj_tag\n");
+    abort();
+  }
+  if ((uintptr_t)obj == 1) {
+    return 0;
+  }
+  if ((uintptr_t)obj == 2) {
+    return 1;
+  }
   if ((uintptr_t)obj < 256) {
-    return (uint64_t)(uintptr_t)obj;
+    fprintf(stderr, "CRITICAL: Unexpected small pointer (%p) in trip_obj_tag\n", (void*)obj);
+    abort();
   }
 #ifdef _WIN32
   if (IsBadReadPtr(obj, sizeof(trip_obj_t))) {
@@ -63,14 +74,14 @@ uint64_t trip_obj_tag(const trip_obj_t *obj) {
     abort();
   }
 #endif
-  if (obj == NULL) {
-    fprintf(stderr, "CRITICAL: obj is NULL in trip_obj_tag\n");
-    abort();
-  }
   return obj->tag;
 }
 
 trip_word_t trip_obj_field(const trip_obj_t *obj, uint64_t index) {
+  if (obj == NULL) {
+    fprintf(stderr, "CRITICAL: obj is NULL in trip_obj_field\n");
+    abort();
+  }
   if ((uintptr_t)obj < 256) {
     fprintf(stderr, "CRITICAL: obj < 256 (%p) in trip_obj_field (index=%llu)\n", (void*)obj, (unsigned long long)index);
     abort();
@@ -81,8 +92,8 @@ trip_word_t trip_obj_field(const trip_obj_t *obj, uint64_t index) {
     abort();
   }
 #endif
-  if (obj == NULL || index >= obj->arity) {
-    fprintf(stderr, "CRITICAL: Null or index %llu >= arity %llu in trip_obj_field (obj=%p, tag=%llu)\n", (unsigned long long)index, obj ? (unsigned long long)obj->arity : 0, (void*)obj, obj ? (unsigned long long)obj->tag : 0);
+  if (index >= obj->arity) {
+    fprintf(stderr, "CRITICAL: Index %llu >= arity %llu in trip_obj_field (obj=%p, tag=%llu)\n", (unsigned long long)index, (unsigned long long)obj->arity, (void*)obj, (unsigned long long)obj->tag);
     abort();
   }
   return obj->fields[index];

--- a/runtime/trip/trip_runtime.h
+++ b/runtime/trip/trip_runtime.h
@@ -18,5 +18,4 @@ void trip_obj_set_field(trip_obj_t *obj, uint64_t index, trip_word_t value);
 uint64_t trip_obj_tag(const trip_obj_t *obj);
 trip_word_t trip_obj_field(const trip_obj_t *obj, uint64_t index);
 trip_obj_t *trip_read_stdin_list_u8(void);
-
 #endif

--- a/scripts/update_goldens.ts
+++ b/scripts/update_goldens.ts
@@ -9,8 +9,30 @@ import {
   buildMiniVerifyHarnessSource,
   MINI_VERIFY_MODULE_NAMES,
 } from "../test/compiler/minicoreAnfHarness.ts";
-import { realBootstrapBundle } from "../test/compiler/llvm/bundleV1.test.ts";
-import { summarizeTripBundleV1ParsedModules } from "../lib/compiler/index.ts";
+import { readFileSync } from "node:fs";
+import { isKnownCompilerTripModule } from "../lib/compiler/bootstrapModules.ts";
+import { serializeTripBundleV1, summarizeTripBundleV1ParsedModules } from "../lib/compiler/index.ts";
+
+function realBootstrapModuleSource(name: string): string {
+  if (!isKnownCompilerTripModule(name)) {
+    throw new Error(
+      `realBootstrapModuleSource: unknown built-in module '${name}'`,
+    );
+  }
+  return readFileSync(compilerTripModuleSourcePath(name), "utf8");
+}
+
+function realBootstrapBundle(moduleNames: string[]): Uint8Array {
+  return serializeTripBundleV1({
+    entryModule: moduleNames.at(-1) ?? "Prelude",
+    target: { kind: "x86_64-unknown-linux-gnu" },
+    emitMainWrapper: true,
+    modules: moduleNames.map((name) => ({
+      name,
+      source: realBootstrapModuleSource(name),
+    })),
+  });
+}
 
 function valueToBytes(value: Value): number[] {
   const bytes: number[] = [];

--- a/scripts/update_goldens.ts
+++ b/scripts/update_goldens.ts
@@ -11,7 +11,10 @@ import {
 } from "../test/compiler/minicoreAnfHarness.ts";
 import { readFileSync } from "node:fs";
 import { isKnownCompilerTripModule } from "../lib/compiler/bootstrapModules.ts";
-import { serializeTripBundleV1, summarizeTripBundleV1ParsedModules } from "../lib/compiler/index.ts";
+import {
+  serializeTripBundleV1,
+  summarizeTripBundleV1ParsedModules,
+} from "../lib/compiler/index.ts";
 
 function realBootstrapModuleSource(name: string): string {
   if (!isKnownCompilerTripModule(name)) {

--- a/test/compiler/anfLlvmEmit.test.ts
+++ b/test/compiler/anfLlvmEmit.test.ts
@@ -97,15 +97,15 @@ poly konst = \\x : U8 => \\y : U8 => x
 poly main = \\z : U8 => konst (konst z z) z
 `;
 
-const EXPECTED_LLVM = String.raw`define i64 @konst(i64 %x, i64 %y) {
-entry:
+const EXPECTED_LLVM = String.raw`define i64 @konst(i64 %dummy_env, i64 %x, i64 %y) {
+__entry:
   ret i64 %x
 }
 
-define i64 @main(i64 %z) {
-entry:
-  %__ll0 = call i64 @konst(i64 %z, i64 %z)
-  %__ll1 = call i64 @konst(i64 %__ll0, i64 %z)
+define i64 @main(i64 %dummy_env, i64 %z) {
+__entry:
+  %__ll0 = call i64 @konst(i64 0, i64 %z, i64 %z)
+  %__ll1 = call i64 @konst(i64 0, i64 %__ll0, i64 %z)
   ret i64 %__ll1
 }
 
@@ -162,8 +162,8 @@ describe("ANF -> LLVM emitter (.trip)", () => {
 export main
 poly main = #u8(7)
 `,
-        String.raw`define i64 @main() {
-entry:
+        String.raw`define i64 @main(i64 %dummy_env) {
+__entry:
   ret i64 7
 }
 
@@ -243,8 +243,8 @@ poly main = \a : U8 => writeOne a [U8] (\u : U8 => a)
         String.raw`declare void @trip_write_one(i8)
 declare i8 @trip_read_one()
 
-define i64 @main(i64 %a) {
-entry:
+define i64 @main(i64 %dummy_env, i64 %a) {
+__entry:
   %__ll0_t_write = trunc i64 %a to i8
   call void @trip_write_one(i8 %__ll0_t_write)
   ret i64 %a
@@ -262,8 +262,8 @@ poly main = \u : U8 => readOne [U8] (\b : U8 => b)
         String.raw`declare void @trip_write_one(i8)
 declare i8 @trip_read_one()
 
-define i64 @main(i64 %u) {
-entry:
+define i64 @main(i64 %dummy_env, i64 %u) {
+__entry:
   %__ll0_r = call i8 @trip_read_one()
   %__ll0 = zext i8 %__ll0_r to i64
   ret i64 %__ll0
@@ -283,8 +283,8 @@ declare void @trip_obj_set_field(ptr, i64, i64)
 declare i64 @trip_obj_tag(ptr)
 declare i64 @trip_obj_field(ptr, i64)
 
-define i64 @main() {
-entry:
+define i64 @main(i64 %dummy_env) {
+__entry:
   %__ll0_p = call ptr @trip_alloc_obj(i64 0, i64 0)
   %__ll0 = ptrtoint ptr %__ll0_p to i64
   ret i64 %__ll0
@@ -304,8 +304,8 @@ declare void @trip_obj_set_field(ptr, i64, i64)
 declare i64 @trip_obj_tag(ptr)
 declare i64 @trip_obj_field(ptr, i64)
 
-define i64 @main() {
-entry:
+define i64 @main(i64 %dummy_env) {
+__entry:
   %__ll0_p = call ptr @trip_alloc_obj(i64 1, i64 0)
   %__ll0 = ptrtoint ptr %__ll0_p to i64
   ret i64 %__ll0
@@ -325,8 +325,8 @@ declare void @trip_obj_set_field(ptr, i64, i64)
 declare i64 @trip_obj_tag(ptr)
 declare i64 @trip_obj_field(ptr, i64)
 
-define i64 @main(i64 %c) {
-entry:
+define i64 @main(i64 %dummy_env, i64 %c) {
+__entry:
   %__case_res_0 = alloca i64
   %__scrut_ptr_0 = inttoptr i64 %c to ptr
   %__tag_0 = call i64 @trip_obj_tag(ptr %__scrut_ptr_0)

--- a/test/compiler/llvm/bootstrapAnfLlvm.test.ts
+++ b/test/compiler/llvm/bootstrapAnfLlvm.test.ts
@@ -46,8 +46,8 @@ poly main = \a : U8 => writeOne (addU8 a #u8(1)) [U8] (\u : U8 => u)
 const EXPECTED_LLVM = String.raw`declare void @trip_write_one(i8)
 declare i8 @trip_read_one()
 
-define i64 @main(i64 %a) {
-entry:
+define i64 @main(i64 %dummy_env, i64 %a) {
+__entry:
   %__ll0_t1 = trunc i64 %a to i8
   %__ll0_t2 = trunc i64 1 to i8
   %__ll0_res = add i8 %__ll0_t1, %__ll0_t2
@@ -74,8 +74,8 @@ declare void @trip_obj_set_field(ptr, i64, i64)
 declare i64 @trip_obj_tag(ptr)
 declare i64 @trip_obj_field(ptr, i64)
 
-define i64 @main() {
-entry:
+define i64 @main(i64 %dummy_env) {
+__entry:
   %__ll0_p = call ptr @trip_alloc_obj(i64 1, i64 0)
   %__ll0 = ptrtoint ptr %__ll0_p to i64
   ret i64 %__ll0
@@ -98,8 +98,8 @@ declare void @trip_obj_set_field(ptr, i64, i64)
 declare i64 @trip_obj_tag(ptr)
 declare i64 @trip_obj_field(ptr, i64)
 
-define i64 @main(i64 %c) {
-entry:
+define i64 @main(i64 %dummy_env, i64 %c) {
+__entry:
   %__case_res_0 = alloca i64
   %__scrut_ptr_0 = inttoptr i64 %c to ptr
   %__tag_0 = call i64 @trip_obj_tag(ptr %__scrut_ptr_0)

--- a/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
+++ b/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
@@ -226,7 +226,10 @@ poly main = seven
       });
 
       // Stage-2 LLVM IR = compile using Stage-1 compiler executable
-      const stage2Ll = await bootstrap.runNativeCompiler(stage1Exe, compilerBundleBytes);
+      const stage2Ll = await bootstrap.runNativeCompiler(
+        stage1Exe,
+        compilerBundleBytes,
+      );
 
       const stage2LlPath = join(tempDir, "stage2.ll");
       await writeFile(stage2LlPath, stage2Ll, "utf8");
@@ -235,7 +238,10 @@ poly main = seven
       const stage2Exe = await compileLlvmToExecutable(stage2LlPath);
 
       // Stage-3 LLVM IR = compile using Stage-2 compiler executable
-      const stage3Ll = await bootstrap.runNativeCompiler(stage2Exe, compilerBundleBytes);
+      const stage3Ll = await bootstrap.runNativeCompiler(
+        stage2Exe,
+        compilerBundleBytes,
+      );
 
       // Assert that Stage 2 LLVM IR is byte-identical to Stage 3 LLVM IR!
       assert.equal(stage2Ll, stage3Ll);
@@ -247,4 +253,3 @@ poly main = seven
     }
   });
 });
-

--- a/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
+++ b/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
@@ -338,5 +338,5 @@ poly main = seven
         rm(tempDir, { recursive: true, force: true }).catch(() => {}),
       ]);
     }
-  });
+  }, 240000);
 });

--- a/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
+++ b/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
@@ -63,7 +63,7 @@ describe("LLVM self-host bootstrap", () => {
         bundleBytes,
       );
       assert.ok(!stage1Ll.startsWith("ERR:"), stage1Ll);
-      assert.match(stage1Ll, /define i64 @trip_fn_Main_main\(\)/);
+      assert.match(stage1Ll, /define i64 @trip_fn_Main_main\(i64 %/);
       await writeFile(stage1LlPath, stage1Ll, "utf8");
 
       // Compile Stage-1 LLVM to a native executable
@@ -103,10 +103,10 @@ poly main = seven
         multiModuleBundle,
       );
       assert.ok(!multiModuleLl.startsWith("ERR:"), multiModuleLl);
-      assert.match(multiModuleLl, /define i64 @trip_fn_Lib_seven\(\)/);
-      assert.match(multiModuleLl, /define i64 @trip_fn_App_main\(\)/);
-      assert.match(multiModuleLl, /call i64 @trip_fn_Lib_seven\(\)/);
-      assert.match(multiModuleLl, /call i64 @trip_fn_App_main\(\)/);
+      assert.match(multiModuleLl, /define i64 @trip_fn_Lib_seven\(i64 %/);
+      assert.match(multiModuleLl, /define i64 @trip_fn_App_main\(i64 %/);
+      assert.match(multiModuleLl, /call i64 @trip_fn_Lib_seven\(i64 /);
+      assert.match(multiModuleLl, /call i64 @trip_fn_App_main\(i64 /);
       await writeFile(multiModuleLlPath, multiModuleLl, "utf8");
 
       const multiModuleExe = await compileLlvmToExecutable(multiModuleLlPath);
@@ -180,4 +180,71 @@ poly main = seven
       ]);
     }
   });
+
+  it("reaches a byte-identical LLVM IR fixpoint between Stage 2 and Stage 3", async () => {
+    const { exePath: stage1Exe, cleanup: cleanupBootstrap } =
+      await bootstrap.compileCompilerToNative();
+    const tempDir = await mkdtemp(join(tmpdir(), "typed-ski-llvm-fixpoint-"));
+
+    try {
+      const moduleNames: readonly CompilerTripModuleName[] = [
+        "Prelude",
+        "Nat",
+        "Bin",
+        "BundleSummary",
+        "Avl",
+        "Lexer",
+        "Parser",
+        "Core",
+        "DataEnv",
+        "Unparse",
+        "Bridge",
+        "Llvm",
+        "BundleParseSummary",
+        "BundleInventory",
+        "ModuleEnv",
+        "CoreToMini",
+        "MiniCore",
+        "MiniVerify",
+        "Anf",
+        "AnfLlvm",
+        "Compiler",
+      ];
+
+      const modules = await Promise.all(
+        moduleNames.map(async (name) => ({
+          name,
+          source: await readFile(compilerTripModuleSourcePath(name), "utf8"),
+        })),
+      );
+
+      const compilerBundleBytes = serializeTripBundleV1({
+        entryModule: "Compiler",
+        target: { kind: "generic" },
+        emitMainWrapper: true,
+        modules,
+      });
+
+      // Stage-2 LLVM IR = compile using Stage-1 compiler executable
+      const stage2Ll = await bootstrap.runNativeCompiler(stage1Exe, compilerBundleBytes);
+
+      const stage2LlPath = join(tempDir, "stage2.ll");
+      await writeFile(stage2LlPath, stage2Ll, "utf8");
+
+      // Stage-2 compiler executable = compile Stage-2 LLVM IR to native
+      const stage2Exe = await compileLlvmToExecutable(stage2LlPath);
+
+      // Stage-3 LLVM IR = compile using Stage-2 compiler executable
+      const stage3Ll = await bootstrap.runNativeCompiler(stage2Exe, compilerBundleBytes);
+
+      // Assert that Stage 2 LLVM IR is byte-identical to Stage 3 LLVM IR!
+      assert.equal(stage2Ll, stage3Ll);
+    } finally {
+      await Promise.all([
+        cleanupBootstrap(),
+        rm(tempDir, { recursive: true, force: true }).catch(() => {}),
+      ]);
+    }
+  });
 });
+

--- a/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
+++ b/test/compiler/llvm/bootstrapLlvmSelfHost.test.ts
@@ -243,8 +243,95 @@ poly main = seven
         compilerBundleBytes,
       );
 
+      const stage3LlPath = join(tempDir, "stage3.ll");
+      await writeFile(stage3LlPath, stage3Ll, "utf8");
+
+      // Stage-3 compiler executable = compile Stage-3 LLVM IR to native
+      const stage3Exe = await compileLlvmToExecutable(stage3LlPath);
+
+      // Stage-4 LLVM IR = compile using Stage-3 compiler executable
+      const stage4Ll = await bootstrap.runNativeCompiler(
+        stage3Exe,
+        compilerBundleBytes,
+      );
+
       // Assert that Stage 2 LLVM IR is byte-identical to Stage 3 LLVM IR!
       assert.equal(stage2Ll, stage3Ll);
+
+      // Assert that Stage 3 LLVM IR is byte-identical to Stage 4 LLVM IR (no 2-cycle oscillation)!
+      assert.equal(stage3Ll, stage4Ll);
+
+      // --- Correctness Anchors compiled and executed via Stage 3 compiler ---
+      const preludeSource = await readFile(
+        join(workspaceRoot, "lib", "prelude.trip"),
+        "utf8",
+      );
+
+      const helloBundleBytes = serializeTripBundleV1({
+        entryModule: "Main",
+        target: { kind: "generic" },
+        emitMainWrapper: true,
+        modules: [
+          { name: "Main", source: HELLO_SOURCE },
+          { name: "Prelude", source: preludeSource },
+        ],
+      });
+
+      console.log("Compiling hello correctness anchor via stage-3 compiler...");
+      const helloStage3Ll = await bootstrap.runNativeCompiler(
+        stage3Exe,
+        helloBundleBytes,
+      );
+      assert.ok(!helloStage3Ll.startsWith("ERR:"), helloStage3Ll);
+      const helloStage3LlPath = join(tempDir, "hello.stage3.ll");
+      await writeFile(helloStage3LlPath, helloStage3Ll, "utf8");
+
+      const helloStage3Exe = await compileLlvmToExecutable(helloStage3LlPath);
+      const helloResult = runExecutable(helloStage3Exe);
+      assert.equal(helloResult.status, 0);
+      assert.equal(helloResult.stdout, "Hello, world!\n");
+
+      // Multi-module correctness check using Stage 3 compiler
+      const multiModuleBundle = serializeTripBundleV1({
+        entryModule: "App",
+        target: { kind: "generic" },
+        emitMainWrapper: true,
+        modules: [
+          {
+            name: "Lib",
+            source: `module Lib
+export seven
+poly seven = #u8(7)
+`,
+          },
+          {
+            name: "App",
+            source: `module App
+import Lib seven
+export main
+poly main = seven
+`,
+          },
+        ],
+      });
+
+      console.log(
+        "Compiling multi-module correctness anchor via stage-3 compiler...",
+      );
+      const multiModuleStage3Ll = await bootstrap.runNativeCompiler(
+        stage3Exe,
+        multiModuleBundle,
+      );
+      assert.ok(!multiModuleStage3Ll.startsWith("ERR:"), multiModuleStage3Ll);
+      const multiModuleStage3LlPath = join(tempDir, "multi-module.stage3.ll");
+      await writeFile(multiModuleStage3LlPath, multiModuleStage3Ll, "utf8");
+
+      const multiModuleStage3Exe = await compileLlvmToExecutable(
+        multiModuleStage3LlPath,
+      );
+      const multiModuleResult = runExecutable(multiModuleStage3Exe);
+      assert.equal(multiModuleResult.status, 0);
+      assert.equal(multiModuleResult.stdout, "");
     } finally {
       await Promise.all([
         cleanupBootstrap(),

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer-parser.txt
@@ -251,8 +251,8 @@ poly simpleTokenFromU8Brace
 poly simpleTokenFromU8
 poly consumeIdent
 poly consumeDigits
-poly consumeString
 poly escapedCharValue
+poly consumeString
 poly charLiteralError
 poly finishCharLiteral
 poly consumeCharLiteral

--- a/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
+++ b/test/compiler/llvm/fixtures/bootstrap-parse-summary-prelude-bin-lexer.txt
@@ -251,8 +251,8 @@ poly simpleTokenFromU8Brace
 poly simpleTokenFromU8
 poly consumeIdent
 poly consumeDigits
-poly consumeString
 poly escapedCharValue
+poly consumeString
 poly charLiteralError
 poly finishCharLiteral
 poly consumeCharLiteral

--- a/test/compiler/llvm/nativeHarness.test.ts
+++ b/test/compiler/llvm/nativeHarness.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "../../util/test_shim.ts";
-import { compileTripAndRun } from "./nativeHarness.ts";
+import { compileTripAndRun, macosSdkArgs } from "./nativeHarness.ts";
 import { findLocalClangPath } from "../../../lib/shared/clangPath.ts";
 import { workspaceRoot } from "../../../lib/shared/workspaceRoot.ts";
 
@@ -27,6 +27,7 @@ async function runRuntimeCTest(cSource: string) {
     join(workspaceRoot, "runtime/trip/trip_runtime.c"),
     "-I",
     join(workspaceRoot, "runtime/trip"),
+    ...macosSdkArgs(),
     "-o",
     exePath,
   ];

--- a/test/compiler/llvm/nativeHarness.test.ts
+++ b/test/compiler/llvm/nativeHarness.test.ts
@@ -1,6 +1,46 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, it } from "../../util/test_shim.ts";
 import { compileTripAndRun } from "./nativeHarness.ts";
+import { findLocalClangPath } from "../../../lib/shared/clangPath.ts";
+import { workspaceRoot } from "../../../lib/shared/workspaceRoot.ts";
+
+async function runRuntimeCTest(cSource: string) {
+  const tempDir = await mkdtemp(join(tmpdir(), "trip-runtime-test-"));
+  const cPath = join(tempDir, "test.c");
+  const exePath = join(
+    tempDir,
+    process.platform === "win32" ? "test.exe" : "test",
+  );
+  await writeFile(cPath, cSource, "utf8");
+
+  const CLANG = process.env["TYPED_SKI_CLANG"] ?? findLocalClangPath();
+  if (!CLANG) {
+    throw new Error("Clang path not found");
+  }
+
+  const args = [
+    cPath,
+    join(workspaceRoot, "runtime/trip/trip_runtime.c"),
+    "-I",
+    join(workspaceRoot, "runtime/trip"),
+    "-o",
+    exePath,
+  ];
+
+  const compileResult = spawnSync(CLANG, args, { encoding: "utf8" });
+  if (compileResult.status !== 0) {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`Clang failed:\n${compileResult.stderr}`);
+  }
+
+  const runResult = spawnSync(exePath, [], { encoding: "utf8" });
+  await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+  return runResult;
+}
 
 describe("LLVM native harness", () => {
   it("compiles and runs a simple arithmetic Trip program", async () => {
@@ -32,5 +72,46 @@ poly main = writeOne #u8(42) [U8] (\\x : U8 => x)
     const result = await compileTripAndRun(source, { emitMainWrapper: true });
 
     assert.equal(result.status, 123);
+  });
+
+  describe("C runtime trip_obj_tag validation", () => {
+    it("returns tag 0 for pointer 1 (false) and tag 1 for pointer 2 (true)", async () => {
+      const cSource = `
+#include "trip_runtime.h"
+#include <assert.h>
+int main() {
+    assert(trip_obj_tag((const trip_obj_t*)1) == 0);
+    assert(trip_obj_tag((const trip_obj_t*)2) == 1);
+    return 0;
+}
+`;
+      const result = await runRuntimeCTest(cSource);
+      assert.equal(result.status, 0);
+    });
+
+    it("aborts on NULL pointer", async () => {
+      const cSource = `
+#include "trip_runtime.h"
+#include <stddef.h>
+int main() {
+    trip_obj_tag(NULL);
+    return 0;
+}
+`;
+      const result = await runRuntimeCTest(cSource);
+      assert.ok(result.status !== 0 || result.status === null);
+    });
+
+    it("aborts on small invalid pointer 3", async () => {
+      const cSource = `
+#include "trip_runtime.h"
+int main() {
+    trip_obj_tag((const trip_obj_t*)3);
+    return 0;
+}
+`;
+      const result = await runRuntimeCTest(cSource);
+      assert.ok(result.status !== 0 || result.status === null);
+    });
   });
 });

--- a/test/compiler/llvm/nativeHarness.ts
+++ b/test/compiler/llvm/nativeHarness.ts
@@ -165,7 +165,7 @@ export const bootstrap = {
     cleanup: () => Promise<void>;
   }> {
     const tempDir = await mkdtemp(join(tmpdir(), "trip-compiler-bootstrap-"));
-    const cleanup = () => rm(tempDir, { recursive: true, force: true });
+    const cleanup = () => rm(tempDir, { recursive: true, force: true }).catch(() => {});
 
     try {
       const moduleNames: readonly CompilerTripModuleName[] = [

--- a/test/compiler/llvm/nativeHarness.ts
+++ b/test/compiler/llvm/nativeHarness.ts
@@ -165,7 +165,8 @@ export const bootstrap = {
     cleanup: () => Promise<void>;
   }> {
     const tempDir = await mkdtemp(join(tmpdir(), "trip-compiler-bootstrap-"));
-    const cleanup = () => rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    const cleanup = () =>
+      rm(tempDir, { recursive: true, force: true }).catch(() => {});
 
     try {
       const moduleNames: readonly CompilerTripModuleName[] = [

--- a/test/compiler/llvm/nativeHarness.ts
+++ b/test/compiler/llvm/nativeHarness.ts
@@ -30,7 +30,7 @@ export interface HarnessOptions extends CompileTripSourceToLlvmOptions {
 
 const CLANG = process.env["TYPED_SKI_CLANG"] ?? findLocalClangPath();
 
-function macosSdkArgs(): string[] {
+export function macosSdkArgs(): string[] {
   if (process.platform !== "darwin") {
     return [];
   }


### PR DESCRIPTION
# Description

This PR stabilizes the self-hosted compiler bootstrap pipeline, implements unboxed boolean representation shifts to prevent runtime pointer conflation with `NULL`, supports string escape sequences in the bootstrap lexer, and fixes macOS compilation/sandbox testing issues.

---

## Key Changes

### 1. Safe Unboxed Boolean Representations
- **Pointer Tagging**: Shifted the representation of unboxed booleans from `0` / `1` to `1` (for `false`) and `2` (for `true`) at the LLVM pointer/word level. This prevents booleans from being conflated with `NULL` (0).
- **TS Host Compiler**: Updated `emitLlvm.ts`'s `wordFromValue` and `valueFromWord` to tag (`+1`) and untag (`-1`) `i1` values when mapping to/from uniform `i64` representations.
- **Bootstrap Compiler**: Updated `anfLlvm.trip`'s comparison primitives (`emitEqU8` and `emitLtU8`) to zext comparison results and add `1` (`dest = add i64 dest_zext, 1`).
- **C Runtime Safeguards**: 
  - Updated `trip_obj_tag` in `trip_runtime.c` to map pointer value `1` to tag `0` (`false`) and pointer value `2` to tag `1` (`true`).
  - Added explicit abort guards on `NULL` and small invalid pointers ($3 \le \text{ptr} < 256$) inside `trip_obj_tag` and `trip_obj_field`.
  - Integrated `IsBadReadPtr` on Windows to detect and abort early on invalid memory references.

### 2. Self-Hosted Fixpoint Stabilization & Currying ABI Fixes
- **AVL Tree Specialization**: Specialized the general AVL tree to a monomorphic `BridgeAvl` in `dataEnv.trip` using `U8` heights, bypassing Church-encoded `Nat` arity/closure mismatches.
- **Recursion Specialization**: Eliminated closure allocation overhead inside critical compiler passes. Specialized recursive traversals `norm`, `normArms`, `normWriteOneCall`, and `normReadOneCall` in `anf.trip`, and `elaborateExpr` / `elaborateArms` / `elaborateMatchWith` in `bridge.trip` to recursively call directly rather than passing functional arguments.
- **Main Entry calling convention**: Prepended a dummy `env` argument to top-level functions. Updated main wrapper codegen in `index.trip` to call entry points passing `0` (`i64 0`) to match this calling convention.
- **Boolean Intrinsics**: Added compiler-time intrinsics in `coreToMini.trip` for `if`/`Prelude.if`, `and`/`Prelude.and`, and `or`/`Prelude.or` to desugar them directly to pattern matches (`ME_Match`), avoiding closure/currying overhead.
- **Qualification**: Supported resolving non-imported constructor aliases via module exports in `index.trip`'s `qualifyExpr`.

### 3. Lexer String Escape Sequence Processing
- Implemented string escape sequence parsing in `bootstrap/src/lexer.trip` (using `escapedCharValue` helper) to process `\n`, `\r`, `\t`, `\"`, `\'`, and `\\`. This fixes compiler output corruption where string escape sequences were previously emitted literally.

### 4. Verification and Test Stabilizations
- **4-Phase Fixpoint Verification**: Updated `bootstrapLlvmSelfHost.test.ts` to run a 4-phase fixpoint pipeline where `stage2.ll === stage3.ll === stage4.ll` is verified.
- **Correctness Anchors**: Wired verification assertions to compile `helloWorld.trip` and multi-module fixtures using the `stage3Exe` compiler and assert output correctness.
- **macOS SDK Support**: Exported and passed `macosSdkArgs` sysroot arguments to Clang inside `nativeHarness.test.ts` to locate `<assert.h>` and `<stdio.h>` inside the macOS sandbox.
- **Timeout Extension**: Increased self-host bootstrap test timeout to 240 seconds to accommodate local compilation times.
- **Bazel Test Timeout**: Increased `--test_timeout` to 240 seconds in `.bazelrc` to prevent slow sharded node tests from timing out on Windows CI runners.

### 5. Determinism Contracts
- Added Haskell-style determinism warning comments in `index.trip` and `moduleEnv.trip` to document strict symbol table traversal constraints.
